### PR TITLE
Update (2022.09.20)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
@@ -1057,10 +1057,6 @@ void LIRGenerator::do_FmaIntrinsic(Intrinsic* x) {
   }
 }
 
-void LIRGenerator::do_continuation_doYield(Intrinsic* x) {
-  fatal("Continuation.doYield intrinsic is not implemented on this platform");
-}
-
 void LIRGenerator::do_vectorizedMismatch(Intrinsic* x) {
   fatal("vectorizedMismatch intrinsic is not implemented on this platform");
 }

--- a/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.cpp
@@ -403,6 +403,15 @@ void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* 
   Label done;
   Label runtime;
 
+  // Is marking still active?
+  if (in_bytes(SATBMarkQueue::byte_width_of_active()) == 4) {  // 4-byte width
+    __ ld_w(tmp, in_progress);
+  } else {
+    assert(in_bytes(SATBMarkQueue::byte_width_of_active()) == 1, "Assumption");
+    __ ld_b(tmp, in_progress);
+  }
+  __ beqz(tmp, done);
+
   // Can we store original value in the thread's buffer?
   __ ld_d(tmp, queue_index);
   __ beqz(tmp, runtime);

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -5237,12 +5237,6 @@ class StubGenerator: public StubCodeGenerator {
     return nullptr;
   }
 
-  RuntimeStub* generate_cont_doYield() {
-    if (!Continuations::enabled()) return nullptr;
-    Unimplemented();
-    return nullptr;
-  }
-
 #if INCLUDE_JFR
 
 #undef __
@@ -5349,9 +5343,6 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::_cont_thaw             = generate_cont_thaw();
     StubRoutines::_cont_returnBarrier    = generate_cont_returnBarrier();
     StubRoutines::_cont_returnBarrierExc = generate_cont_returnBarrier_exception();
-    StubRoutines::_cont_doYield_stub     = generate_cont_doYield();
-    StubRoutines::_cont_doYield = StubRoutines::_cont_doYield_stub == nullptr ? nullptr
-                                   : StubRoutines::_cont_doYield_stub->entry_point();
 
     JFR_ONLY(StubRoutines::_jfr_write_checkpoint_stub = generate_jfr_write_checkpoint();)
     JFR_ONLY(StubRoutines::_jfr_write_checkpoint = StubRoutines::_jfr_write_checkpoint_stub == nullptr ? nullptr

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -280,12 +280,6 @@ address TemplateInterpreterGenerator::generate_CRC32C_updateBytes_entry(Abstract
   return NULL;
 }
 
-address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) {
-  if (!Continuations::enabled()) return nullptr;
-  Unimplemented();
-  return NULL;
-}
-
 //
 // Various method entries
 //


### PR DESCRIPTION
27984: LA port of 8293353: [BACKOUT] G1: Remove redundant is-marking-active checks in C1 barrier
27982: LA port of 8292584: assert(cb != __null) failed: must be with -XX:-Inline