### PR TITLE
Update (2022.09.30)

### DIFF
--- a/src/hotspot/cpu/loongarch/assembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.cpp
@@ -105,7 +105,7 @@ int AbstractAssembler::code_fill_byte() {
 }
 
 // Now the Assembler instruction (identical for 32/64 bits)
-void Assembler::ld_b(Register rd, Address src) {
+void Assembler::ld_b(Register rd, const Address &src) {
   Register dst   = rd;
   Register base  = src.base();
   Register index = src.index();
@@ -150,7 +150,7 @@ void Assembler::ld_b(Register rd, Address src) {
   }
 }
 
-void Assembler::ld_bu(Register rd, Address src) {
+void Assembler::ld_bu(Register rd, const Address &src) {
   Register dst   = rd;
   Register base  = src.base();
   Register index = src.index();
@@ -195,7 +195,7 @@ void Assembler::ld_bu(Register rd, Address src) {
   }
 }
 
-void Assembler::ld_d(Register rd, Address src){
+void Assembler::ld_d(Register rd, const Address &src) {
   Register dst   = rd;
   Register base  = src.base();
   Register index = src.index();
@@ -249,7 +249,7 @@ void Assembler::ld_d(Register rd, Address src){
   }
 }
 
-void Assembler::ld_h(Register rd, Address src){
+void Assembler::ld_h(Register rd, const Address &src) {
   Register dst   = rd;
   Register base  = src.base();
   Register index = src.index();
@@ -294,7 +294,7 @@ void Assembler::ld_h(Register rd, Address src){
   }
 }
 
-void Assembler::ld_hu(Register rd, Address src){
+void Assembler::ld_hu(Register rd, const Address &src) {
   Register dst   = rd;
   Register base  = src.base();
   Register index = src.index();
@@ -339,17 +339,17 @@ void Assembler::ld_hu(Register rd, Address src){
   }
 }
 
-void Assembler::ll_w(Register rd, Address src){
+void Assembler::ll_w(Register rd, const Address &src) {
   assert(src.index() == NOREG, "index is unimplemented");
   ll_w(rd, src.base(), src.disp());
 }
 
-void Assembler::ll_d(Register rd, Address src){
+void Assembler::ll_d(Register rd, const Address &src) {
   assert(src.index() == NOREG, "index is unimplemented");
   ll_d(rd, src.base(), src.disp());
 }
 
-void Assembler::ld_w(Register rd, Address src){
+void Assembler::ld_w(Register rd, const Address &src) {
   Register dst   = rd;
   Register base  = src.base();
   Register index = src.index();
@@ -403,7 +403,7 @@ void Assembler::ld_w(Register rd, Address src){
   }
 }
 
-void Assembler::ld_wu(Register rd, Address src){
+void Assembler::ld_wu(Register rd, const Address &src) {
   Register dst   = rd;
   Register base  = src.base();
   Register index = src.index();
@@ -448,7 +448,7 @@ void Assembler::ld_wu(Register rd, Address src){
   }
 }
 
-void Assembler::st_b(Register rd, Address dst) {
+void Assembler::st_b(Register rd, const Address &dst) {
   Register src   = rd;
   Register base  = dst.base();
   Register index = dst.index();
@@ -495,17 +495,17 @@ void Assembler::st_b(Register rd, Address dst) {
   }
 }
 
-void Assembler::sc_w(Register rd, Address dst) {
+void Assembler::sc_w(Register rd, const Address &dst) {
   assert(dst.index() == NOREG, "index is unimplemented");
   sc_w(rd, dst.base(), dst.disp());
 }
 
-void Assembler::sc_d(Register rd, Address dst) {
+void Assembler::sc_d(Register rd, const Address &dst) {
   assert(dst.index() == NOREG, "index is unimplemented");
   sc_d(rd, dst.base(), dst.disp());
 }
 
-void Assembler::st_d(Register rd, Address dst) {
+void Assembler::st_d(Register rd, const Address &dst) {
   Register src   = rd;
   Register base  = dst.base();
   Register index = dst.index();
@@ -561,7 +561,7 @@ void Assembler::st_d(Register rd, Address dst) {
   }
 }
 
-void Assembler::st_h(Register rd, Address dst) {
+void Assembler::st_h(Register rd, const Address &dst) {
   Register src   = rd;
   Register base  = dst.base();
   Register index = dst.index();
@@ -608,7 +608,7 @@ void Assembler::st_h(Register rd, Address dst) {
   }
 }
 
-void Assembler::st_w(Register rd, Address dst) {
+void Assembler::st_w(Register rd, const Address &dst) {
   Register src   = rd;
   Register base  = dst.base();
   Register index = dst.index();
@@ -664,7 +664,7 @@ void Assembler::st_w(Register rd, Address dst) {
   }
 }
 
-void Assembler::fld_s(FloatRegister fd, Address src) {
+void Assembler::fld_s(FloatRegister fd, const Address &src) {
   Register base  = src.base();
   Register index = src.index();
 
@@ -708,7 +708,7 @@ void Assembler::fld_s(FloatRegister fd, Address src) {
   }
 }
 
-void Assembler::fld_d(FloatRegister fd, Address src) {
+void Assembler::fld_d(FloatRegister fd, const Address &src) {
   Register base  = src.base();
   Register index = src.index();
 
@@ -752,7 +752,7 @@ void Assembler::fld_d(FloatRegister fd, Address src) {
   }
 }
 
-void Assembler::fst_s(FloatRegister fd, Address dst) {
+void Assembler::fst_s(FloatRegister fd, const Address &dst) {
   Register base  = dst.base();
   Register index = dst.index();
 
@@ -796,7 +796,7 @@ void Assembler::fst_s(FloatRegister fd, Address dst) {
   }
 }
 
-void Assembler::fst_d(FloatRegister fd, Address dst) {
+void Assembler::fst_d(FloatRegister fd, const Address &dst) {
   Register base  = dst.base();
   Register index = dst.index();
 

--- a/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
@@ -2074,25 +2074,25 @@ public:
   void fstx_s (FloatRegister fd, Register rj, Register rk) { emit_int32(insn_RRR(fstx_s_op,    (int)rk->encoding(), (int)rj->encoding(), (int)fd->encoding())); }
   void fstx_d (FloatRegister fd, Register rj, Register rk) { emit_int32(insn_RRR(fstx_d_op,    (int)rk->encoding(), (int)rj->encoding(), (int)fd->encoding())); }
 
-  void ld_b  (Register rd, Address src);
-  void ld_bu (Register rd, Address src);
-  void ld_d  (Register rd, Address src);
-  void ld_h  (Register rd, Address src);
-  void ld_hu (Register rd, Address src);
-  void ll_w  (Register rd, Address src);
-  void ll_d  (Register rd, Address src);
-  void ld_wu (Register rd, Address src);
-  void ld_w  (Register rd, Address src);
-  void st_b  (Register rd, Address dst);
-  void st_d  (Register rd, Address dst);
-  void st_w  (Register rd, Address dst);
-  void sc_w  (Register rd, Address dst);
-  void sc_d  (Register rd, Address dst);
-  void st_h  (Register rd, Address dst);
-  void fld_s (FloatRegister fd, Address src);
-  void fld_d (FloatRegister fd, Address src);
-  void fst_s (FloatRegister fd, Address dst);
-  void fst_d (FloatRegister fd, Address dst);
+  void ld_b  (Register rd, const Address &src);
+  void ld_bu (Register rd, const Address &src);
+  void ld_d  (Register rd, const Address &src);
+  void ld_h  (Register rd, const Address &src);
+  void ld_hu (Register rd, const Address &src);
+  void ll_w  (Register rd, const Address &src);
+  void ll_d  (Register rd, const Address &src);
+  void ld_wu (Register rd, const Address &src);
+  void ld_w  (Register rd, const Address &src);
+  void st_b  (Register rd, const Address &dst);
+  void st_d  (Register rd, const Address &dst);
+  void st_w  (Register rd, const Address &dst);
+  void sc_w  (Register rd, const Address &dst);
+  void sc_d  (Register rd, const Address &dst);
+  void st_h  (Register rd, const Address &dst);
+  void fld_s (FloatRegister fd, const Address &src);
+  void fld_d (FloatRegister fd, const Address &src);
+  void fst_s (FloatRegister fd, const Address &dst);
+  void fst_d (FloatRegister fd, const Address &dst);
 
   void amswap_w   (Register rd, Register rk, Register rj) { assert_different_registers(rd, rj); assert_different_registers(rd, rk); emit_int32(insn_RRR(amswap_w_op,    (int)rk->encoding(), (int)rj->encoding(), (int)rd->encoding())); }
   void amswap_d   (Register rd, Register rk, Register rj) { assert_different_registers(rd, rj); assert_different_registers(rd, rk); emit_int32(insn_RRR(amswap_d_op,    (int)rk->encoding(), (int)rj->encoding(), (int)rd->encoding())); }

--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -588,7 +588,7 @@ void LIR_Assembler::const2mem(LIR_Opr src, LIR_Opr dest, BasicType type,
   LIR_Const* c = src->as_constant_ptr();
   LIR_Address* to_addr = dest->as_address_ptr();
 
-  void (Assembler::* insn)(Register Rt, Address adr);
+  void (Assembler::* insn)(Register Rt, const Address &adr);
 
   switch (type) {
   case T_ADDRESS:

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -265,7 +265,7 @@ void C2_MacroAssembler::bc1f_long(Label& L) {
   bind(not_taken);
 }
 
-typedef void (MacroAssembler::* load_chr_insn)(Register rd, Address adr);
+typedef void (MacroAssembler::* load_chr_insn)(Register rd, const Address &adr);
 
 void C2_MacroAssembler::string_indexof(Register haystack, Register needle,
                                        Register haystack_len, Register needle_len,

--- a/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
@@ -368,7 +368,7 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   // in C2 code but it will have been pushed onto the stack. so we
   // have to find it relative to the unextended sp
 
-  assert(_cb->frame_size() >= 0, "must have non-zero frame size");
+  assert(_cb->frame_size() > 0, "must have non-zero frame size");
   intptr_t* l_sender_sp = unextended_sp() + _cb->frame_size();
   intptr_t* unextended_sp = l_sender_sp;
 

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
@@ -281,7 +281,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
         __ srli_d(RA, SCR1, 32);
         __ orr(SCR2, SCR2, RA);
         // Read the global epoch value.
-        __ ld_wu(SCR2, SCR2);
+        __ ld_wu(SCR2, SCR2, 0);
         // Combine the guard value (low order) with the epoch value (high order).
         __ slli_d(SCR2, SCR2, 32);
         __ orr(SCR1, SCR1, SCR2);
@@ -305,7 +305,8 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
     __ emit_int32(0);   // nmethod guard value. Skipped over in common case.
     __ bind(skip_barrier);
   } else {
-    __ bne(SCR1, SCR2, *slow_path);
+    __ xorr(SCR1, SCR1, SCR2);
+    __ bnez(SCR1, *slow_path);
     __ bind(*continuation);
   }
 }

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetNMethod_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetNMethod_loongarch.cpp
@@ -40,7 +40,7 @@
 static int slow_path_size(nmethod* nm) {
   // The slow path code is out of line with C2.
   // Leave a b to the stub in the fast path.
-  return nm->is_compiled_by_c2() ? 1 : 6;
+  return nm->is_compiled_by_c2() ? 2 : 6;
 }
 
 static int entry_barrier_offset(nmethod* nm) {

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -2593,14 +2593,15 @@ int MacroAssembler::patched_branch(int dest_pos, int inst, int inst_pos) {
   case bge_op:
   case bltu_op:
   case bgeu_op:
-    assert(is_simm16(v), "must be simm16");
 #ifndef PRODUCT
     if(!is_simm16(v))
     {
       tty->print_cr("must be simm16");
       tty->print_cr("Inst: %x", inst);
+      tty->print_cr("Op:   %x", high(inst, 6));
     }
 #endif
+    assert(is_simm16(v), "must be simm16");
 
     inst &= 0xfc0003ff;
     inst |= ((v & 0xffff) << 10);

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -79,50 +79,6 @@
 
 // Implementation of MacroAssembler
 
-intptr_t MacroAssembler::i[32] = {0};
-float MacroAssembler::f[32] = {0.0};
-
-void MacroAssembler::print(outputStream *s) {
-  unsigned int k;
-  for(k=0; k<sizeof(i)/sizeof(i[0]); k++) {
-    s->print_cr("i%d = 0x%.16lx", k, i[k]);
-  }
-  s->cr();
-
-  for(k=0; k<sizeof(f)/sizeof(f[0]); k++) {
-    s->print_cr("f%d = %f", k, f[k]);
-  }
-  s->cr();
-}
-
-int MacroAssembler::i_offset(unsigned int k) { return (intptr_t)&((MacroAssembler*)0)->i[k]; }
-int MacroAssembler::f_offset(unsigned int k) { return (intptr_t)&((MacroAssembler*)0)->f[k]; }
-
-void MacroAssembler::save_registers(MacroAssembler *masm) {
-#define __ masm->
-  for(int k=0; k<32; k++) {
-    __ st_w (as_Register(k), A0, i_offset(k));
-  }
-
-  for(int k=0; k<32; k++) {
-    __ fst_s (as_FloatRegister(k), A0, f_offset(k));
-  }
-#undef __
-}
-
-void MacroAssembler::restore_registers(MacroAssembler *masm) {
-#define __ masm->
-  for(int k=0; k<32; k++) {
-    __ ld_w (as_Register(k), A0, i_offset(k));
-  }
-
-  for(int k=0; k<32; k++) {
-    __ fld_s (as_FloatRegister(k), A0, f_offset(k));
-  }
-#undef __
-}
-
-
 void MacroAssembler::pd_patch_instruction(address branch, address target, const char* file, int line) {
   jint& stub_inst = *(jint*)branch;
   jint *pc = (jint *)branch;
@@ -960,11 +916,10 @@ void MacroAssembler::super_call_VM_leaf(address entry_point,
   MacroAssembler::call_VM_leaf_base(entry_point, 3);
 }
 
-void MacroAssembler::check_and_handle_earlyret(Register java_thread) {
-}
+// these are no-ops overridden by InterpreterMacroAssembler
+void MacroAssembler::check_and_handle_earlyret(Register java_thread) {}
 
-void MacroAssembler::check_and_handle_popframe(Register java_thread) {
-}
+void MacroAssembler::check_and_handle_popframe(Register java_thread) {}
 
 void MacroAssembler::null_check(Register reg, int offset) {
   if (needs_explicit_null_check(offset)) {
@@ -1470,14 +1425,6 @@ void MacroAssembler::verify_tlab(Register t1, Register t2) {
 #endif
 }
 
-RegisterOrConstant MacroAssembler::delayed_value_impl(intptr_t* delayed_value_addr,
-                                                      Register tmp,
-                                                      int offset) {
-  //TODO: LA
-  guarantee(0, "LA not implemented yet");
-  return RegisterOrConstant(tmp);
-}
-
 void MacroAssembler::bswap_h(Register dst, Register src) {
   revb_2h(dst, src);
   ext_w_h(dst, dst);  // sign extension of the lower 16 bits
@@ -1611,25 +1558,8 @@ void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval, R
     b(*fail);
 }
 
-// be sure the three register is different
-void MacroAssembler::rem_s(FloatRegister fd, FloatRegister fs, FloatRegister ft, FloatRegister tmp) {
-  //TODO: LA
-  guarantee(0, "LA not implemented yet");
-}
-
-// be sure the three register is different
-void MacroAssembler::rem_d(FloatRegister fd, FloatRegister fs, FloatRegister ft, FloatRegister tmp) {
-  //TODO: LA
-  guarantee(0, "LA not implemented yet");
-}
-
 void MacroAssembler::align(int modulus) {
   while (offset() % modulus != 0) nop();
-}
-
-
-void MacroAssembler::verify_FPU(int stack_depth, const char* s) {
-  //Unimplemented();
 }
 
 static RegSet caller_saved_regset = RegSet::range(A0, A7) + RegSet::range(T0, T8) + RegSet::of(FP, RA) - RegSet::of(SCR1, SCR2);

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -98,16 +98,6 @@ class MacroAssembler: public Assembler {
   Address as_Address(AddressLiteral adr);
   Address as_Address(ArrayAddress adr);
 
-  static intptr_t  i[32];
-  static float  f[32];
-  static void print(outputStream *s);
-
-  static int i_offset(unsigned int k);
-  static int f_offset(unsigned int k);
-
-  static void save_registers(MacroAssembler *masm);
-  static void restore_registers(MacroAssembler *masm);
-
   // Support for NULL-checks
   //
   // Generates code that causes a NULL OS exception if the content of reg is NULL.
@@ -130,14 +120,8 @@ class MacroAssembler: public Assembler {
 
   address emit_trampoline_stub(int insts_call_instruction_offset, address target);
 
-  // Support for inc/dec with optimal instruction selection depending on value
-  // void incrementl(Register reg, int value = 1);
-  // void decrementl(Register reg, int value = 1);
-
-
   // Alignment
   void align(int modulus);
-
 
   // Stack frame creation/removal
   void enter();
@@ -295,8 +279,6 @@ class MacroAssembler: public Assembler {
   // Sign extension
   void sign_extend_short(Register reg) { ext_w_h(reg, reg); }
   void sign_extend_byte(Register reg)  { ext_w_b(reg, reg); }
-  void rem_s(FloatRegister fd, FloatRegister fs, FloatRegister ft, FloatRegister tmp);
-  void rem_d(FloatRegister fd, FloatRegister fs, FloatRegister ft, FloatRegister tmp);
 
   // allocation
   void tlab_allocate(
@@ -394,9 +376,6 @@ class MacroAssembler: public Assembler {
 #define verify_method_ptr(reg) _verify_method_ptr(reg, "broken method " #reg, __FILE__, __LINE__)
 #define verify_klass_ptr(reg) _verify_method_ptr(reg, "broken klass " #reg, __FILE__, __LINE__)
 
-  // only if +VerifyFPU
-  void verify_FPU(int stack_depth, const char* s = "illegal FPU state");
-
   // prints msg, dumps registers and stops execution
   void stop(const char* msg);
 
@@ -411,8 +390,6 @@ class MacroAssembler: public Assembler {
   void unimplemented(const char* what = "");
 
   void should_not_reach_here()                   { stop("should not reach here"); }
-
-  void print_CPU_state();
 
   // Stack overflow checking
   void bang_stack_with_offset(int offset) {
@@ -436,13 +413,8 @@ class MacroAssembler: public Assembler {
   // Check for reserved stack access in method being exited (for JIT)
   void reserved_stack_check();
 
-  virtual RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr,
-                                                Register tmp,
-                                                int offset);
-
   void safepoint_poll(Label& slow_path, Register thread_reg, bool at_return, bool acquire, bool in_nmethod);
 
-  //void verify_tlab();
   void verify_tlab(Register t1, Register t2);
 
   // the follow two might use AT register, be sure you have no meanful data in AT before you call them
@@ -537,8 +509,6 @@ class MacroAssembler: public Assembler {
   void cmpxchg32(Address addr, Register oldval, Register newval, Register tmp,
                  bool sign, bool retold, bool barrier, Label& succ, Label* fail = nullptr);
 
-  void extend_sign(Register rh, Register rl) { /*stop("extend_sign");*/ guarantee(0, "LA not implemented yet");}
-  void neg(Register reg) { /*dsubu(reg, R0, reg);*/ guarantee(0, "LA not implemented yet");}
   void push (Register reg)      { addi_d(SP, SP, -8); st_d  (reg, SP, 0); }
   void push (FloatRegister reg) { addi_d(SP, SP, -8); fst_d (reg, SP, 0); }
   void pop  (Register reg)      { ld_d  (reg, SP, 0);  addi_d(SP, SP, 8); }

--- a/src/hotspot/cpu/loongarch/registerMap_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/registerMap_loongarch.hpp
@@ -30,7 +30,6 @@
   friend class frame;
 
  private:
-#ifndef CORE
   // This is the hook for finding a register in an "well-known" location,
   // such as a register block of a predetermined format.
   // Since there is none, we just return NULL.
@@ -51,7 +50,6 @@
       return location(base_reg->next(slot_idx), nullptr);
     }
   }
-#endif
 
   // no PD state to clear or copy:
   void pd_clear() {}

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1941,9 +1941,6 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // no exception, we're almost done
 
-  // check that only result value is on FPU stack
-  __ verify_FPU(ret_type == T_FLOAT || ret_type == T_DOUBLE ? 1 : 0, "native_wrapper normal exit");
-
   // Return
   __ leave();
 

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -5372,10 +5372,9 @@ class StubGenerator: public StubCodeGenerator {
     if (VerifyOops) {
       StubRoutines::_verify_oop_subroutine_entry   = generate_verify_oop();
     }
-#ifndef CORE
+
     // arraycopy stubs used by compilers
     generate_arraycopy_stubs();
-#endif
 
     if (UseLSX && vmIntrinsics::is_intrinsic_available(vmIntrinsics::_dsin)) {
       StubRoutines::_dsin = generate_dsin_dcos(/* isCos = */ false);

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -732,8 +732,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // disjoint large copy
   void generate_disjoint_large_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     {
       UnsafeCopyMemoryMark ucmm(this, true, true);
@@ -817,8 +817,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // disjoint large copy lsx
   void generate_disjoint_large_copy_lsx(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     {
       UnsafeCopyMemoryMark ucmm(this, true, true);
@@ -902,8 +902,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // disjoint large copy lasx
   void generate_disjoint_large_copy_lasx(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     {
       UnsafeCopyMemoryMark ucmm(this, true, true);
@@ -987,8 +987,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // conjoint large copy
   void generate_conjoint_large_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     {
       UnsafeCopyMemoryMark ucmm(this, true, true);
@@ -1069,8 +1069,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // conjoint large copy lsx
   void generate_conjoint_large_copy_lsx(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     {
       UnsafeCopyMemoryMark ucmm(this, true, true);
@@ -1151,8 +1151,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // conjoint large copy lasx
   void generate_conjoint_large_copy_lasx(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     {
       UnsafeCopyMemoryMark ucmm(this, true, true);
@@ -1233,8 +1233,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // Byte small copy: less than { int:9, lsx:17, lasx:33 } elements.
   void generate_byte_small_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label L;
     __ bind(entry);
@@ -1599,8 +1599,8 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_disjoint_byte_copy(bool aligned, Label &small, Label &large,
                                       Label &large_aligned, const char * name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     if (UseLASX)
@@ -1639,8 +1639,8 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_conjoint_byte_copy(bool aligned, Label &small, Label &large,
                                       Label &large_aligned, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     array_overlap_test(StubRoutines::jbyte_disjoint_arraycopy(), 0);
@@ -1666,8 +1666,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // Short small copy: less than { int:9, lsx:9, lasx:17 } elements.
   void generate_short_small_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label L;
     __ bind(entry);
@@ -1878,8 +1878,8 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_disjoint_short_copy(bool aligned, Label &small, Label &large,
                                        Label &large_aligned, const char * name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     if (UseLASX)
@@ -1918,8 +1918,8 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_conjoint_short_copy(bool aligned, Label &small, Label &large,
                                        Label &large_aligned, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     array_overlap_test(StubRoutines::jshort_disjoint_arraycopy(), 1);
@@ -1945,8 +1945,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // Int small copy: less than { int:7, lsx:7, lasx:9 } elements.
   void generate_int_small_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label L;
     __ bind(entry);
@@ -2174,8 +2174,8 @@ class StubGenerator: public StubCodeGenerator {
   address generate_disjoint_int_oop_copy(bool aligned, bool is_oop, Label &small,
                                          Label &large, Label &large_aligned, const char *name,
                                          int small_limit, bool dest_uninitialized = false) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     gen_maybe_oop_copy(is_oop, true, aligned, small, large, large_aligned,
@@ -2202,8 +2202,8 @@ class StubGenerator: public StubCodeGenerator {
   address generate_conjoint_int_oop_copy(bool aligned, bool is_oop, Label &small,
                                          Label &large, Label &large_aligned, const char *name,
                                          int small_limit, bool dest_uninitialized = false) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     if (is_oop) {
@@ -2220,8 +2220,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // Long small copy: less than { int:4, lsx:4, lasx:5 } elements.
   void generate_long_small_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label L;
     __ bind(entry);
@@ -2326,8 +2326,8 @@ class StubGenerator: public StubCodeGenerator {
   address generate_disjoint_long_oop_copy(bool aligned, bool is_oop, Label &small,
                                           Label &large, Label &large_aligned, const char *name,
                                           int small_limit, bool dest_uninitialized = false) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     gen_maybe_oop_copy(is_oop, true, aligned, small, large, large_aligned,
@@ -2354,8 +2354,8 @@ class StubGenerator: public StubCodeGenerator {
   address generate_conjoint_long_oop_copy(bool aligned, bool is_oop, Label &small,
                                           Label &large, Label &large_aligned, const char *name,
                                           int small_limit, bool dest_uninitialized = false) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     if (is_oop) {

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -3049,7 +3049,7 @@ class StubGenerator: public StubCodeGenerator {
       BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
       Address thread_epoch_addr(TREG, in_bytes(bs_nm->thread_disarmed_offset()) + 4);
       __ lea(SCR1, ExternalAddress(bs_asm->patching_epoch_addr()));
-      __ ld_wu(SCR1, SCR1);
+      __ ld_wu(SCR1, SCR1, 0);
       __ st_w(SCR1, thread_epoch_addr);
       __ ibar(0);
       __ membar(__ LoadLoad);

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -403,6 +403,13 @@ void VM_Version::get_processor_features() {
   if (FLAG_IS_DEFAULT(UseMontgomerySquareIntrinsic)) {
     UseMontgomerySquareIntrinsic = true;
   }
+
+  if (UseFPUForSpilling && !FLAG_IS_DEFAULT(UseFPUForSpilling)) {
+    if (UseCompressedOops || UseCompressedClassPointers) {
+      warning("UseFPUForSpilling not supported when UseCompressedOops or UseCompressedClassPointers is on");
+      UseFPUForSpilling = false;
+    }
+  }
 #endif
 
   // This machine allows unaligned memory accesses

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/loongarch64/LOONGARCH64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/loongarch64/LOONGARCH64Frame.java
@@ -346,7 +346,7 @@ public class LOONGARCH64Frame extends Frame {
 
     // frame owned by optimizing compiler
     if (Assert.ASSERTS_ENABLED) {
-        Assert.that(cb.getFrameSize() >= 0, "must have non-zero frame size");
+        Assert.that(cb.getFrameSize() > 0, "must have non-zero frame size");
     }
     Address senderSP = getUnextendedSP().addOffsetTo(cb.getFrameSize());
 

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.management.jmxremote;
 
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -924,9 +923,6 @@ public final class ConnectorBootstrap {
     private static class HostAwareSslSocketFactory extends SslRMIServerSocketFactory {
 
         private final String bindAddress;
-        private final String[] enabledCipherSuites;
-        private final String[] enabledProtocols;
-        private final boolean needClientAuth;
         private final SSLContext context;
 
         private HostAwareSslSocketFactory(String[] enabledCipherSuites,
@@ -941,11 +937,9 @@ public final class ConnectorBootstrap {
                                           String[] enabledProtocols,
                                           boolean sslNeedClientAuth,
                                           String bindAddress) throws IllegalArgumentException {
-            this.context = ctx;
+            super(ctx, enabledCipherSuites, enabledProtocols, sslNeedClientAuth);
             this.bindAddress = bindAddress;
-            this.enabledProtocols = enabledProtocols;
-            this.enabledCipherSuites = enabledCipherSuites;
-            this.needClientAuth = sslNeedClientAuth;
+            this.context = ctx;
             checkValues(ctx, enabledCipherSuites, enabledProtocols);
         }
 
@@ -955,14 +949,15 @@ public final class ConnectorBootstrap {
                 try {
                     InetAddress addr = InetAddress.getByName(bindAddress);
                     return new SslServerSocket(port, 0, addr, context,
-                                               enabledCipherSuites, enabledProtocols, needClientAuth);
+                            this.getEnabledCipherSuites(), this.getEnabledProtocols(),
+                            this.getNeedClientAuth());
                 } catch (UnknownHostException e) {
                     return new SslServerSocket(port, context,
-                                               enabledCipherSuites, enabledProtocols, needClientAuth);
+                            this.getEnabledCipherSuites(), this.getEnabledProtocols(), this.getNeedClientAuth());
                 }
             } else {
                 return new SslServerSocket(port, context,
-                                           enabledCipherSuites, enabledProtocols, needClientAuth);
+                        this.getEnabledCipherSuites(), this.getEnabledProtocols(), this.getNeedClientAuth());
             }
         }
 

--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -44,6 +44,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022. These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /* hsdis.c -- dump a range of addresses as native instructions
    This implements the plugin protocol required by the
    HotSpot PrintAssembly option.
@@ -500,6 +506,9 @@ static const char* native_arch_name() {
 #endif
 #ifdef LIBARCH_riscv64
   res = "riscv:rv64";
+#endif
+#ifdef LIBARCH_loongarch64
+  res = "loongarch64";
 #endif
   if (res == NULL)
     res = "architecture not set in Makefile!";

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022, These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package nsk.share.jdi;
 
 import nsk.share.*;
@@ -520,21 +526,22 @@ class CheckedFeatures {
          *  available only on the Microsoft Windows platform.
          *  "
          */
-        {"linux-i586",      "com.sun.jdi.SharedMemoryAttach"},
-        {"linux-ia64",      "com.sun.jdi.SharedMemoryAttach"},
-        {"linux-amd64",     "com.sun.jdi.SharedMemoryAttach"},
-        {"linux-x64",       "com.sun.jdi.SharedMemoryAttach"},
-        {"linux-aarch64",   "com.sun.jdi.SharedMemoryAttach"},
-        {"linux-arm",       "com.sun.jdi.SharedMemoryAttach"},
-        {"linux-ppc64",     "com.sun.jdi.SharedMemoryAttach"},
-        {"linux-ppc64le",   "com.sun.jdi.SharedMemoryAttach"},
-        {"linux-s390x",     "com.sun.jdi.SharedMemoryAttach"},
-        {"linux-riscv64",   "com.sun.jdi.SharedMemoryAttach"},
-        {"macosx-amd64",    "com.sun.jdi.SharedMemoryAttach"},
-        {"mac-x64",         "com.sun.jdi.SharedMemoryAttach"},
-        {"macosx-aarch64",  "com.sun.jdi.SharedMemoryAttach"},
-        {"mac-aarch64",     "com.sun.jdi.SharedMemoryAttach"},
-        {"aix-ppc64",       "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-i586",        "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-ia64",        "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-amd64",       "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-x64",         "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-aarch64",     "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-arm",         "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-ppc64",       "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-ppc64le",     "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-s390x",       "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-riscv64",     "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-loongarch64", "com.sun.jdi.SharedMemoryAttach"},
+        {"macosx-amd64",      "com.sun.jdi.SharedMemoryAttach"},
+        {"mac-x64",           "com.sun.jdi.SharedMemoryAttach"},
+        {"macosx-aarch64",    "com.sun.jdi.SharedMemoryAttach"},
+        {"mac-aarch64",       "com.sun.jdi.SharedMemoryAttach"},
+        {"aix-ppc64",         "com.sun.jdi.SharedMemoryAttach"},
 
             // listening connectors
         /*
@@ -546,21 +553,22 @@ class CheckedFeatures {
          *  It is available only on the Microsoft Windows platform.
          *  "
          */
-        {"linux-i586",      "com.sun.jdi.SharedMemoryListen"},
-        {"linux-ia64",      "com.sun.jdi.SharedMemoryListen"},
-        {"linux-amd64",     "com.sun.jdi.SharedMemoryListen"},
-        {"linux-x64",       "com.sun.jdi.SharedMemoryListen"},
-        {"linux-aarch64",   "com.sun.jdi.SharedMemoryListen"},
-        {"linux-arm",       "com.sun.jdi.SharedMemoryListen"},
-        {"linux-ppc64",     "com.sun.jdi.SharedMemoryListen"},
-        {"linux-ppc64le",   "com.sun.jdi.SharedMemoryListen"},
-        {"linux-s390x",     "com.sun.jdi.SharedMemoryListen"},
-        {"linux-riscv64",   "com.sun.jdi.SharedMemoryListen"},
-        {"macosx-amd64",    "com.sun.jdi.SharedMemoryListen"},
-        {"mac-x64",         "com.sun.jdi.SharedMemoryListen"},
-        {"macosx-aarch64",  "com.sun.jdi.SharedMemoryListen"},
-        {"mac-aarch64",     "com.sun.jdi.SharedMemoryListen"},
-        {"aix-ppc64",       "com.sun.jdi.SharedMemoryListen"},
+        {"linux-i586",        "com.sun.jdi.SharedMemoryListen"},
+        {"linux-ia64",        "com.sun.jdi.SharedMemoryListen"},
+        {"linux-amd64",       "com.sun.jdi.SharedMemoryListen"},
+        {"linux-x64",         "com.sun.jdi.SharedMemoryListen"},
+        {"linux-aarch64",     "com.sun.jdi.SharedMemoryListen"},
+        {"linux-arm",         "com.sun.jdi.SharedMemoryListen"},
+        {"linux-ppc64",       "com.sun.jdi.SharedMemoryListen"},
+        {"linux-ppc64le",     "com.sun.jdi.SharedMemoryListen"},
+        {"linux-s390x",       "com.sun.jdi.SharedMemoryListen"},
+        {"linux-riscv64",     "com.sun.jdi.SharedMemoryListen"},
+        {"linux-loongarch64", "com.sun.jdi.SharedMemoryListen"},
+        {"macosx-amd64",      "com.sun.jdi.SharedMemoryListen"},
+        {"mac-x64",           "com.sun.jdi.SharedMemoryListen"},
+        {"macosx-aarch64",    "com.sun.jdi.SharedMemoryListen"},
+        {"mac-aarch64",       "com.sun.jdi.SharedMemoryListen"},
+        {"aix-ppc64",         "com.sun.jdi.SharedMemoryListen"},
 
             // launching connectors
         /*
@@ -575,78 +583,82 @@ class CheckedFeatures {
          *  Windows, the shared memory transport is used. On Linux the socket transport is used.
          * "
          */
-        {"linux-i586",      "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-i586",      "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-i586",        "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-i586",        "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"linux-ia64",      "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-ia64",      "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-ia64",        "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-ia64",        "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"linux-amd64",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-amd64",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-amd64",       "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-amd64",       "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"linux-x64",       "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-x64",       "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-x64",         "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-x64",         "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"linux-aarch64",   "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-aarch64",   "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-aarch64",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-aarch64",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"linux-arm",       "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-arm",       "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-arm",         "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-arm",         "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"linux-ppc64",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-ppc64",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-ppc64",       "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-ppc64",       "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"linux-ppc64le",   "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-ppc64le",   "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-ppc64le",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-ppc64le",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"linux-s390x",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-s390x",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-s390x",       "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-s390x",       "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"linux-riscv64",   "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"linux-riscv64",   "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"linux-riscv64",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-riscv64",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"windows-i586",    "com.sun.jdi.CommandLineLaunch", "dt_socket"},
-        {"windows-i586",    "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
+        {"linux-loongarch64", "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-loongarch64", "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"windows-ia64",    "com.sun.jdi.CommandLineLaunch", "dt_socket"},
-        {"windows-ia64",    "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
+        {"windows-i586",      "com.sun.jdi.CommandLineLaunch", "dt_socket"},
+        {"windows-i586",      "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
 
-        {"windows-amd64",   "com.sun.jdi.CommandLineLaunch", "dt_socket"},
-        {"windows-amd64",   "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
+        {"windows-ia64",      "com.sun.jdi.CommandLineLaunch", "dt_socket"},
+        {"windows-ia64",      "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
 
-        {"windows-x64",     "com.sun.jdi.CommandLineLaunch", "dt_socket"},
-        {"windows-x64",     "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
+        {"windows-amd64",     "com.sun.jdi.CommandLineLaunch", "dt_socket"},
+        {"windows-amd64",     "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
 
-        {"macosx-amd64",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"macosx-amd64",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"windows-x64",       "com.sun.jdi.CommandLineLaunch", "dt_socket"},
+        {"windows-x64",       "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
 
-        {"mac-x64",          "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"mac-x64",          "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"macosx-amd64",      "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"macosx-amd64",      "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"macosx-aarch64",   "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"macosx-aarch64",   "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"mac-x64",           "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"mac-x64",           "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"mac-aarch64",      "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"mac-aarch64",      "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"macosx-aarch64",    "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"macosx-aarch64",    "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"aix-ppc64",       "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"aix-ppc64",       "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"mac-aarch64",       "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"mac-aarch64",       "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+
+        {"aix-ppc64",         "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"aix-ppc64",         "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
         // shared memory transport is implemented only on windows platform
-        {"linux-i586",      "dt_shmem"},
-        {"linux-ia64",      "dt_shmem"},
-        {"linux-amd64",     "dt_shmem"},
-        {"linux-x64",       "dt_shmem"},
-        {"linux-aarch64",   "dt_shmem"},
-        {"linux-arm",       "dt_shmem"},
-        {"linux-ppc64",     "dt_shmem"},
-        {"linux-ppc64le",   "dt_shmem"},
-        {"linux-s390x",     "dt_shmem"},
-        {"linux-riscv64",   "dt_shmem"},
-        {"macosx-amd64",    "dt_shmem"},
-        {"mac-x64",         "dt_shmem"},
-        {"macosx-aarch64",  "dt_shmem"},
-        {"mac-aarch64",     "dt_shmem"},
-        {"aix-ppc64",       "dt_shmem"},
+        {"linux-i586",        "dt_shmem"},
+        {"linux-ia64",        "dt_shmem"},
+        {"linux-amd64",       "dt_shmem"},
+        {"linux-x64",         "dt_shmem"},
+        {"linux-aarch64",     "dt_shmem"},
+        {"linux-arm",         "dt_shmem"},
+        {"linux-ppc64",       "dt_shmem"},
+        {"linux-ppc64le",     "dt_shmem"},
+        {"linux-s390x",       "dt_shmem"},
+        {"linux-riscv64",     "dt_shmem"},
+        {"linux-loongarch64", "dt_shmem"},
+        {"macosx-amd64",      "dt_shmem"},
+        {"mac-x64",           "dt_shmem"},
+        {"macosx-aarch64",    "dt_shmem"},
+        {"mac-aarch64",       "dt_shmem"},
+        {"aix-ppc64",         "dt_shmem"},
     };
 }

--- a/test/jdk/sun/management/jmxremote/bootstrap/management_ssltest07_ok.properties.in
+++ b/test/jdk/sun/management/jmxremote/bootstrap/management_ssltest07_ok.properties.in
@@ -1,5 +1,5 @@
-com.sun.management.jmxremote.ssl.enabled.cipher.suites=TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+com.sun.management.jmxremote.ssl.enabled.cipher.suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
 com.sun.management.jmxremote.ssl.enabled.protocols=SSLv2Hello,SSLv3,TLSv1
 com.sun.management.jmxremote.ssl.need.client.auth=true
 com.sun.management.jmxremote.authenticate=false
-javax.rmi.ssl.client.enabledCipherSuites=TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+javax.rmi.ssl.client.enabledCipherSuites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA


### PR DESCRIPTION
28135: Add linux-loongarch64 to CheckedFeatures.notImplemented
28039: Fix typo for generate_method_entry_barrier and BarrierSetAssembler::nmethod_entry_barrier
28128: using Address reference as argument
28133: 8293657: sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 failed with "SSLHandshakeException: Remote host terminated the handshake"
27811: [LA][C2] xml.validation fatal error SIGSEGV with +UseFPUForSpilling
28051: LA port of 8293660: Fix frame::sender_for_compiled_frame frame size assert
27891: Deprecated assembler removal
27957: Mark stub code without alignment padding
27965: Remove unused CORE macro definition
28048: Enable hsdis for loongarch64