### PR TITLE
Update (2022.10.11)

### DIFF
--- a/src/hotspot/cpu/loongarch/nativeInst_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/nativeInst_loongarch.cpp
@@ -31,6 +31,7 @@
 #include "nativeInst_loongarch.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.hpp"
+#include "runtime/safepoint.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/ostream.hpp"

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
+#include "classfile/javaClasses.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/interp_masm.hpp"

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -442,9 +442,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
-  print_hex_dump(st, (address)(sp - 32), (address)(sp + 32), sizeof(intptr_t));
+  address sp = (address)os::Linux::ucontext_get_sp(uc);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may


### PR DESCRIPTION
28098: Minimal build failed with --disable-precompiled-headers
28096: LA port of 8293851: hs_err should print more stack in hex dump