### PR TITLE
Update (2022.11.02)

### DIFF
--- a/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
@@ -97,13 +97,10 @@ constexpr Register TREG           = S6;
 constexpr Register S5_heapbase    = S5;
 
 constexpr Register FSR            = V0;
-constexpr Register SSR            = T6;
 constexpr FloatRegister FSF       = FA0;
 
 constexpr Register RECEIVER       = T0;
 constexpr Register IC_Klass       = T1;
-
-constexpr Register SHIFT_count    = T3;
 
 // ---------- Scratch Register ----------
 constexpr Register AT             = T7;

--- a/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
@@ -1531,27 +1531,18 @@ class Assembler : public AbstractAssembler  {
   // get the offset field of beq, bne, blt[u], bge[u] instruction
   int offset16(address entry) {
     assert(is_simm16((entry - pc()) / 4), "change this code");
-    if (!is_simm16((entry - pc()) / 4)) {
-      tty->print_cr("!!! is_simm16: %lx", (entry - pc()) / 4);
-    }
     return (entry - pc()) / 4;
   }
 
   // get the offset field of beqz, bnez instruction
   int offset21(address entry) {
     assert(is_simm((int)(entry - pc()) / 4, 21), "change this code");
-    if (!is_simm((int)(entry - pc()) / 4, 21)) {
-      tty->print_cr("!!! is_simm21: %lx", (entry - pc()) / 4);
-    }
     return (entry - pc()) / 4;
   }
 
   // get the offset field of b instruction
   int offset26(address entry) {
     assert(is_simm((int)(entry - pc()) / 4, 26), "change this code");
-    if (!is_simm((int)(entry - pc()) / 4, 26)) {
-      tty->print_cr("!!! is_simm26: %lx", (entry - pc()) / 4);
-    }
     return (entry - pc()) / 4;
   }
 

--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -297,10 +297,7 @@ void LIR_Assembler::jobject2reg(jobject o, Register reg) {
   if (o == NULL) {
     __ move(reg, R0);
   } else {
-    int oop_index = __ oop_recorder()->find_index(o);
-    RelocationHolder rspec = oop_Relocation::spec(oop_index);
-    __ relocate(rspec);
-    __ patchable_li52(reg, (long)o);
+    __ movoop(reg, o);
   }
 }
 

--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -2309,6 +2309,7 @@ void LIR_Assembler::call(LIR_OpJavaCall* op, relocInfo::relocType rtype) {
     return;
   }
   add_call_info(code_offset(), op->info());
+  __ post_call_nop();
 }
 
 void LIR_Assembler::ic_call(LIR_OpJavaCall* op) {
@@ -2318,6 +2319,7 @@ void LIR_Assembler::ic_call(LIR_OpJavaCall* op) {
     return;
   }
   add_call_info(code_offset(), op->info());
+  __ post_call_nop();
 }
 
 void LIR_Assembler::emit_static_call_stub() {
@@ -3163,6 +3165,7 @@ void LIR_Assembler::rt_call(LIR_Opr result, address dest, const LIR_OprList* arg
   if (info != NULL) {
     add_call_info_here(info);
   }
+  __ post_call_nop();
 }
 
 void LIR_Assembler::volatile_move_op(LIR_Opr src, LIR_Opr dest, BasicType type,

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
@@ -41,14 +41,6 @@ public:
   void fast_unlock(Register oop, Register box, Register flag,
                    Register disp_hdr, Register tmp);
 
-  // For C2 to support long branches
-  void beq_long   (Register rs, Register rt, Label& L);
-  void bne_long   (Register rs, Register rt, Label& L);
-  void blt_long   (Register rs, Register rt, Label& L, bool is_signed);
-  void bge_long   (Register rs, Register rt, Label& L, bool is_signed);
-  void bc1t_long  (Label& L);
-  void bc1f_long  (Label& L);
-
   // Compare strings.
   void string_compare(Register str1, Register str2,
                       Register cnt1, Register cnt2, Register result,

--- a/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
@@ -79,9 +79,6 @@ define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
 
 define_pd_global(bool,  TrapBasedRangeChecks,        false);
 
-// Heap related flags
-define_pd_global(uintx,MetaspaceSize,    ScaleForWordSize(16*M));
-
 // Ergonomics related flags
 define_pd_global(bool, NeverActAsServerClassMachine, false);
 

--- a/src/hotspot/cpu/loongarch/continuationEntry_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/continuationEntry_loongarch.inline.hpp
@@ -28,20 +28,25 @@
 
 #include "runtime/continuationEntry.hpp"
 
-// TODO: Implement
+#include "code/codeCache.hpp"
+#include "oops/method.inline.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/registerMap.hpp"
 
 inline frame ContinuationEntry::to_frame() const {
-  Unimplemented();
-  return frame();
+  static CodeBlob* cb = CodeCache::find_blob_fast(entry_pc());
+  assert(cb != nullptr, "");
+  assert(cb->as_compiled_method()->method()->is_continuation_enter_intrinsic(), "");
+  return frame(entry_sp(), entry_sp(), entry_fp(), entry_pc(), cb);
 }
 
 inline intptr_t* ContinuationEntry::entry_fp() const {
-  Unimplemented();
-  return nullptr;
+  return (intptr_t*)((address)this + size()) + 2;
 }
 
 inline void ContinuationEntry::update_register_map(RegisterMap* map) const {
-  Unimplemented();
+  intptr_t** fp = (intptr_t**)(bottom_sender_sp() - 2);
+  frame::update_map_with_saved_link(map, fp);
 }
 
 #endif // CPU_LOONGARCH_CONTINUATIONENTRY_LOONGARCH_INLINE_HPP

--- a/src/hotspot/cpu/loongarch/continuationFreezeThaw_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/continuationFreezeThaw_loongarch.inline.hpp
@@ -26,75 +26,265 @@
 #ifndef CPU_LOONGARCH_CONTINUATIONFREEZETHAW_LOONGARCH_INLINE_HPP
 #define CPU_LOONGARCH_CONTINUATIONFREEZETHAW_LOONGARCH_INLINE_HPP
 
+#include "code/codeBlob.inline.hpp"
 #include "oops/stackChunkOop.inline.hpp"
 #include "runtime/frame.hpp"
 #include "runtime/frame.inline.hpp"
 
 
-inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
-  Unimplemented();
+inline void patch_callee_link(const frame& f, intptr_t* fp) {
+  DEBUG_ONLY(intptr_t* orig = *ContinuationHelper::Frame::callee_link_address(f));
+  *ContinuationHelper::Frame::callee_link_address(f) = fp;
 }
+
+inline void patch_callee_link_relative(const frame& f, intptr_t* fp) {
+  intptr_t* la = (intptr_t*)ContinuationHelper::Frame::callee_link_address(f);
+  intptr_t new_value = fp - la;
+  *la = new_value;
+}
+
+////// Freeze
+
+// Fast path
+
+inline void FreezeBase::patch_stack_pd(intptr_t* frame_sp, intptr_t* heap_sp) {
+  // copy the spilled fp from the heap to the stack
+  *(frame_sp - 2) = *(heap_sp - 2);
+}
+
+// Slow path
 
 template<typename FKind>
 inline frame FreezeBase::sender(const frame& f) {
-  Unimplemented();
-  return frame();
+  assert(FKind::is_instance(f), "");
+  if (FKind::interpreted) {
+    return frame(f.sender_sp(), f.interpreter_frame_sender_sp(), f.link(), f.sender_pc());
+  }
+
+  intptr_t** link_addr = link_address<FKind>(f);
+  intptr_t* sender_sp = (intptr_t*)(link_addr + 2); //  f.unextended_sp() + (fsize/wordSize); //
+  address sender_pc = (address) *(sender_sp - 1);
+  assert(sender_sp != f.sp(), "must have changed");
+
+  int slot = 0;
+  CodeBlob* sender_cb = CodeCache::find_blob_and_oopmap(sender_pc, slot);
+  return sender_cb != nullptr
+    ? frame(sender_sp, sender_sp, *link_addr, sender_pc, sender_cb,
+            slot == -1 ? nullptr : sender_cb->oop_map_for_slot(slot, sender_pc),
+            false /* on_heap ? */)
+    : frame(sender_sp, sender_sp, *link_addr, sender_pc);
 }
 
 template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
-  Unimplemented();
-  return frame();
+  assert(FKind::is_instance(f), "");
+  assert(!caller.is_interpreted_frame()
+    || caller.unextended_sp() == (intptr_t*)caller.at(frame::interpreter_frame_last_sp_offset), "");
+
+  intptr_t *sp, *fp; // sp is really our unextended_sp
+  if (FKind::interpreted) {
+    assert((intptr_t*)f.at(frame::interpreter_frame_last_sp_offset) == nullptr
+      || f.unextended_sp() == (intptr_t*)f.at(frame::interpreter_frame_last_sp_offset), "");
+    int locals = f.interpreter_frame_method()->max_locals();
+    // If the caller.is_empty(), i.e. we're freezing into an empty chunk, then we set
+    // the chunk's argsize in finalize_freeze and make room for it above the unextended_sp
+    bool overlap_caller = caller.is_interpreted_frame() || caller.is_empty();
+    fp = caller.unextended_sp() - (locals + frame::sender_sp_offset) + (overlap_caller ? ContinuationHelper::InterpretedFrame::stack_argsize(f) : 0);
+    sp = fp - (f.fp() - f.unextended_sp());
+    assert(sp <= fp, "");
+    assert(fp <= caller.unextended_sp(), "");
+    caller.set_sp(fp + frame::sender_sp_offset);
+
+    assert(_cont.tail()->is_in_chunk(sp), "");
+
+    frame hf(sp, sp, fp, f.pc(), nullptr, nullptr, true /* on_heap */);
+    *hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + locals - 1;
+    return hf;
+  } else {
+    // We need to re-read fp out of the frame because it may be an oop and we might have
+    // had a safepoint in finalize_freeze, after constructing f.
+    fp = *(intptr_t**)(f.sp() - 2);
+
+    int fsize = FKind::size(f);
+    sp = caller.unextended_sp() - fsize;
+    if (caller.is_interpreted_frame()) {
+      // If the caller is interpreted, our stackargs are not supposed to overlap with it
+      // so we make more room by moving sp down by argsize
+      int argsize = FKind::stack_argsize(f);
+      sp -= argsize;
+    }
+    caller.set_sp(sp + fsize);
+
+    assert(_cont.tail()->is_in_chunk(sp), "");
+
+    return frame(sp, sp, fp, f.pc(), nullptr, nullptr, true /* on_heap */);
+  }
 }
 
 void FreezeBase::adjust_interpreted_frame_unextended_sp(frame& f) {
-  Unimplemented();
+  assert((f.at(frame::interpreter_frame_last_sp_offset) != 0) || (f.unextended_sp() == f.sp()), "");
+  intptr_t* real_unextended_sp = (intptr_t*)f.at(frame::interpreter_frame_last_sp_offset);
+  if (real_unextended_sp != nullptr) {
+    f.set_unextended_sp(real_unextended_sp); // can be null at a safepoint
+  }
+}
+
+static inline void relativize_one(intptr_t* const vfp, intptr_t* const hfp, int offset) {
+  assert(*(hfp + offset) == *(vfp + offset), "");
+  intptr_t* addr = hfp + offset;
+  intptr_t value = *(intptr_t**)addr - vfp;
+  *addr = value;
 }
 
 inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
-  Unimplemented();
+  intptr_t* vfp = f.fp();
+  intptr_t* hfp = hf.fp();
+  assert(hfp == hf.unextended_sp() + (f.fp() - f.unextended_sp()), "");
+  assert((f.at(frame::interpreter_frame_last_sp_offset) != 0)
+    || (f.unextended_sp() == f.sp()), "");
+  assert(f.fp() > (intptr_t*)f.at(frame::interpreter_frame_initial_sp_offset), "");
+
+  // at(frame::interpreter_frame_last_sp_offset) can be NULL at safepoint preempts
+  *hf.addr_at(frame::interpreter_frame_last_sp_offset) = hf.unextended_sp() - hf.fp();
+  *hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + f.interpreter_frame_method()->max_locals() - 1;
+
+  relativize_one(vfp, hfp, frame::interpreter_frame_initial_sp_offset); // == block_top == block_bottom
+
+  assert((hf.fp() - hf.unextended_sp()) == (f.fp() - f.unextended_sp()), "");
+  assert(hf.unextended_sp() == (intptr_t*)hf.at(frame::interpreter_frame_last_sp_offset), "");
+  assert(hf.unextended_sp() <= (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
+  assert(hf.fp()            >  (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
+  // assert(hf.fp()            <= (intptr_t*)hf.at(frame::interpreter_frame_locals_offset), "");
+}
+
+inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
+  stackChunkOop chunk = _cont.tail();
+  assert(chunk->is_in_chunk(hf.sp() - 1), "");
+  assert(chunk->is_in_chunk(hf.sp() - 2), "");
+
+  *(hf.sp() - 1) = (intptr_t)hf.pc();
+
+  intptr_t* fp_addr = hf.sp() - 2;
+  *fp_addr = hf.is_interpreted_frame() ? (intptr_t)(hf.fp() - fp_addr)
+                                       : (intptr_t)hf.fp();
 }
 
 inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
-  Unimplemented();
+  if (caller.is_interpreted_frame()) {
+    assert(!caller.is_empty(), "");
+    patch_callee_link_relative(caller, caller.fp());
+  } else {
+    // If we're the bottom-most frame frozen in this freeze, the caller might have stayed frozen in the chunk,
+    // and its oop-containing fp fixed. We've now just overwritten it, so we must patch it back to its value
+    // as read from the chunk.
+    patch_callee_link(caller, caller.fp());
+  }
 }
 
-inline void FreezeBase::patch_stack_pd(intptr_t* frame_sp, intptr_t* heap_sp) {
-  Unimplemented();
-}
+//////// Thaw
 
-inline frame ThawBase::new_entry_frame() {
-  Unimplemented();
-  return frame();
-}
+// Fast path
 
-template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame& caller, bool bottom) {
-  Unimplemented();
-  return frame();
-}
-
-inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
-  Unimplemented();
-}
-
-inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
-  Unimplemented();
-}
-
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom) {
-  Unimplemented();
-  return NULL;
-}
-
-inline void ThawBase::patch_pd(frame& f, const frame& caller) {
-  Unimplemented();
+inline void ThawBase::prefetch_chunk_pd(void* start, int size) {
+  size <<= LogBytesPerWord;
+  Prefetch::read(start, size);
+  Prefetch::read(start, size - 64);
 }
 
 void ThawBase::patch_chunk_pd(intptr_t* sp) {
-  Unimplemented();
+  intptr_t* fp = _cont.entryFP();
+  *(intptr_t**)(sp - 2) = fp;
 }
 
-inline void ThawBase::prefetch_chunk_pd(void* start, int size) {
-  Unimplemented();
+// Slow path
+
+inline frame ThawBase::new_entry_frame() {
+  intptr_t* sp = _cont.entrySP();
+  return frame(sp, sp, _cont.entryFP(), _cont.entryPC()); // TODO PERF: This finds code blob and computes deopt state
+}
+
+template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame& caller, bool bottom) {
+  assert(FKind::is_instance(hf), "");
+  // The values in the returned frame object will be written into the callee's stack in patch.
+
+  if (FKind::interpreted) {
+    intptr_t* heap_sp = hf.unextended_sp();
+    // If caller is interpreted it already made room for the callee arguments
+    int overlap = caller.is_interpreted_frame() ? ContinuationHelper::InterpretedFrame::stack_argsize(hf) : 0;
+    const int fsize = ContinuationHelper::InterpretedFrame::frame_bottom(hf) - hf.unextended_sp() - overlap;
+    const int locals = hf.interpreter_frame_method()->max_locals();
+    intptr_t* frame_sp = caller.unextended_sp() - fsize;
+    intptr_t* fp = frame_sp + (hf.fp() - heap_sp);
+    DEBUG_ONLY(intptr_t* unextended_sp = fp + *hf.addr_at(frame::interpreter_frame_last_sp_offset);)
+    assert(frame_sp == unextended_sp, "");
+    caller.set_sp(fp + frame::sender_sp_offset);
+    frame f(frame_sp, frame_sp, fp, hf.pc());
+    // it's set again later in set_interpreter_frame_bottom, but we need to set the locals now so that
+    // we could call ContinuationHelper::InterpretedFrame::frame_bottom
+    intptr_t offset = *hf.addr_at(frame::interpreter_frame_locals_offset);
+    assert((int)offset == frame::sender_sp_offset + locals - 1, "");
+    // derelativize locals
+    *(intptr_t**)f.addr_at(frame::interpreter_frame_locals_offset) = fp + offset;
+    return f;
+  } else {
+    int fsize = FKind::size(hf);
+    intptr_t* frame_sp = caller.unextended_sp() - fsize;
+    if (bottom || caller.is_interpreted_frame()) {
+      int argsize = hf.compiled_frame_stack_argsize();
+
+      fsize += argsize;
+      frame_sp -= argsize;
+      caller.set_sp(caller.sp() - argsize);
+      assert(caller.sp() == frame_sp + (fsize-argsize), "");
+
+      frame_sp = align(hf, frame_sp, caller, bottom);
+    }
+
+    assert(hf.cb() != nullptr, "");
+    assert(hf.oop_map() != nullptr, "");
+    intptr_t* fp;
+    if (PreserveFramePointer) {
+      // we need to recreate a "real" frame pointer, pointing into the stack
+      fp = frame_sp + FKind::size(hf) - 2;
+    } else {
+      fp = FKind::stub
+        ? frame_sp + fsize - 2 // this value is used for the safepoint stub
+        : *(intptr_t**)(hf.sp() - 2); // we need to re-read fp because it may be an oop and we might have fixed the frame.
+    }
+    return frame(frame_sp, frame_sp, fp, hf.pc(), hf.cb(), hf.oop_map(), false); // TODO PERF : this computes deopt state; is it necessary?
+  }
+}
+
+inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom) {
+#ifdef _LP64
+  if (((intptr_t)frame_sp % frame::frame_alignment) != 0) {
+    // assert(caller.is_interpreted_frame() || (bottom && hf.compiled_frame_stack_argsize() % 2 != 0), "");
+    frame_sp--;
+    caller.set_sp(caller.sp() - 1);
+  }
+  assert(is_aligned(frame_sp, frame::frame_alignment), "");
+#endif
+
+  return frame_sp;
+}
+
+inline void ThawBase::patch_pd(frame& f, const frame& caller) {
+  patch_callee_link(caller, caller.fp());
+}
+
+static inline void derelativize_one(intptr_t* const fp, int offset) {
+  intptr_t* addr = fp + offset;
+  *addr = (intptr_t)(fp + *addr);
+}
+
+inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+  intptr_t* vfp = f.fp();
+
+  derelativize_one(vfp, frame::interpreter_frame_last_sp_offset);
+  derelativize_one(vfp, frame::interpreter_frame_initial_sp_offset);
+}
+
+inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+  *(intptr_t**)f.addr_at(frame::interpreter_frame_locals_offset) = bottom - 1;
 }
 
 #endif // CPU_LOONGARCH_CONTINUATIONFREEZETHAW_LOONGARCH_INLINE_HPP

--- a/src/hotspot/cpu/loongarch/continuationHelper_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/continuationHelper_loongarch.inline.hpp
@@ -28,97 +28,113 @@
 
 #include "runtime/continuationHelper.hpp"
 
+#include "runtime/continuationEntry.inline.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/registerMap.hpp"
+#include "utilities/macros.hpp"
+
 template<typename FKind>
 static inline intptr_t** link_address(const frame& f) {
-  Unimplemented();
-  return NULL;
+  assert(FKind::is_instance(f), "");
+  return FKind::interpreted
+            ? (intptr_t**)(f.fp() + frame::link_offset)
+            : (intptr_t**)(f.unextended_sp() + f.cb()->frame_size() - 2);
 }
 
 inline int ContinuationHelper::frame_align_words(int size) {
-  Unimplemented();
-  return 0;
+  if (frame::frame_alignment != 1) {
+    return size & 1;
+  } else {
+    return 0;
+  }
 }
 
 inline intptr_t* ContinuationHelper::frame_align_pointer(intptr_t* sp) {
-  Unimplemented();
-  return NULL;
+#ifdef _LP64
+  sp = align_down(sp, frame::frame_alignment);
+#endif
+  return sp;
 }
 
 template<typename FKind>
 inline void ContinuationHelper::update_register_map(const frame& f, RegisterMap* map) {
-  Unimplemented();
+  frame::update_map_with_saved_link(map, link_address<FKind>(f));
 }
 
 inline void ContinuationHelper::update_register_map_with_callee(const frame& f, RegisterMap* map) {
-  Unimplemented();
+  frame::update_map_with_saved_link(map, ContinuationHelper::Frame::callee_link_address(f));
 }
 
 inline void ContinuationHelper::push_pd(const frame& f) {
-  Unimplemented();
+  *(intptr_t**)(f.sp() - 2) = f.fp();
 }
 
-
-inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
-  Unimplemented();
+inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* entry) {
+  anchor->set_last_Java_fp(entry->entry_fp());
 }
 
 #ifdef ASSERT
 inline void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
-  Unimplemented();
+  intptr_t* fp = *(intptr_t**)(sp - 2);
+  anchor->set_last_Java_fp(fp);
 }
 
 inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
-  Unimplemented();
-  return false;
+  intptr_t* sp = f.sp();
+  address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());
+  intptr_t* fp = *(intptr_t**)(sp - 2);
+  assert(f.raw_pc() == pc, "f.ra_pc: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.raw_pc()), p2i(pc));
+  assert(f.fp() == fp, "f.fp: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.fp()), p2i(fp));
+  return f.raw_pc() == pc && f.fp() == fp;
 }
 #endif
 
 inline intptr_t** ContinuationHelper::Frame::callee_link_address(const frame& f) {
-  Unimplemented();
-  return NULL;
-}
-
-template<typename FKind>
-static inline intptr_t* real_fp(const frame& f) {
-  Unimplemented();
-  return NULL;
-}
-
-inline address* ContinuationHelper::InterpretedFrame::return_pc_address(const frame& f) {
-  Unimplemented();
-  return NULL;
-}
-
-inline void ContinuationHelper::InterpretedFrame::patch_sender_sp(frame& f, intptr_t* sp) {
-  Unimplemented();
+  return (intptr_t**)(f.sp() - 2);
 }
 
 inline address* ContinuationHelper::Frame::return_pc_address(const frame& f) {
   return (address*)(f.real_fp() - 1);
 }
 
+inline address* ContinuationHelper::InterpretedFrame::return_pc_address(const frame& f) {
+  return (address*)(f.fp() + frame::return_addr_offset);
+}
+
+inline void ContinuationHelper::InterpretedFrame::patch_sender_sp(frame& f, intptr_t* sp) {
+  assert(f.is_interpreted_frame(), "");
+  intptr_t* la = f.addr_at(frame::interpreter_frame_sender_sp_offset);
+  *la = f.is_heap_frame() ? (intptr_t)(sp - f.fp()) : (intptr_t)sp;
+}
+
 inline address ContinuationHelper::Frame::real_pc(const frame& f) {
-  Unimplemented();
-  return NULL;
+  address* pc_addr = &(((address*) f.sp())[-1]);
+  return *pc_addr;
 }
 
 inline void ContinuationHelper::Frame::patch_pc(const frame& f, address pc) {
-  Unimplemented();
+  address* pc_addr = &(((address*) f.sp())[-1]);
+  *pc_addr = pc;
 }
 
 inline intptr_t* ContinuationHelper::InterpretedFrame::frame_top(const frame& f, InterpreterOopMap* mask) { // inclusive; this will be copied with the frame
-  Unimplemented();
-  return NULL;
+  // interpreter_frame_last_sp_offset, points to unextended_sp includes arguments in the frame
+  // interpreter_frame_initial_sp_offset excludes expression stack slots
+  int expression_stack_sz = expression_stack_size(f, mask);
+  intptr_t* res = *(intptr_t**)f.addr_at(frame::interpreter_frame_initial_sp_offset) - expression_stack_sz;
+  assert(res == (intptr_t*)f.interpreter_frame_monitor_end() - expression_stack_sz, "");
+  assert(res >= f.unextended_sp(),
+    "res: " INTPTR_FORMAT " initial_sp: " INTPTR_FORMAT " last_sp: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " expression_stack_size: %d",
+    p2i(res), p2i(f.addr_at(frame::interpreter_frame_initial_sp_offset)), f.at(frame::interpreter_frame_last_sp_offset), p2i(f.unextended_sp()), expression_stack_sz);
+  return res;
 }
 
 inline intptr_t* ContinuationHelper::InterpretedFrame::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
-  Unimplemented();
-  return NULL;
+  return (intptr_t*)f.at(frame::interpreter_frame_locals_offset) + 1; // exclusive, so we add 1 word
 }
 
 inline intptr_t* ContinuationHelper::InterpretedFrame::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {
-  Unimplemented();
-  return NULL;
+  return f.unextended_sp() + (callee_interpreted ? callee_argsize : 0);
 }
 
 #endif // CPU_LOONGARCH_CONTINUATIONFRAMEHELPERS_LOONGARCH_INLINE_HPP

--- a/src/hotspot/cpu/loongarch/frame_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.hpp
@@ -104,9 +104,9 @@
     arg_reg_save_area_bytes                          =  0,
 
     // size, in words, of frame metadata (e.g. pc and link)
-    metadata_words                                   = sender_sp_offset,
+    metadata_words                                   =  2,
     // in bytes
-    frame_alignment                                  = 16,
+    frame_alignment                                  =  16,
     // size, in words, of maximum shift in frame position due to alignment
     align_wiggle                                     =  1
   };
@@ -121,7 +121,10 @@
 
  private:
   // an additional field beyond _sp and _pc:
-  intptr_t*   _fp; // frame pointer
+  union {
+    intptr_t*  _fp; // frame pointer
+    int _offset_fp; // relative frame pointer for use in stack-chunk frames
+  };
   // The interpreter and adapters will extend the frame of the caller.
   // Since oopMaps are based on the sp of the caller before extension
   // we need to know that value. However in order to compute the address
@@ -129,12 +132,17 @@
   // uses sp() to mean "raw" sp and unextended_sp() to mean the caller's
   // original sp we use that convention.
 
-  intptr_t*     _unextended_sp;
+  union {
+    intptr_t* _unextended_sp;
+    int _offset_unextended_sp; // for use in stack-chunk frames
+  };
+
   void adjust_unextended_sp() NOT_DEBUG_RETURN;
 
   intptr_t* ptr_at_addr(int offset) const {
     return (intptr_t*) addr_at(offset);
   }
+
 #ifdef ASSERT
   // Used in frame::sender_for_{interpreter,compiled}_frame
   static void verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp);
@@ -145,17 +153,26 @@
  public:
   // Constructors
 
-  frame(intptr_t* sp, intptr_t* fp, address pc);
+  frame(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc);
 
-  frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address pc);
+  frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp, address pc);
 
-  frame(intptr_t* sp, intptr_t* fp);
+  frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address pc, CodeBlob* cb);
+  // used for fast frame construction by continuations
+  frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address pc, CodeBlob* cb, const ImmutableOopMap* oop_map, bool on_heap);
 
-  void init(intptr_t* sp, intptr_t* fp, address pc);
+  frame(intptr_t* ptr_sp, intptr_t* ptr_fp);
+
+  void init(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc);
   void setup(address pc);
 
   // accessors for the instance variables
-  intptr_t* fp() const { return _fp; }
+  // Note: not necessarily the real 'frame pointer' (see real_fp)
+
+  intptr_t* fp() const          { assert_absolute(); return _fp; }
+  void set_fp(intptr_t* newfp)  { _fp = newfp; }
+  int offset_fp() const         { assert_offset(); return _offset_fp; }
+  void set_offset_fp(int value) { assert_on_heap(); _offset_fp = value; }
 
   inline address* sender_pc_addr() const;
 
@@ -166,7 +183,7 @@
   static void update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr);
 
   // deoptimization support
-  void interpreter_frame_set_last_sp(intptr_t* sp);
+  void interpreter_frame_set_last_sp(intptr_t* last_sp);
 
   static jint interpreter_frame_expression_stack_direction() { return -1; }
 

--- a/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
@@ -26,8 +26,11 @@
 #ifndef CPU_LOONGARCH_FRAME_LOONGARCH_INLINE_HPP
 #define CPU_LOONGARCH_FRAME_LOONGARCH_INLINE_HPP
 
-#include "code/codeCache.hpp"
+#include "code/codeBlob.inline.hpp"
+#include "code/codeCache.inline.hpp"
 #include "code/vmreg.inline.hpp"
+#include "interpreter/interpreter.hpp"
+#include "interpreter/oopMapCache.hpp"
 #include "runtime/sharedRuntime.hpp"
 
 // Inline functions for Loongson frames:
@@ -83,6 +86,48 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc) {
   init(ptr_sp, ptr_fp, pc);
 }
 
+inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp, address pc, CodeBlob* cb) {
+  intptr_t a = intptr_t(ptr_sp);
+  intptr_t b = intptr_t(ptr_fp);
+  _sp = ptr_sp;
+  _unextended_sp = unextended_sp;
+  _fp = ptr_fp;
+  _pc = pc;
+  assert(pc != NULL, "no pc?");
+  _cb = cb;
+  _oop_map = NULL;
+  assert(_cb != NULL, "pc: " INTPTR_FORMAT, p2i(pc));
+  _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
+  setup(pc);
+}
+
+inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp, address pc, CodeBlob* cb,
+                    const ImmutableOopMap* oop_map, bool on_heap) {
+  _sp = ptr_sp;
+  _unextended_sp = unextended_sp;
+  _fp = ptr_fp;
+  _pc = pc;
+  _cb = cb;
+  _oop_map = oop_map;
+  _deopt_state = not_deoptimized;
+  _on_heap = on_heap;
+  DEBUG_ONLY(_frame_index = -1;)
+
+  // In thaw, non-heap frames use this constructor to pass oop_map.  I don't know why.
+  assert(_on_heap || _cb != nullptr, "these frames are always heap frames");
+  if (cb != NULL) {
+    setup(pc);
+  }
+#ifdef ASSERT
+  // The following assertion has been disabled because it would sometime trap for Continuation.run,
+  // which is not *in* a continuation and therefore does not clear the _cont_fastpath flag, but this
+  // is benign even in fast mode (see Freeze::setup_jump)
+  // We might freeze deoptimized frame in slow mode
+  // assert(_pc == pc && _deopt_state == not_deoptimized, "");
+#endif
+}
+
 inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp, address pc) {
   intptr_t a = intptr_t(ptr_sp);
   intptr_t b = intptr_t(ptr_fp);
@@ -91,7 +136,8 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp,
   _fp = ptr_fp;
   _pc = pc;
   assert(pc != NULL, "no pc?");
-  _cb = CodeCache::find_blob(pc);
+  _cb = CodeCache::find_blob_fast(pc);
+  assert(_cb != NULL, "pc: " INTPTR_FORMAT " sp: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " fp: " INTPTR_FORMAT, p2i(pc), p2i(ptr_sp), p2i(unextended_sp), p2i(ptr_fp));
   _oop_map = NULL;
   _on_heap = false;
   DEBUG_ONLY(_frame_index = -1;)
@@ -99,9 +145,7 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp,
   setup(pc);
 }
 
-inline frame::frame(intptr_t* ptr_sp) {
-  Unimplemented();
-}
+inline frame::frame(intptr_t* ptr_sp) : frame(ptr_sp, ptr_sp, *(intptr_t**)(ptr_sp - 2), *(address*)(ptr_sp - 1)) {}
 
 inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp) {
   intptr_t a = intptr_t(ptr_sp);
@@ -110,6 +154,8 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp) {
   _unextended_sp = ptr_sp;
   _fp = ptr_fp;
   _pc = (address)(ptr_sp[-1]);
+  _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
 
   // Here's a sticky one. This constructor can be called via AsyncGetCallTrace
   // when last_Java_sp is non-null but the pc fetched is junk.
@@ -129,18 +175,15 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp) {
   } else {
     _deopt_state = not_deoptimized;
   }
-
-  _on_heap = false;
-  DEBUG_ONLY(_frame_index = -1;)
 }
 
 // Accessors
 
 inline bool frame::equal(frame other) const {
-  bool ret =  sp() == other.sp()
-              && unextended_sp() == other.unextended_sp()
-              && fp() == other.fp()
-              && pc() == other.pc();
+  bool ret =  sp() == other.sp() &&
+              unextended_sp() == other.unextended_sp() &&
+              fp() == other.fp() &&
+              pc() == other.pc();
   assert(!ret || ret && cb() == other.cb() && _deopt_state == other._deopt_state, "inconsistent construction");
   return ret;
 }
@@ -154,29 +197,17 @@ inline intptr_t* frame::id(void) const { return unextended_sp(); }
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != NULL && id != NULL, "NULL frame id");
                                                     return this->id() > id ; }
 
-inline intptr_t* frame::link() const {
-  return (intptr_t*) *(intptr_t **)addr_at(link_offset);
-}
+inline intptr_t* frame::link() const              { return (intptr_t*) *(intptr_t **)addr_at(link_offset); }
 
 inline intptr_t* frame::link_or_null() const {
   intptr_t** ptr = (intptr_t **)addr_at(link_offset);
   return os::is_readable_pointer(ptr) ? *ptr : NULL;
 }
 
-inline intptr_t* frame::unextended_sp() const     { return _unextended_sp; }
-
-inline void frame::set_unextended_sp(intptr_t* value) {
-  Unimplemented();
-}
-
-inline int frame::offset_unextended_sp() const {
-  Unimplemented();
-  return 0;
-}
-
-inline void frame::set_offset_unextended_sp(int value) {
-  Unimplemented();
-}
+inline intptr_t* frame::unextended_sp() const          { assert_absolute(); return _unextended_sp; }
+inline void frame::set_unextended_sp(intptr_t* value)  { _unextended_sp = value; }
+inline int frame::offset_unextended_sp() const         { assert_offset(); return _offset_unextended_sp; }
+inline void frame::set_offset_unextended_sp(int value) { assert_on_heap(); _offset_unextended_sp = value; }
 
 inline intptr_t* frame::real_fp() const {
   if (_cb != NULL) {
@@ -197,19 +228,22 @@ inline int frame::frame_size() const {
     : cb()->frame_size();
 }
 
-// Return address:
-
-inline address* frame::sender_pc_addr() const {
-  return (address*) addr_at(return_addr_offset);
+inline int frame::compiled_frame_stack_argsize() const {
+  assert(cb()->is_compiled(), "");
+  return (cb()->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord;
 }
 
-inline address  frame::sender_pc() const {
-  return *sender_pc_addr();
+inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
+  assert(mask != NULL, "");
+  Method* m = interpreter_frame_method();
+  int   bci = interpreter_frame_bci();
+  m->mask_for(bci, mask); // OopMapCache::compute_one_oop_map(m, bci, mask);
 }
 
-inline intptr_t* frame::sender_sp() const {
-  return addr_at(sender_sp_offset);
-}
+// Return address
+inline address* frame::sender_pc_addr() const     { return (address*) addr_at(return_addr_offset); }
+inline address  frame::sender_pc() const          { return *sender_pc_addr(); }
+inline intptr_t* frame::sender_sp() const         { return addr_at(sender_sp_offset); }
 
 inline intptr_t** frame::interpreter_frame_locals_addr() const {
   return (intptr_t**)addr_at(interpreter_frame_locals_offset);
@@ -274,8 +308,9 @@ inline int frame::interpreter_frame_monitor_size() {
 
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   intptr_t* monitor_end = (intptr_t*) interpreter_frame_monitor_end();
-  return monitor_end-1;
+  return monitor_end - 1;
 }
+
 
 // Entry frames
 
@@ -283,43 +318,40 @@ inline JavaCallWrapper** frame::entry_frame_call_wrapper_addr() const {
   return (JavaCallWrapper**)addr_at(entry_frame_call_wrapper_offset);
 }
 
+
 // Compiled frames
-PRAGMA_DIAG_PUSH
-PRAGMA_NONNULL_IGNORED
 inline oop frame::saved_oop_result(RegisterMap* map) const {
-  oop* result_adr = (oop *)map->location(V0->as_VMReg(), nullptr);
+  oop* result_adr = (oop *)map->location(A0->as_VMReg(), nullptr);
   guarantee(result_adr != NULL, "bad register save location");
   return (*result_adr);
 }
 
 inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
-  oop* result_adr = (oop *)map->location(V0->as_VMReg(), nullptr);
+  oop* result_adr = (oop *)map->location(A0->as_VMReg(), nullptr);
   guarantee(result_adr != NULL, "bad register save location");
   *result_adr = obj;
 }
-PRAGMA_DIAG_POP
+
+inline bool frame::is_interpreted_frame() const {
+  return Interpreter::contains(pc());
+}
+
+inline int frame::sender_sp_ret_address_offset() {
+  return frame::sender_sp_offset - frame::return_addr_offset;
+}
 
 inline const ImmutableOopMap* frame::get_oop_map() const {
   if (_cb == NULL) return NULL;
   if (_cb->oop_maps() != NULL) {
+    NativePostCallNop* nop = nativePostCallNop_at(_pc);
+    if (nop != NULL && nop->displacement() != 0) {
+      int slot = ((nop->displacement() >> 24) & 0xff);
+      return _cb->oop_map_for_slot(slot, _pc);
+    }
     const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
     return oop_map;
   }
   return NULL;
-}
-
-inline int frame::compiled_frame_stack_argsize() const {
-  Unimplemented();
-  return 0;
-}
-
-inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
-  Unimplemented();
-}
-
-inline int frame::sender_sp_ret_address_offset() {
-  Unimplemented();
-  return 0;
 }
 
 //------------------------------------------------------------------------------
@@ -327,7 +359,7 @@ inline int frame::sender_sp_ret_address_offset() {
 frame frame::sender(RegisterMap* map) const {
   frame result = sender_raw(map);
 
-  if (map->process_frames()) {
+  if (map->process_frames() && !map->in_cont()) {
     StackWatermarkSet::on_iteration(map->thread(), result);
   }
 
@@ -342,6 +374,10 @@ frame frame::sender_raw(RegisterMap* map) const {
   assert(map != NULL, "map must be set");
   map->set_include_argument_oops(false);
 
+  if (map->in_cont()) { // already in an h-stack
+    return map->stack_chunk()->sender(*this, map);
+  }
+
   if (is_entry_frame()) {
     return sender_for_entry_frame(map);
   }
@@ -351,16 +387,18 @@ frame frame::sender_raw(RegisterMap* map) const {
   if (is_interpreted_frame()) {
     return sender_for_interpreter_frame(map);
   }
-  assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
 
-  // This test looks odd: why is it not is_compiled_frame() ?  That's
-  // because stubs also have OOP maps.
+  assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
   if (_cb != NULL) {
     return sender_for_compiled_frame(map);
   }
 
   // Must be native-compiled frame, i.e. the marshaling code for native
   // methods that exists in the core system.
+
+  // Native code may or may not have signed the return address, we have no way to be sure
+  // or what signing methods they used. Instead, just ensure the stripped value is used.
+
   return frame(sender_sp(), link(), sender_pc());
 }
 
@@ -373,21 +411,26 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
 
   assert(_cb->frame_size() > 0, "must have non-zero frame size");
   intptr_t* l_sender_sp = unextended_sp() + _cb->frame_size();
-  intptr_t* unextended_sp = l_sender_sp;
 
   // the return_address is always the word on the stack
-  address sender_pc = (address) *(l_sender_sp - 1);
+  address sender_pc = (address) *(l_sender_sp + frame::return_addr_offset);
 
-  intptr_t** saved_fp_addr = (intptr_t**) (l_sender_sp - 2);
+  intptr_t** saved_fp_addr = (intptr_t**) (l_sender_sp + frame::link_offset);
 
   assert(map != NULL, "map must be set");
   if (map->update_map()) {
     // Tell GC to use argument oopmaps for some runtime stubs that need it.
     // For C1, the runtime stub might not have oop maps, so set this flag
     // outside of update_register_map.
-    map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
-    if (_cb->oop_maps() != NULL) {
-      OopMapSet::update_register_map(this, map);
+    if (!_cb->is_compiled()) { // compiled frames do not use callee-saved registers
+      map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
+      if (oop_map() != NULL) {
+        _oop_map->update_register_map(this, map);
+      }
+    } else {
+      assert(!_cb->caller_must_gc_arguments(map->thread()), "");
+      assert(!map->include_argument_oops(), "");
+      assert(oop_map() == NULL || !oop_map()->has_any(OopMapValue::callee_saved_value), "callee-saved value in compiled frame");
     }
 
     // Since the prolog does the save and restore of FP there is no
@@ -397,6 +440,15 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
     update_map_with_saved_link(map, saved_fp_addr);
   }
 
+  if (Continuation::is_return_barrier_entry(sender_pc)) {
+    if (map->walk_cont()) { // about to walk into an h-stack
+      return Continuation::top_frame(*this, map);
+    } else {
+      return Continuation::continuation_bottom_sender(map->thread(), *this, l_sender_sp);
+    }
+  }
+
+  intptr_t* unextended_sp = l_sender_sp;
   return frame(l_sender_sp, unextended_sp, *saved_fp_addr, sender_pc);
 }
 
@@ -404,19 +456,16 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
 // frame::update_map_with_saved_link
 template <typename RegisterMapT>
 void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
-  // The interpreter and compiler(s) always save fp in a known
-  // location on entry. We must record where that location is
-  // so that if fp was live on callout from c2 we can find
-  // the saved copy no matter what it called.
-
-  // Since the interpreter always saves fp if we record where it is then
-  // we don't have to always save fp on entry and exit to c2 compiled
-  // code, on entry will be enough.
   assert(map != NULL, "map must be set");
+  // The interpreter and compiler(s) always save FP in a known
+  // location on entry. C2-compiled code uses FP as an allocatable
+  // callee-saved register. We must record where that location is so
+  // that if FP was live on callout from C2 we can find the saved copy.
   map->set_location(FP->as_VMReg(), (address) link_addr);
   // this is weird "H" ought to be at a higher address however the
   // oopMaps seems to have the "H" regs at the same address and the
   // vanilla register.
   map->set_location(FP->as_VMReg()->next(), (address) link_addr);
 }
+
 #endif // CPU_LOONGARCH_FRAME_LOONGARCH_INLINE_HPP

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.hpp
@@ -88,6 +88,12 @@ public:
   virtual void nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation, Label* guard);
   virtual void c2i_entry_barrier(MacroAssembler* masm);
 
+  virtual bool supports_instruction_patching() {
+    NMethodPatchingType patching_type = nmethod_patching_type();
+    return patching_type == NMethodPatchingType::conc_instruction_and_data_patch ||
+            patching_type == NMethodPatchingType::stw_instruction_and_data_patch;
+  }
+
   static address patching_epoch_addr();
   static void clear_patching_epoch();
   static void increment_patching_epoch();

--- a/src/hotspot/cpu/loongarch/globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globals_loongarch.hpp
@@ -59,7 +59,7 @@ define_pd_global(intx, StackRedPages, DEFAULT_STACK_RED_PAGES);
 define_pd_global(intx, StackShadowPages, DEFAULT_STACK_SHADOW_PAGES);
 define_pd_global(intx, StackReservedPages, DEFAULT_STACK_RESERVED_PAGES);
 
-define_pd_global(bool, VMContinuations, false);
+define_pd_global(bool, VMContinuations, true);
 
 define_pd_global(bool, RewriteBytecodes,     true);
 define_pd_global(bool, RewriteFrequentPairs, true);

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -456,7 +456,6 @@ void InterpreterMacroAssembler::pop(TosState state) {
   }
 }
 
-//FSR=V0,SSR=V1
 void InterpreterMacroAssembler::push(TosState state) {
   switch (state) {
     case atos:

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -5069,7 +5069,7 @@ instruct loadConP_general(mRegP dst, immP src) %{
     if ($src->constant_reloc() == relocInfo::metadata_type){
       __ mov_metadata(dst, (Metadata*)value);
     } else if($src->constant_reloc() == relocInfo::oop_type){
-      __ movoop(dst, (jobject)value, /*immediate*/true);
+      __ movoop(dst, (jobject)value);
     } else if ($src->constant_reloc() == relocInfo::none) {
       __ li(dst, (long)value);
     }

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -5295,16 +5295,19 @@ instruct jmpCon_flags_long(cmpOpEqNe cop, FlagsReg cr, label labl) %{
 
   ins_encode %{
     Label*    L =  $labl$$label;
+    Label not_taken;
     switch($cop$$cmpcode) {
       case 0x01: //equal
-        __ bne_long($cr$$Register, R0, *L);
+        __ bne($cr$$Register, R0, not_taken);
         break;
       case 0x02: //not equal
-        __ beq_long($cr$$Register, R0, *L);
+        __ beq($cr$$Register, R0, not_taken);
         break;
       default:
         Unimplemented();
     }
+    __ jmp_far(*L);
+    __ bind(not_taken);
   %}
 
   ins_pipe( pipe_jump );
@@ -5569,36 +5572,39 @@ instruct branchConF_reg_reg_long(cmpOp cmp, regF src1, regF src2, label labl) %{
     FloatRegister reg_op1 = $src1$$FloatRegister;
     FloatRegister reg_op2 = $src2$$FloatRegister;
     Label*     L =  $labl$$label;
+    Label not_taken;
     int     flag = $cmp$$cmpcode;
 
     switch(flag) {
       case 0x01: //equal
         __ fcmp_ceq_s(FCC0, reg_op1, reg_op2);
-        __ bc1t_long(*L);
+        __ bceqz(FCC0, not_taken);
         break;
       case 0x02: //not_equal
         __ fcmp_ceq_s(FCC0, reg_op1, reg_op2);
-        __ bc1f_long(*L);
+        __ bcnez(FCC0, not_taken);
         break;
       case 0x03: //greater
         __ fcmp_cule_s(FCC0, reg_op1, reg_op2);
-        __ bc1f_long(*L);
+        __ bcnez(FCC0, not_taken);
         break;
       case 0x04: //greater_equal
         __ fcmp_cult_s(FCC0, reg_op1, reg_op2);
-        __ bc1f_long(*L);
+        __ bcnez(FCC0, not_taken);
         break;
       case 0x05: //less
         __ fcmp_cult_s(FCC0, reg_op1, reg_op2);
-        __ bc1t_long(*L);
+        __ bceqz(FCC0, not_taken);
         break;
       case 0x06: //less_equal
         __ fcmp_cule_s(FCC0, reg_op1, reg_op2);
-        __ bc1t_long(*L);
+        __ bceqz(FCC0, not_taken);
         break;
       default:
         Unimplemented();
     }
+    __ jmp_far(*L);
+    __ bind(not_taken);
   %}
 
   ins_pc_relative(1);
@@ -5614,37 +5620,40 @@ instruct branchConD_reg_reg_long(cmpOp cmp, regD src1, regD src2, label labl) %{
     FloatRegister reg_op1 = $src1$$FloatRegister;
     FloatRegister reg_op2 = $src2$$FloatRegister;
     Label*     L =  $labl$$label;
+    Label not_taken;
     int     flag = $cmp$$cmpcode;
 
     switch(flag) {
       case 0x01: //equal
         __ fcmp_ceq_d(FCC0, reg_op1, reg_op2);
-        __ bc1t_long(*L);
+        __ bceqz(FCC0, not_taken);
         break;
       case 0x02: //not_equal
         // c_ueq_d cannot distinguish NaN from equal. Double.isNaN(Double) is implemented by 'f != f', so the use of c_ueq_d causes bugs.
         __ fcmp_ceq_d(FCC0, reg_op1, reg_op2);
-        __ bc1f_long(*L);
+        __ bcnez(FCC0, not_taken);
         break;
       case 0x03: //greater
         __ fcmp_cule_d(FCC0, reg_op1, reg_op2);
-        __ bc1f_long(*L);
+        __ bcnez(FCC0, not_taken);
         break;
       case 0x04: //greater_equal
         __ fcmp_cult_d(FCC0, reg_op1, reg_op2);
-        __ bc1f_long(*L);
+        __ bcnez(FCC0, not_taken);
         break;
       case 0x05: //less
         __ fcmp_cult_d(FCC0, reg_op1, reg_op2);
-        __ bc1t_long(*L);
+        __ bceqz(FCC0, not_taken);
         break;
       case 0x06: //less_equal
         __ fcmp_cule_d(FCC0, reg_op1, reg_op2);
-        __ bc1t_long(*L);
+        __ bceqz(FCC0, not_taken);
         break;
       default:
         Unimplemented();
     }
+    __ jmp_far(*L);
+    __ bind(not_taken);
   %}
 
   ins_pc_relative(1);

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -2309,12 +2309,15 @@ encode %{
     cbuf.set_insts_mark();
     __ relocate(relocInfo::runtime_call_type);
     __ patchable_call((address)$meth$$method);
+    _masm.clear_inst_mark();
+    __ post_call_nop();
   %}
 
   enc_class Java_Static_Call (method meth) %{    // JAVA STATIC CALL
     // CALL to fixup routine.  Fixup routine uses ScopeDesc info to determine
     // who we intended to call.
     C2_MacroAssembler _masm(&cbuf);
+    cbuf.set_insts_mark();
     address addr = (address)$meth$$method;
     address call;
     __ block_comment("Java_Static_Call");
@@ -2348,6 +2351,8 @@ encode %{
         }
       }
     }
+    _masm.clear_inst_mark();
+    __ post_call_nop();
   %}
 
 
@@ -2362,6 +2367,8 @@ encode %{
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
+    _masm.clear_inst_mark();
+    __ post_call_nop();
   %}
 
 

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -406,51 +406,51 @@ register %{
 //S6 is used for get_thread(S6)
 //S5 is used for heapbase of compressed oop
 alloc_class chunk0(
-                     S7, S7_H,
-                     S0, S0_H,
-                     S1, S1_H,
-                     S2, S2_H,
-                     S4, S4_H,
-                     S5, S5_H,
-                     S6, S6_H,
-                     S3, S3_H,
+                     // volatiles
+                     T0, T0_H,
+                     T1, T1_H,
                      T2, T2_H,
                      T3, T3_H,
-                     T8, T8_H,
                      T4, T4_H,
-                     T1, T1_H, // inline_cache_reg
+                     T5, T5_H,
                      T6, T6_H,
+                     T8, T8_H,
+
+                     // args
                      A7, A7_H,
                      A6, A6_H,
                      A5, A5_H,
                      A4, A4_H,
-                     T5, T5_H,
                      A3, A3_H,
                      A2, A2_H,
                      A1, A1_H,
                      A0, A0_H,
-                     T0, T0_H,
+
+                     // non-volatiles
+                     S0, S0_H,
+                     S1, S1_H,
+                     S2, S2_H,
+                     S3, S3_H,
+                     S4, S4_H,
+                     S5, S5_H,
+                     S6, S6_H,
+                     S7, S7_H,
                      S8, S8_H
+
+                     // non-allocatable registers
                      RA, RA_H,
                      SP, SP_H, // stack_pointer
                      FP, FP_H, // frame_pointer
-
-                     // non-allocatable registers
-                     T7, T7_H,
+                     T7, T7_H, // rscratch
                      TP, TP_H,
                      RX, RX_H,
                      R0, R0_H,
                  );
 
 // F23 is scratch reg
-alloc_class chunk1(  F0, F0_H, F0_J, F0_K, F0_L, F0_M, F0_N, F0_O,
-                     F1, F1_H, F1_J, F1_K, F1_L, F1_M, F1_N, F1_O,
-                     F2, F2_H, F2_J, F2_K, F2_L, F2_M, F2_N, F2_O,
-                     F3, F3_H, F3_J, F3_K, F3_L, F3_M, F3_N, F3_O,
-                     F4, F4_H, F4_J, F4_K, F4_L, F4_M, F4_N, F4_O,
-                     F5, F5_H, F5_J, F5_K, F5_L, F5_M, F5_N, F5_O,
-                     F6, F6_H, F6_J, F6_K, F6_L, F6_M, F6_N, F6_O,
-                     F7, F7_H, F7_J, F7_K, F7_L, F7_M, F7_N, F7_O,
+alloc_class chunk1(
+
+                     // no save
                      F8, F8_H, F8_J, F8_K, F8_L, F8_M, F8_N, F8_O,
                      F9, F9_H, F9_J, F9_K, F9_L, F9_M, F9_N, F9_O,
                      F10, F10_H, F10_J, F10_K, F10_L, F10_M, F10_N, F10_O,
@@ -466,6 +466,18 @@ alloc_class chunk1(  F0, F0_H, F0_J, F0_K, F0_L, F0_M, F0_N, F0_O,
                      F20, F20_H, F20_J, F20_K, F20_L, F20_M, F20_N, F20_O,
                      F21, F21_H, F21_J, F21_K, F21_L, F21_M, F21_N, F21_O,
                      F22, F22_H, F22_J, F22_K, F22_L, F22_M, F22_N, F22_O,
+
+                     // arg registers
+                     F0, F0_H, F0_J, F0_K, F0_L, F0_M, F0_N, F0_O,
+                     F1, F1_H, F1_J, F1_K, F1_L, F1_M, F1_N, F1_O,
+                     F2, F2_H, F2_J, F2_K, F2_L, F2_M, F2_N, F2_O,
+                     F3, F3_H, F3_J, F3_K, F3_L, F3_M, F3_N, F3_O,
+                     F4, F4_H, F4_J, F4_K, F4_L, F4_M, F4_N, F4_O,
+                     F5, F5_H, F5_J, F5_K, F5_L, F5_M, F5_N, F5_O,
+                     F6, F6_H, F6_J, F6_K, F6_L, F6_M, F6_N, F6_O,
+                     F7, F7_H, F7_J, F7_K, F7_L, F7_M, F7_N, F7_O,
+
+                     // non-volatiles
                      F24, F24_H, F24_J, F24_K, F24_L, F24_M, F24_N, F24_O,
                      F25, F25_H, F25_J, F25_K, F25_L, F25_M, F25_N, F25_O,
                      F26, F26_H, F26_J, F26_K, F26_L, F26_M, F26_N, F26_O,

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -11936,6 +11936,106 @@ instruct isInfiniteD_cmovI(mRegI dst, mRegI src1, mRegI src2, regD op, immI_0 ze
   ins_pipe( pipe_slow );
 %}
 
+// Float.isFinite
+instruct isFiniteF_reg_reg(mRegI dst, regF src)
+%{
+  match(Set dst (IsFiniteF src));
+  format %{ "isFinite    $dst, $src @isFiniteF_reg_reg" %}
+  ins_encode %{
+    FloatRegister src = $src$$FloatRegister;
+    Register      dst = $dst$$Register;
+
+    __ fclass_s(fscratch, src);
+    __ movfr2gr_s(dst, fscratch);
+    __ andi(dst, dst, 0b1110111000);
+    __ slt(dst, R0, dst);
+  %}
+  size(16);
+  ins_pipe( pipe_slow );
+%}
+
+// Double.isFinite
+instruct isFiniteD_reg_reg(mRegI dst, regD src)
+%{
+  match(Set dst (IsFiniteD src));
+  format %{ "isFinite    $dst, $src @isFiniteD_reg_reg" %}
+  ins_encode %{
+    FloatRegister src = $src$$FloatRegister;
+    Register      dst = $dst$$Register;
+
+    __ fclass_d(fscratch, src);
+    __ movfr2gr_d(dst, fscratch);
+    __ andi(dst, dst, 0b1110111000);
+    __ slt(dst, R0, dst);
+  %}
+  size(16);
+  ins_pipe( pipe_slow );
+%}
+
+instruct isFiniteF_cmovI(mRegI dst, mRegI src1, mRegI src2, regF op, immI_0 zero, cmpOp cop)
+%{
+  match(Set dst (CMoveI (Binary cop (CmpI (IsFiniteF op) zero)) (Binary src1 src2)));
+  format %{ "isFinite_cmovI    $dst, $src1, $src2, $op, $cop @isFiniteF_cmovI" %}
+  ins_encode %{
+    Register      src1 = $src1$$Register;
+    Register      src2 = $src2$$Register;
+    Register      dst  = $dst$$Register;
+    FloatRegister op   = $op$$FloatRegister;
+    int         flag = $cop$$cmpcode;
+
+    __ fclass_s(fscratch, op);
+    __ movfr2gr_s(AT, fscratch);
+    __ andi(dst, dst, 0b1110111000);
+    switch(flag) {
+      case 0x01: // EQ
+        __ maskeqz(dst, src1, AT);
+        __ masknez(AT, src2, AT);
+        break;
+      case 0x02: // NE
+        __ masknez(dst, src1, AT);
+        __ maskeqz(AT, src2, AT);
+        break;
+      default:
+        ShouldNotReachHere();
+    }
+    __ orr(dst, dst, AT);
+  %}
+  size(24);
+  ins_pipe( pipe_slow );
+%}
+
+instruct isFiniteD_cmovI(mRegI dst, mRegI src1, mRegI src2, regD op, immI_0 zero, cmpOp cop)
+%{
+  match(Set dst (CMoveI (Binary cop (CmpI (IsFiniteD op) zero)) (Binary src1 src2)));
+  format %{ "isFinite_cmovI    $dst, $src1, $src2, $op, $cop @isFiniteD_cmovI" %}
+  ins_encode %{
+    Register      src1 = $src1$$Register;
+    Register      src2 = $src2$$Register;
+    Register      dst  = $dst$$Register;
+    FloatRegister op   = $op$$FloatRegister;
+    int           flag = $cop$$cmpcode;
+
+    __ fclass_d(fscratch, op);
+    __ movfr2gr_d(AT, fscratch);
+    __ andi(dst, dst, 0b1110111000);
+    switch(flag) {
+      case 0x01: // EQ
+        __ maskeqz(dst, src1, AT);
+        __ masknez(AT, src2, AT);
+        break;
+      case 0x02: // NE
+        __ masknez(dst, src1, AT);
+        __ maskeqz(AT, src2, AT);
+        break;
+      default:
+        ShouldNotReachHere();
+    }
+    __ orr(dst, dst, AT);
+  %}
+  size(24);
+  ins_pipe( pipe_slow );
+%}
+
 instruct combine_i2l(mRegL dst, mRegI src1, immL_MaxUI mask, mRegI src2, immI_32 shift32)
 %{
   match(Set dst (OrL (AndL (ConvI2L src1) mask) (LShiftL (ConvI2L src2) shift32)));

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -11836,6 +11836,106 @@ instruct minD_reg_reg(regD dst, regD src1, regD src2) %{
   ins_pipe( fpu_regF_regF );
 %}
 
+// Float.isInfinite
+instruct isInfiniteF_reg_reg(mRegI dst, regF src)
+%{
+  match(Set dst (IsInfiniteF src));
+  format %{ "isInfinite    $dst, $src @isInfiniteF_reg_reg" %}
+  ins_encode %{
+    FloatRegister src = $src$$FloatRegister;
+    Register      dst = $dst$$Register;
+
+    __ fclass_s(fscratch, src);
+    __ movfr2gr_s(dst, fscratch);
+    __ andi(dst, dst, 0b0001000100);
+    __ slt(dst, R0, dst);
+  %}
+  size(16);
+  ins_pipe( pipe_slow );
+%}
+
+// Double.isInfinite
+instruct isInfiniteD_reg_reg(mRegI dst, regD src)
+%{
+  match(Set dst (IsInfiniteD src));
+  format %{ "isInfinite    $dst, $src @isInfiniteD_reg_reg" %}
+  ins_encode %{
+    FloatRegister src = $src$$FloatRegister;
+    Register      dst = $dst$$Register;
+
+    __ fclass_d(fscratch, src);
+    __ movfr2gr_d(dst, fscratch);
+    __ andi(dst, dst, 0b0001000100);
+    __ slt(dst, R0, dst);
+  %}
+  size(16);
+  ins_pipe( pipe_slow );
+%}
+
+instruct isInfiniteF_cmovI(mRegI dst, mRegI src1, mRegI src2, regF op, immI_0 zero, cmpOp cop)
+%{
+  match(Set dst (CMoveI (Binary cop (CmpI (IsInfiniteF op) zero)) (Binary src1 src2)));
+  format %{ "isInfinite_cmovI    $dst, $src1, $src2, $op, $cop @isInfiniteF_cmovI" %}
+  ins_encode %{
+    Register      src1 = $src1$$Register;
+    Register      src2 = $src2$$Register;
+    Register      dst  = $dst$$Register;
+    FloatRegister op   = $op$$FloatRegister;
+    int         flag = $cop$$cmpcode;
+
+    __ fclass_s(fscratch, op);
+    __ movfr2gr_s(AT, fscratch);
+    __ andi(AT, AT, 0b0001000100);
+    switch(flag) {
+      case 0x01: // EQ
+        __ maskeqz(dst, src1, AT);
+        __ masknez(AT, src2, AT);
+        break;
+      case 0x02: // NE
+        __ masknez(dst, src1, AT);
+        __ maskeqz(AT, src2, AT);
+        break;
+      default:
+        ShouldNotReachHere();
+    }
+    __ orr(dst, dst, AT);
+  %}
+  size(24);
+  ins_pipe( pipe_slow );
+%}
+
+instruct isInfiniteD_cmovI(mRegI dst, mRegI src1, mRegI src2, regD op, immI_0 zero, cmpOp cop)
+%{
+  match(Set dst (CMoveI (Binary cop (CmpI (IsInfiniteD op) zero)) (Binary src1 src2)));
+  format %{ "isInfinite_cmovI    $dst, $src1, $src2, $op, $cop @isInfiniteD_cmovI" %}
+  ins_encode %{
+    Register      src1 = $src1$$Register;
+    Register      src2 = $src2$$Register;
+    Register      dst  = $dst$$Register;
+    FloatRegister op   = $op$$FloatRegister;
+    int           flag = $cop$$cmpcode;
+
+    __ fclass_d(fscratch, op);
+    __ movfr2gr_d(AT, fscratch);
+    __ andi(AT, AT, 0b0001000100);
+    switch(flag) {
+      case 0x01: // EQ
+        __ maskeqz(dst, src1, AT);
+        __ masknez(AT, src2, AT);
+        break;
+      case 0x02: // NE
+        __ masknez(dst, src1, AT);
+        __ maskeqz(AT, src2, AT);
+        break;
+      default:
+        ShouldNotReachHere();
+    }
+    __ orr(dst, dst, AT);
+  %}
+  size(24);
+  ins_pipe( pipe_slow );
+%}
+
 instruct combine_i2l(mRegL dst, mRegI src1, immL_MaxUI mask, mRegI src2, immI_32 shift32)
 %{
   match(Set dst (OrL (AndL (ConvI2L src1) mask) (LShiftL (ConvI2L src2) shift32)));

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -592,6 +592,10 @@ reg_class no_CR_reg %{
   return _NO_CR_REG_mask;
 %}
 
+reg_class p_has_s6_reg %{
+  return _PTR_HAS_S6_REG_mask;
+%}
+
 reg_class all_reg(
                     S8, S8_H,
                     S7, S7_H,
@@ -795,6 +799,7 @@ extern RegMask _ANY_REG32_mask;
 extern RegMask _ANY_REG_mask;
 extern RegMask _PTR_REG_mask;
 extern RegMask _NO_CR_REG_mask;
+extern RegMask _PTR_HAS_S6_REG_mask;
 
 class CallStubImpl {
 
@@ -873,11 +878,13 @@ RegMask _ANY_REG32_mask;
 RegMask _ANY_REG_mask;
 RegMask _PTR_REG_mask;
 RegMask _NO_CR_REG_mask;
+RegMask _PTR_HAS_S6_REG_mask;
 
 void reg_mask_init() {
   _ANY_REG32_mask = _ALL_REG32_mask;
   _ANY_REG_mask = _ALL_REG_mask;
   _PTR_REG_mask = _ALL_REG_mask;
+  _PTR_HAS_S6_REG_mask = _ALL_REG_mask;
 
   if (UseCompressedOops && (CompressedOops::ptrs_base() != NULL)) {
     _ANY_REG32_mask.Remove(OptoReg::as_OptoReg(r28->as_VMReg()));
@@ -900,6 +907,8 @@ void reg_mask_init() {
 
   _NO_CR_REG_mask = _PTR_REG_mask;
   _NO_CR_REG_mask.SUBTRACT(_T0_LONG_REG_mask);
+
+  _PTR_HAS_S6_REG_mask.OR(_S6_LONG_REG_mask);
 }
 
 void PhaseOutput::pd_perform_mach_node_analysis() {
@@ -3455,6 +3464,7 @@ operand mRegP() %{
   constraint(ALLOC_IN_RC(p_reg));
   match(RegP);
   match(a0_RegP);
+  match(javaThread_RegP);
 
   format %{  %}
   interface(REG_INTER);
@@ -3462,6 +3472,15 @@ operand mRegP() %{
 
 operand no_CR_mRegP() %{
   constraint(ALLOC_IN_RC(no_CR_reg));
+  match(RegP);
+  match(mRegP);
+
+  format %{  %}
+  interface(REG_INTER);
+%}
+
+operand p_has_s6_mRegP() %{
+  constraint(ALLOC_IN_RC(p_has_s6_reg));
   match(RegP);
   match(mRegP);
 
@@ -3515,6 +3534,16 @@ operand s6_RegP()
   match(RegP);
   match(mRegP);
 
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Java Thread Register
+operand javaThread_RegP(mRegP reg)
+%{
+  constraint(ALLOC_IN_RC(s6_long_reg)); // S6 denotes TREG (java_thread)
+  match(reg);
+  op_cost(0);
   format %{ %}
   interface(REG_INTER);
 %}
@@ -3906,7 +3935,7 @@ operand indirect(mRegP reg) %{
 %}
 
 // Indirect Memory Plus Short Offset Operand
-operand indOffset12(mRegP reg, immL12 off)
+operand indOffset12(p_has_s6_mRegP reg, immL12 off)
 %{
   constraint(ALLOC_IN_RC(p_reg));
   match(AddP reg off);
@@ -10633,17 +10662,23 @@ instruct decodeKlass_not_null(mRegP dst, mRegN src) %{
   ins_pipe( ialu_regL_regL );
 %}
 
-//FIXME
-instruct tlsLoadP(mRegP dst) %{
+// ============================================================================
+// This name is KNOWN by the ADLC and cannot be changed.
+// The ADLC forces a 'TypeRawPtr::BOTTOM' output type
+// for this guy.
+instruct tlsLoadP(javaThread_RegP dst)
+%{
   match(Set dst (ThreadLocal));
 
   ins_cost(0);
-  format %{ " get_thread in $dst #@tlsLoadP" %}
-  ins_encode %{
-    __ move($dst$$Register, TREG);
-  %}
 
-  ins_pipe( ialu_loadI );
+  format %{ " -- \t// $dst=Thread::current(), empty encoding, #@tlsLoadP" %}
+
+  size(0);
+
+  ins_encode( /*empty*/ );
+
+  ins_pipe( empty );
 %}
 
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -704,9 +704,9 @@ void MacroAssembler::call_VM(Register oop_result,
                              Register arg_1,
                              Register arg_2,
                              bool check_exceptions) {
-  if (arg_1!=A1) move(A1, arg_1);
-  if (arg_2!=A2) move(A2, arg_2);
+  if (arg_1 != A1) move(A1, arg_1);
   assert(arg_2 != A1, "smashed argument");
+  if (arg_2 != A2) move(A2, arg_2);
   call_VM_helper(oop_result, entry_point, 2, check_exceptions);
 }
 
@@ -716,9 +716,11 @@ void MacroAssembler::call_VM(Register oop_result,
                              Register arg_2,
                              Register arg_3,
                              bool check_exceptions) {
-  if (arg_1!=A1) move(A1, arg_1);
-  if (arg_2!=A2) move(A2, arg_2); assert(arg_2 != A1, "smashed argument");
-  if (arg_3!=A3) move(A3, arg_3); assert(arg_3 != A1 && arg_3 != A2, "smashed argument");
+  if (arg_1 != A1) move(A1, arg_1);
+  assert(arg_2 != A1, "smashed argument");
+  if (arg_2 != A2) move(A2, arg_2);
+  assert(arg_3 != A1 && arg_3 != A2, "smashed argument");
+  if (arg_3 != A3) move(A3, arg_3);
   call_VM_helper(oop_result, entry_point, 3, check_exceptions);
 }
 
@@ -746,7 +748,8 @@ void MacroAssembler::call_VM(Register oop_result,
                              Register arg_2,
                              bool check_exceptions) {
   if (arg_1 != A1) move(A1, arg_1);
-  if (arg_2 != A2) move(A2, arg_2); assert(arg_2 != A1, "smashed argument");
+  assert(arg_2 != A1, "smashed argument");
+  if (arg_2 != A2) move(A2, arg_2);
   call_VM(oop_result, last_java_sp, entry_point, 2, check_exceptions);
 }
 
@@ -758,8 +761,10 @@ void MacroAssembler::call_VM(Register oop_result,
                              Register arg_3,
                              bool check_exceptions) {
   if (arg_1 != A1) move(A1, arg_1);
-  if (arg_2 != A2) move(A2, arg_2); assert(arg_2 != A1, "smashed argument");
-  if (arg_3 != A3) move(A3, arg_3); assert(arg_3 != A1 && arg_3 != A2, "smashed argument");
+  assert(arg_2 != A1, "smashed argument");
+  if (arg_2 != A2) move(A2, arg_2);
+  assert(arg_3 != A1 && arg_3 != A2, "smashed argument");
+  if (arg_3 != A3) move(A3, arg_3);
   call_VM(oop_result, last_java_sp, entry_point, 3, check_exceptions);
 }
 
@@ -853,14 +858,17 @@ void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0) {
 
 void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0, Register arg_1) {
   if (arg_0 != A0) move(A0, arg_0);
-  if (arg_1 != A1) move(A1, arg_1); assert(arg_1 != A0, "smashed argument");
+  assert(arg_1 != A0, "smashed argument");
+  if (arg_1 != A1) move(A1, arg_1);
   call_VM_leaf(entry_point, 2);
 }
 
 void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0, Register arg_1, Register arg_2) {
   if (arg_0 != A0) move(A0, arg_0);
-  if (arg_1 != A1) move(A1, arg_1); assert(arg_1 != A0, "smashed argument");
-  if (arg_2 != A2) move(A2, arg_2); assert(arg_2 != A0 && arg_2 != A1, "smashed argument");
+  assert(arg_1 != A0, "smashed argument");
+  if (arg_1 != A1) move(A1, arg_1);
+  assert(arg_2 != A0 && arg_2 != A1, "smashed argument");
+  if (arg_2 != A2) move(A2, arg_2);
   call_VM_leaf(entry_point, 3);
 }
 
@@ -878,7 +886,8 @@ void MacroAssembler::super_call_VM_leaf(address entry_point,
                                                    Register arg_1,
                                                    Register arg_2) {
   if (arg_1 != A0) move(A0, arg_1);
-  if (arg_2 != A1) move(A1, arg_2); assert(arg_2 != A0, "smashed argument");
+  assert(arg_2 != A0, "smashed argument");
+  if (arg_2 != A1) move(A1, arg_2);
   MacroAssembler::call_VM_leaf_base(entry_point, 2);
 }
 
@@ -887,8 +896,10 @@ void MacroAssembler::super_call_VM_leaf(address entry_point,
                                                    Register arg_2,
                                                    Register arg_3) {
   if (arg_1 != A0) move(A0, arg_1);
-  if (arg_2 != A1) move(A1, arg_2); assert(arg_2 != A0, "smashed argument");
-  if (arg_3 != A2) move(A2, arg_3); assert(arg_3 != A0 && arg_3 != A1, "smashed argument");
+  assert(arg_2 != A0, "smashed argument");
+  if (arg_2 != A1) move(A1, arg_2);
+  assert(arg_3 != A0 && arg_3 != A1, "smashed argument");
+  if (arg_3 != A2) move(A2, arg_3);
   MacroAssembler::call_VM_leaf_base(entry_point, 3);
 }
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -488,11 +488,8 @@ void MacroAssembler::jmp_far(Label& L) {
   }
 }
 
-// Move an oop into a register.  immediate is true if we want
-// immediate instructions and nmethod entry barriers are not enabled.
-// i.e. we are not going to patch this instruction while the code is being
-// executed by another thread.
-void MacroAssembler::movoop(Register dst, jobject obj, bool immediate) {
+// Move an oop into a register.
+void MacroAssembler::movoop(Register dst, jobject obj) {
   int oop_index;
   if (obj == NULL) {
     oop_index = oop_recorder()->allocate_oop_index(obj);
@@ -507,17 +504,13 @@ void MacroAssembler::movoop(Register dst, jobject obj, bool immediate) {
   }
   RelocationHolder rspec = oop_Relocation::spec(oop_index);
 
-  // nmethod entry barrier necessitate using the constant pool. They have to be
-  // ordered with respected to oop accesses.
-  // Using immediate literals would necessitate ISBs.
-  BarrierSet* bs = BarrierSet::barrier_set();
-  if ((bs->barrier_set_nmethod() != NULL && bs->barrier_set_assembler()->nmethod_patching_type() == NMethodPatchingType::conc_data_patch) || !immediate) {
+  if (BarrierSet::barrier_set()->barrier_set_assembler()->supports_instruction_patching()) {
+    relocate(rspec);
+    patchable_li52(dst, (long)obj);
+  } else {
     address dummy = address(uintptr_t(pc()) & -wordSize); // A nearby aligned address
     relocate(rspec);
     patchable_li52(dst, (long)dummy);
-  } else {
-    relocate(rspec);
-    patchable_li52(dst, (long)obj);
   }
 }
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -123,8 +123,13 @@ class MacroAssembler: public Assembler {
 
   address emit_trampoline_stub(int insts_call_instruction_offset, address target);
 
+  void push_cont_fastpath(Register java_thread);
+  void pop_cont_fastpath(Register java_thread);
+
   // Alignment
   void align(int modulus);
+
+  void post_call_nop();
 
   // Stack frame creation/removal
   void enter();

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -662,7 +662,7 @@ class MacroAssembler: public Assembler {
   void mul_add(Register out, Register in, Register offset,
                Register len, Register k);
 
-  void movoop(Register dst, jobject obj, bool immediate = false);
+  void movoop(Register dst, jobject obj);
 
 #undef VIRTUAL
 

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1458,8 +1458,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
     // load oop into a register
     __ movoop(c_rarg1,
-              JNIHandles::make_local((method->method_holder())->java_mirror()),
-              /*immediate*/true);
+              JNIHandles::make_local(method->method_holder()->java_mirror()));
 
     // Now handlize the static class mirror it's known not-null.
     __ st_d(c_rarg1, SP, klass_offset);

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "code/compiledIC.hpp"
 #include "code/debugInfoRec.hpp"
 #include "code/icBuffer.hpp"
 #include "code/nativeInst.hpp"
@@ -35,7 +36,10 @@
 #include "interpreter/interpreter.hpp"
 #include "oops/compiledICHolder.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/method.inline.hpp"
 #include "prims/methodHandles.hpp"
+#include "runtime/continuation.hpp"
+#include "runtime/continuationEntry.inline.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/signature.hpp"
@@ -751,6 +755,8 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
     }
   }
 
+  __ push_cont_fastpath(TREG); // Set JavaThread::_cont_fastpath to the sp of the oldest interpreted frame we know about
+
   // 6243940 We might end up in handle_wrong_method if
   // the callee is deoptimized as we race thru here. If that
   // happens we don't want to take a safepoint because the
@@ -1050,6 +1056,194 @@ static void verify_oop_args(MacroAssembler* masm,
   }
 }
 
+// defined in stubGenerator_loongarch.cpp
+OopMap* continuation_enter_setup(MacroAssembler* masm, int& stack_slots);
+void fill_continuation_entry(MacroAssembler* masm);
+void continuation_enter_cleanup(MacroAssembler* masm);
+
+// enterSpecial(Continuation c, boolean isContinue, boolean isVirtualThread)
+// On entry: j_rarg0 (T0) -- the continuation object
+//           j_rarg1 (A0) -- isContinue
+//           j_rarg2 (A1) -- isVirtualThread
+static void gen_continuation_enter(MacroAssembler* masm,
+                                   const methodHandle& method,
+                                   const BasicType* sig_bt,
+                                   const VMRegPair* regs,
+                                   int& exception_offset,
+                                   OopMapSet*oop_maps,
+                                   int& frame_complete,
+                                   int& stack_slots,
+                                   int& interpreted_entry_offset,
+                                   int& compiled_entry_offset) {
+  AddressLiteral resolve(SharedRuntime::get_resolve_static_call_stub(),
+                         relocInfo::static_call_type);
+
+  address start = __ pc();
+
+  Label call_thaw, exit;
+
+  // i2i entry used at interp_only_mode only
+  interpreted_entry_offset = __ pc() - start;
+  {
+#ifdef ASSERT
+    Label is_interp_only;
+    __ ld_w(AT, Address(TREG, JavaThread::interp_only_mode_offset()));
+    __ bnez(AT, is_interp_only);
+    __ stop("enterSpecial interpreter entry called when not in interp_only_mode");
+    __ bind(is_interp_only);
+#endif
+
+    // Read interpreter arguments into registers (this is an ad-hoc i2c adapter)
+    __ ld_d(j_rarg0, Address(SP, Interpreter::stackElementSize * 2));
+    __ ld_d(j_rarg1, Address(SP, Interpreter::stackElementSize * 1));
+    __ ld_d(j_rarg2, Address(SP, Interpreter::stackElementSize * 0));
+    __ push_cont_fastpath(TREG);
+
+    __ enter();
+    stack_slots = 2; // will be adjusted in setup
+    OopMap* map = continuation_enter_setup(masm, stack_slots);
+    // The frame is complete here, but we only record it for the compiled entry, so the frame would appear unsafe,
+    // but that's okay because at the very worst we'll miss an async sample, but we're in interp_only_mode anyway.
+
+    fill_continuation_entry(masm);
+
+    __ bnez(j_rarg1, call_thaw);
+
+    address mark = __ pc();
+    __ trampoline_call(resolve);
+
+    oop_maps->add_gc_map(__ pc() - start, map);
+    __ post_call_nop();
+
+    __ b(exit);
+
+    CodeBuffer* cbuf = masm->code_section()->outer();
+    CompiledStaticCall::emit_to_interp_stub(*cbuf, mark);
+  }
+
+  // compiled entry
+  __ align(CodeEntryAlignment);
+  compiled_entry_offset = __ pc() - start;
+
+  __ enter();
+  stack_slots = 2; // will be adjusted in setup
+  OopMap* map = continuation_enter_setup(masm, stack_slots);
+  frame_complete = __ pc() - start;
+
+  fill_continuation_entry(masm);
+
+  __ bnez(j_rarg1, call_thaw);
+
+  address mark = __ pc();
+  __ trampoline_call(resolve);
+
+  oop_maps->add_gc_map(__ pc() - start, map);
+  __ post_call_nop();
+
+  __ b(exit);
+
+  __ bind(call_thaw);
+
+  __ call(CAST_FROM_FN_PTR(address, StubRoutines::cont_thaw()), relocInfo::runtime_call_type);
+  oop_maps->add_gc_map(__ pc() - start, map->deep_copy());
+  ContinuationEntry::_return_pc_offset = __ pc() - start;
+  __ post_call_nop();
+
+  __ bind(exit);
+
+  // We've succeeded, set sp to the ContinuationEntry
+  __ ld_d(SP, Address(TREG, JavaThread::cont_entry_offset()));
+  continuation_enter_cleanup(masm);
+  __ leave();
+  __ jr(RA);
+
+  // exception handling
+  exception_offset = __ pc() - start;
+  {
+    __ move(TSR, A0); // save return value contaning the exception oop in callee-saved TSR
+
+    // We've succeeded, set sp to the ContinuationEntry
+    __ ld_d(SP, Address(TREG, JavaThread::cont_entry_offset()));
+    continuation_enter_cleanup(masm);
+
+    __ ld_d(c_rarg1, Address(FP, -1 * wordSize)); // return address
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::exception_handler_for_return_address), TREG, c_rarg1);
+
+    // Continue at exception handler:
+    //   A0: exception oop
+    //   T4: exception handler
+    //   A1: exception pc
+    __ move(T4, A0);
+    __ move(A0, TSR);
+    __ verify_oop(A0);
+
+    __ leave();
+    __ move(A1, RA);
+    __ jr(T4);
+  }
+
+  CodeBuffer* cbuf = masm->code_section()->outer();
+  CompiledStaticCall::emit_to_interp_stub(*cbuf, mark);
+}
+
+static void gen_continuation_yield(MacroAssembler* masm,
+                                   const methodHandle& method,
+                                   const BasicType* sig_bt,
+                                   const VMRegPair* regs,
+                                   int& exception_offset,
+                                   OopMapSet* oop_maps,
+                                   int& frame_complete,
+                                   int& stack_slots,
+                                   int& interpreted_entry_offset,
+                                   int& compiled_entry_offset) {
+  enum layout {
+    fp_off,
+    fp_off2,
+    return_off,
+    return_off2,
+    framesize // inclusive of return address
+  };
+
+  stack_slots = framesize / VMRegImpl::slots_per_word;
+  assert(stack_slots == 2, "recheck layout");
+
+  address start = __ pc();
+
+  compiled_entry_offset = __ pc() - start;
+  __ enter();
+
+  __ move(c_rarg1, SP);
+
+  frame_complete = __ pc() - start;
+  address the_pc = __ pc();
+
+  Label L;
+  __ bind(L);
+
+  __ post_call_nop(); // this must be exactly after the pc value that is pushed into the frame info, we use this nop for fast CodeBlob lookup
+
+  __ move(c_rarg0, TREG);
+  __ set_last_Java_frame(TREG, SP, FP, L);
+  __ call_VM_leaf(Continuation::freeze_entry(), 2);
+  __ reset_last_Java_frame(true);
+
+  Label pinned;
+
+  __ bnez(A0, pinned);
+
+  // We've succeeded, set sp to the ContinuationEntry
+  __ ld_d(SP, Address(TREG, JavaThread::cont_entry_offset()));
+  continuation_enter_cleanup(masm);
+
+  __ bind(pinned); // pinned -- return to caller
+
+  __ leave();
+  __ jr(RA);
+
+  OopMap* map = new OopMap(framesize, 1);
+  oop_maps->add_gc_map(the_pc - start, map);
+}
+
 static void gen_special_dispatch(MacroAssembler* masm,
                                  methodHandle method,
                                  const BasicType* sig_bt,
@@ -1124,6 +1318,60 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
                                                 BasicType* in_sig_bt,
                                                 VMRegPair* in_regs,
                                                 BasicType ret_type) {
+  if (method->is_continuation_native_intrinsic()) {
+    int vep_offset = 0;
+    int exception_offset = 0;
+    int frame_complete = 0;
+    int stack_slots = 0;
+    OopMapSet* oop_maps =  new OopMapSet();
+    int interpreted_entry_offset = -1;
+    if (method->is_continuation_enter_intrinsic()) {
+      gen_continuation_enter(masm,
+                             method,
+                             in_sig_bt,
+                             in_regs,
+                             exception_offset,
+                             oop_maps,
+                             frame_complete,
+                             stack_slots,
+                             interpreted_entry_offset,
+                             vep_offset);
+    } else if (method->is_continuation_yield_intrinsic()) {
+      gen_continuation_yield(masm,
+                             method,
+                             in_sig_bt,
+                             in_regs,
+                             exception_offset,
+                             oop_maps,
+                             frame_complete,
+                             stack_slots,
+                             interpreted_entry_offset,
+                             vep_offset);
+    } else {
+      guarantee(false, "Unknown Continuation native intrinsic");
+    }
+
+    __ flush();
+    nmethod* nm = nmethod::new_native_nmethod(method,
+                                              compile_id,
+                                              masm->code(),
+                                              vep_offset,
+                                              frame_complete,
+                                              stack_slots,
+                                              in_ByteSize(-1),
+                                              in_ByteSize(-1),
+                                              oop_maps,
+                                              exception_offset);
+    if (method->is_continuation_enter_intrinsic()) {
+      ContinuationEntry::set_enter_code(nm, interpreted_entry_offset);
+    } else if (method->is_continuation_yield_intrinsic()) {
+      _cont_doYield_stub = nm;
+    } else {
+      guarantee(false, "Unknown Continuation native intrinsic");
+    }
+    return nm;
+  }
+
   if (method->is_method_handle_intrinsic()) {
     vmIntrinsics::ID iid = method->intrinsic_id();
     intptr_t start = (intptr_t)__ pc();

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -2170,7 +2170,7 @@ void SharedRuntime::generate_deopt_blob() {
   // Load count of frams into T3
   __ ld_w(count, unroll, Deoptimization::UnrollBlock::number_of_frames_offset_in_bytes());
   // Pick up the initial fp we should save
-  __ ld_d(FP, unroll,  Deoptimization::UnrollBlock::initial_info_offset_in_bytes());
+  __ ld_d(FP, unroll, Deoptimization::UnrollBlock::initial_info_offset_in_bytes());
    // Now adjust the caller's stack to make up for the extra locals
   // but record the original sp so that we can save it in the skeletal interpreter
   // frame and the stack walking of interpreter_sender will get the unextended sp
@@ -2335,11 +2335,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
 
   // Pop deoptimized frame
   __ ld_w(T8, unroll, Deoptimization::UnrollBlock::size_of_deoptimized_frame_offset_in_bytes());
-  __ addi_d(T8, T8, -2 * wordSize);
   __ add_d(SP, SP, T8);
-  __ ld_d(FP, SP, 0);
-  __ ld_d(RA, SP, wordSize);
-  __ addi_d(SP, SP, 2 * wordSize);
 
 #ifdef ASSERT
   // Compilers generate code that bang the stack by as much as the
@@ -2366,14 +2362,17 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   __ ld_d(sizes, unroll, Deoptimization::UnrollBlock::frame_sizes_offset_in_bytes());
   __ ld_wu(count, unroll, Deoptimization::UnrollBlock::number_of_frames_offset_in_bytes());
 
+  // Pick up the initial fp we should save
+  __ ld_d(FP, unroll, Deoptimization::UnrollBlock::initial_info_offset_in_bytes());
+
   // Now adjust the caller's stack to make up for the extra locals
   // but record the original sp so that we can save it in the skeletal interpreter
   // frame and the stack walking of interpreter_sender will get the unextended sp
   // value and not the "real" sp value.
-
   __ move(sender_sp, SP);
   __ ld_w(AT, unroll, Deoptimization::UnrollBlock::caller_adjustment_offset_in_bytes());
   __ sub_d(SP, SP, AT);
+
   // Push interpreter frames in a loop
   Label loop;
   __ bind(loop);

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -794,7 +794,7 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
   address c2i_unverified_entry = __ pc();
   Label skip_fixup;
   {
-    Register holder = T1;
+    Register holder = IC_Klass;
     Register receiver = T0;
     Register temp = T8;
     address ic_miss = SharedRuntime::get_ic_miss_stub();
@@ -1280,8 +1280,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   // restoring them except fp. fp is the only callee save register
   // as far as the interpreter and the compiler(s) are concerned.
 
-  //refer to register_loongarch.hpp:IC_Klass
-  const Register ic_reg = T1;
+  const Register ic_reg = IC_Klass;
   const Register receiver = T0;
 
   Label hit;

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1099,7 +1099,7 @@ static void gen_special_dispatch(MacroAssembler* masm,
       // pass the receiver oop in a register.  If this is not true on some
       // platform, pick a temp and load the receiver from stack.
       fatal("receiver always in a register");
-      receiver_reg = SSR;  // known to be free at this point
+      receiver_reg = T6;  // known to be free at this point
       __ ld_d(receiver_reg, Address(SP, r->reg2stack() * VMRegImpl::stack_slot_size));
     } else {
       // no data motion is needed

--- a/src/hotspot/cpu/loongarch/smallRegisterMap_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/smallRegisterMap_loongarch.inline.hpp
@@ -29,13 +29,13 @@
 #include "runtime/frame.inline.hpp"
 #include "runtime/registerMap.hpp"
 
-// Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
+// Java frames don't have callee saved registers (except for FP), so we can use a smaller RegisterMap
 class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
-                                     DEBUG_ONLY({ Unimplemented(); })
+  static void assert_is_fp(VMReg r) NOT_DEBUG_RETURN
+                                    DEBUG_ONLY({ assert (r == FP->as_VMReg() || r == FP->as_VMReg()->next(), "Reg: %s", r->name()); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap
   // Consider enhancing SmallRegisterMap to support those cases
@@ -43,22 +43,29 @@ public:
   RegisterMap* as_RegisterMap() { return nullptr; }
 
   RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
-    Unimplemented();
+    map->clear();
+    map->set_include_argument_oops(this->include_argument_oops());
+    frame::update_map_with_saved_link(map, (intptr_t**)sp - 2);
     return map;
   }
 
   SmallRegisterMap() {}
 
   SmallRegisterMap(const RegisterMap* map) {
-    Unimplemented();
+  #ifdef ASSERT
+    for(int i = 0; i < RegisterMap::reg_count; i++) {
+      VMReg r = VMRegImpl::as_VMReg(i);
+      if (map->location(r, (intptr_t*)nullptr) != nullptr) assert_is_fp(r);
+    }
+  #endif
   }
 
   inline address location(VMReg reg, intptr_t* sp) const {
-    Unimplemented();
-    return NULL;
+    assert_is_fp(reg);
+    return (address)(sp - 2);
   }
 
-  inline void set_location(VMReg reg, address loc) { assert_is_rfp(reg); }
+  inline void set_location(VMReg reg, address loc) { assert_is_fp(reg); }
 
   JavaThread* thread() const {
   #ifndef ASSERT
@@ -76,10 +83,7 @@ public:
 
 #ifdef ASSERT
   bool should_skip_missing() const  { return false; }
-  VMReg find_register_spilled_here(void* p, intptr_t* sp) {
-    Unimplemented();
-    return NULL;
-  }
+  VMReg find_register_spilled_here(void* p, intptr_t* sp) { return FP->as_VMReg(); }
   void print() const { print_on(tty); }
   void print_on(outputStream* st) const { st->print_cr("Small register map"); }
 #endif

--- a/src/hotspot/cpu/loongarch/stackChunkFrameStream_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/stackChunkFrameStream_loongarch.inline.hpp
@@ -33,80 +33,112 @@
 #ifdef ASSERT
 template <ChunkFrames frame_kind>
 inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
-  Unimplemented();
-  return true;
+  assert(!is_done(), "");
+  intptr_t* p = (intptr_t*)p0;
+  int argsize = is_compiled() ? (_cb->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord : 0;
+  int frame_size = _cb->frame_size() + argsize;
+  return p == sp() - 2 || ((p - unextended_sp()) >= 0 && (p - unextended_sp()) < frame_size);
 }
 #endif
 
 template <ChunkFrames frame_kind>
 inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
-  Unimplemented();
-  return frame();
+  if (is_done()) {
+    return frame(_sp, _sp, nullptr, nullptr, nullptr, nullptr, true);
+  } else {
+    return frame(sp(), unextended_sp(), fp(), pc(), cb(), _oopmap, true);
+  }
 }
 
 template <ChunkFrames frame_kind>
 inline address StackChunkFrameStream<frame_kind>::get_pc() const {
-  Unimplemented();
-  return NULL;
+  assert(!is_done(), "");
+  return *(address*)(_sp - 1);
 }
 
 template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
-  Unimplemented();
-  return NULL;
+  intptr_t* fp_addr = _sp - 2;
+  return (frame_kind == ChunkFrames::Mixed && is_interpreted())
+    ? fp_addr + *fp_addr // derelativize
+    : *(intptr_t**)fp_addr;
 }
 
 template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
-  Unimplemented();
-  return NULL;
+  intptr_t* fp = this->fp();
+  assert(fp != nullptr, "");
+  return fp + fp[offset];
 }
 
 template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
-  Unimplemented();
-  return NULL;
+  assert_is_interpreted_and_frame_type_mixed();
+  return derelativize(frame::interpreter_frame_last_sp_offset);
 }
 
 template <ChunkFrames frame_kind>
 intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
-  Unimplemented();
-  return NULL;
+  assert_is_interpreted_and_frame_type_mixed();
+  return (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) ? _end : fp() + frame::sender_sp_offset;
 }
 
 template <ChunkFrames frame_kind>
 inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
-  Unimplemented();
+  assert_is_interpreted_and_frame_type_mixed();
+  if (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) {
+    _unextended_sp = _end;
+    _sp = _end;
+  } else {
+    intptr_t* fp = this->fp();
+    _unextended_sp = fp + fp[frame::interpreter_frame_sender_sp_offset];
+    _sp = fp + frame::sender_sp_offset;
+  }
 }
 
 template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
-  Unimplemented();
-  return 0;
+  assert_is_interpreted_and_frame_type_mixed();
+
+  intptr_t* top = unextended_sp(); // later subtract argsize if callee is interpreted
+  intptr_t* bottom = derelativize(frame::interpreter_frame_locals_offset) + 1; // the sender's unextended sp: derelativize(frame::interpreter_frame_sender_sp_offset);
+  return (int)(bottom - top);
 }
 
 template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
-  Unimplemented();
-  return 0;
+  assert_is_interpreted_and_frame_type_mixed();
+  int diff = (int)(derelativize(frame::interpreter_frame_locals_offset) - derelativize(frame::interpreter_frame_sender_sp_offset) + 1);
+  return diff;
 }
 
 template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
-  Unimplemented();
-  return 0;
+  assert_is_interpreted_and_frame_type_mixed();
+  ResourceMark rm;
+  InterpreterOopMap mask;
+  frame f = to_frame();
+  f.interpreted_frame_oop_map(&mask);
+  return mask.num_oops()
+        + 1 // for the mirror oop
+        + ((intptr_t*)f.interpreter_frame_monitor_begin()
+            - (intptr_t*)f.interpreter_frame_monitor_end()) / BasicObjectLock::size();
 }
 
 template<>
 template<>
 inline void StackChunkFrameStream<ChunkFrames::Mixed>::update_reg_map_pd(RegisterMap* map) {
-  Unimplemented();
+  if (map->update_map()) {
+    frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)2 : (intptr_t**)(_sp - 2));
+  }
 }
 
 template<>
 template<>
 inline void StackChunkFrameStream<ChunkFrames::CompiledOnly>::update_reg_map_pd(RegisterMap* map) {
-  Unimplemented();
+  if (map->update_map()) {
+    frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)2 : (intptr_t**)(_sp - 2));
+  }
 }
 
 template <ChunkFrames frame_kind>

--- a/src/hotspot/cpu/loongarch/stackChunkOop_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/stackChunkOop_loongarch.inline.hpp
@@ -26,12 +26,18 @@
 #ifndef CPU_LOONGARCH_STACKCHUNKOOP_LOONGARCH_INLINE_HPP
 #define CPU_LOONGARCH_STACKCHUNKOOP_LOONGARCH_INLINE_HPP
 
+#include "runtime/frame.inline.hpp"
+
 inline void stackChunkOopDesc::relativize_frame_pd(frame& fr) const {
-  Unimplemented();
+  if (fr.is_interpreted_frame()) {
+    fr.set_offset_fp(relativize_address(fr.fp()));
+  }
 }
 
 inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
-  Unimplemented();
+  if (fr.is_interpreted_frame()) {
+    fr.set_fp(derelativize_address(fr.offset_fp()));
+  }
 }
 
 #endif // CPU_LOONGARCH_STACKCHUNKOOP_LOONGARCH_INLINE_HPP

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -358,15 +358,13 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
   return entry_point;
 }
 
+// Method entry for java.lang.Thread.currentThread
 address TemplateInterpreterGenerator::generate_currentThread() {
 
   address entry_point = __ pc();
 
-  __ ld_d(A0, TREG, in_bytes(JavaThread::threadObj_offset()));
-
+  __ ld_d(A0, Address(TREG, JavaThread::vthread_offset()));
   __ resolve_oop_handle(A0, T4);
-
-  __ move(SP, Rsender);
   __ jr(RA);
 
   return entry_point;

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -650,7 +650,9 @@ address TemplateInterpreterGenerator::generate_safept_entry_for(
         address runtime_entry) {
   address entry = __ pc();
   __ push(state);
+  __ push_cont_fastpath(TREG);
   __ call_VM(noreg, runtime_entry);
+  __ pop_cont_fastpath(TREG);
   __ dispatch_via(vtos, Interpreter::_normal_table.table_for(vtos));
   return entry;
 }

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -339,9 +339,10 @@ void TemplateTable::ldc(bool wide) {
 
 void TemplateTable::condy_helper(Label& Done) {
   const Register obj = FSR;
-  const Register off = SSR;
-  const Register flags = T3;
   const Register rarg = A1;
+  const Register flags = A2;
+  const Register off = A3;
+
   __ li(rarg, (int)bytecode());
   __ call_VM(obj, CAST_FROM_FN_PTR(address, InterpreterRuntime::resolve_ldc), rarg);
   __ get_vm_result_2(flags, TREG);
@@ -447,8 +448,9 @@ void TemplateTable::fast_aldc(bool wide) {
   transition(vtos, atos);
 
   Register result = FSR;
-  Register tmp = SSR;
-  Register rarg = A1;
+  Register tmp = A1;
+  Register rarg = A2;
+
   int index_size = wide ? sizeof(u2) : sizeof(u1);
 
   Label resolved;
@@ -706,7 +708,8 @@ void TemplateTable::index_check_without_pop(Register array, Register index) {
   __ ld_w(AT, array, arrayOopDesc::length_offset_in_bytes());
   __ bltu(index, AT, ok);
 
-  //throw_ArrayIndexOutOfBoundsException assume abberrant index in A2
+  // throw_ArrayIndexOutOfBoundsException assume abberrant index in A2
+  assert(index != A1, "smashed arg");
   if (A1 != array) __ move(A1, array);
   if (A2 != index) __ move(A2, index);
   __ jmp(Interpreter::_throw_ArrayIndexOutOfBoundsException_entry);
@@ -715,36 +718,36 @@ void TemplateTable::index_check_without_pop(Register array, Register index) {
 
 void TemplateTable::iaload() {
   transition(itos, itos);
-  index_check(SSR, FSR);
-  __ alsl_d(FSR, FSR, SSR, 1);
+  index_check(A1, FSR);
+  __ alsl_d(FSR, FSR, A1, 1);
   __ access_load_at(T_INT, IN_HEAP | IS_ARRAY, FSR, Address(FSR, arrayOopDesc::base_offset_in_bytes(T_INT)), noreg, noreg);
 }
 
 void TemplateTable::laload() {
   transition(itos, ltos);
-  index_check(SSR, FSR);
-  __ alsl_d(T4, FSR, SSR, Address::times_8 - 1);
+  index_check(A1, FSR);
+  __ alsl_d(T4, FSR, A1, Address::times_8 - 1);
   __ access_load_at(T_LONG, IN_HEAP | IS_ARRAY, FSR, Address(T4, arrayOopDesc::base_offset_in_bytes(T_LONG)), noreg, noreg);
 }
 
 void TemplateTable::faload() {
   transition(itos, ftos);
-  index_check(SSR, FSR);
-  __ alsl_d(FSR, FSR, SSR, Address::times_4 - 1);
+  index_check(A1, FSR);
+  __ alsl_d(FSR, FSR, A1, Address::times_4 - 1);
   __ access_load_at(T_FLOAT, IN_HEAP | IS_ARRAY, noreg, Address(FSR, arrayOopDesc::base_offset_in_bytes(T_FLOAT)), noreg, noreg);
 }
 
 void TemplateTable::daload() {
   transition(itos, dtos);
-  index_check(SSR, FSR);
-  __ alsl_d(T4, FSR, SSR, 2);
+  index_check(A1, FSR);
+  __ alsl_d(T4, FSR, A1, 2);
   __ access_load_at(T_DOUBLE, IN_HEAP | IS_ARRAY, noreg, Address(T4, arrayOopDesc::base_offset_in_bytes(T_DOUBLE)), noreg, noreg);
 }
 
 void TemplateTable::aaload() {
   transition(itos, atos);
-  index_check(SSR, FSR);
-  __ alsl_d(FSR, FSR, SSR, (UseCompressedOops ? Address::times_4 : Address::times_8) - 1);
+  index_check(A1, FSR);
+  __ alsl_d(FSR, FSR, A1, (UseCompressedOops ? Address::times_4 : Address::times_8) - 1);
   //add for compressedoops
   do_oop_load(_masm,
               Address(FSR, arrayOopDesc::base_offset_in_bytes(T_OBJECT)),
@@ -754,15 +757,15 @@ void TemplateTable::aaload() {
 
 void TemplateTable::baload() {
   transition(itos, itos);
-  index_check(SSR, FSR);
-  __ add_d(FSR, SSR, FSR);
+  index_check(A1, FSR);
+  __ add_d(FSR, A1, FSR);
   __ access_load_at(T_BYTE, IN_HEAP | IS_ARRAY, FSR, Address(FSR, arrayOopDesc::base_offset_in_bytes(T_BYTE)), noreg, noreg);
 }
 
 void TemplateTable::caload() {
   transition(itos, itos);
-  index_check(SSR, FSR);
-  __ alsl_d(FSR, FSR, SSR, Address::times_2 - 1);
+  index_check(A1, FSR);
+  __ alsl_d(FSR, FSR, A1, Address::times_2 - 1);
   __ access_load_at(T_CHAR, IN_HEAP | IS_ARRAY, FSR, Address(FSR, arrayOopDesc::base_offset_in_bytes(T_CHAR)), noreg, noreg);
 }
 
@@ -774,15 +777,15 @@ void TemplateTable::fast_icaload() {
   // load index out of locals
   locals_index(T2);
   __ ld_w(FSR, T2, 0);
-  index_check(SSR, FSR);
-  __ alsl_d(FSR, FSR, SSR, 0);
+  index_check(A1, FSR);
+  __ alsl_d(FSR, FSR, A1, 0);
   __ access_load_at(T_CHAR, IN_HEAP | IS_ARRAY, FSR, Address(FSR, arrayOopDesc::base_offset_in_bytes(T_CHAR)), noreg, noreg);
 }
 
 void TemplateTable::saload() {
   transition(itos, itos);
-  index_check(SSR, FSR);
-  __ alsl_d(FSR, FSR, SSR, Address::times_2 - 1);
+  index_check(A1, FSR);
+  __ alsl_d(FSR, FSR, A1, Address::times_2 - 1);
   __ access_load_at(T_SHORT, IN_HEAP | IS_ARRAY, FSR, Address(FSR, arrayOopDesc::base_offset_in_bytes(T_SHORT)), noreg, noreg);
 }
 
@@ -957,13 +960,12 @@ void TemplateTable::wide_astore() {
   __ st_d(FSR, T2, 0);
 }
 
-// used register : T2
 void TemplateTable::iastore() {
   transition(itos, vtos);
-  __ pop_i(SSR);   // T2: array  SSR: index
-  index_check(T2, SSR);  // prefer index in SSR
-  __ alsl_d(T2, SSR, T2, Address::times_4 - 1);
-  __ access_store_at(T_INT, IN_HEAP | IS_ARRAY, Address(T2, arrayOopDesc::base_offset_in_bytes(T_INT)), FSR, noreg, noreg);
+  __ pop_i(T2);
+  index_check(A1, T2);
+  __ alsl_d(A1, T2, A1, Address::times_4 - 1);
+  __ access_store_at(T_INT, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_INT)), FSR, noreg, noreg);
 }
 
 // used register T2, T3
@@ -978,10 +980,10 @@ void TemplateTable::lastore() {
 // used register T2
 void TemplateTable::fastore() {
   transition(ftos, vtos);
-  __ pop_i(SSR);
-  index_check(T2, SSR);
-  __ alsl_d(T2, SSR, T2, Address::times_4 - 1);
-  __ access_store_at(T_FLOAT, IN_HEAP | IS_ARRAY, Address(T2, arrayOopDesc::base_offset_in_bytes(T_FLOAT)), noreg, noreg, noreg);
+  __ pop_i(T2);
+  index_check(A1, T2);
+  __ alsl_d(A1, T2, A1, Address::times_4 - 1);
+  __ access_store_at(T_FLOAT, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_FLOAT)), noreg, noreg, noreg);
 }
 
 // used register T2, T3
@@ -993,20 +995,15 @@ void TemplateTable::dastore() {
   __ access_store_at(T_DOUBLE, IN_HEAP | IS_ARRAY, Address(T3, arrayOopDesc::base_offset_in_bytes(T_DOUBLE)), noreg, noreg, noreg);
 }
 
-// used register : T2, T3, T8
-// T2 : array
-// T3 : subklass
-// T8 : supklass
 void TemplateTable::aastore() {
   Label is_null, ok_is_subtype, done;
   transition(vtos, vtos);
   // stack: ..., array, index, value
-  __ ld_d(FSR, at_tos());     // Value
-  __ ld_w(SSR, at_tos_p1());  // Index
-  __ ld_d(T2, at_tos_p2());  // Array
+  __ ld_d(FSR, at_tos());    // Value
+  __ ld_w(T2, at_tos_p1());  // Index
+  __ ld_d(A1, at_tos_p2());  // Array
 
-  // index_check(T2, SSR);
-  index_check_without_pop(T2, SSR);
+  index_check_without_pop(A1, T2);
   // do array store check - check for NULL value first
   __ beq(FSR, R0, is_null);
 
@@ -1015,11 +1012,11 @@ void TemplateTable::aastore() {
   __ load_klass(T3, FSR);
   // Move superklass into T8
   //add for compressedoops
-  __ load_klass(T8, T2);
+  __ load_klass(T8, A1);
   __ ld_d(T8, Address(T8,  ObjArrayKlass::element_klass_offset()));
-  // Compress array+index*4+12 into a single register. T2
-  __ alsl_d(T2, SSR, T2, (UseCompressedOops? Address::times_4 : Address::times_8) - 1);
-  __ addi_d(T2, T2, arrayOopDesc::base_offset_in_bytes(T_OBJECT));
+  // Compress array+index*4+12 into a single register.
+  __ alsl_d(A1, T2, A1, (UseCompressedOops? Address::times_4 : Address::times_8) - 1);
+  __ addi_d(A1, A1, arrayOopDesc::base_offset_in_bytes(T_OBJECT));
 
   // Generate subtype check.
   // Superklass in T8.  Subklass in T3.
@@ -1029,14 +1026,14 @@ void TemplateTable::aastore() {
   __ jmp(Interpreter::_throw_ArrayStoreException_entry);
   // Come here on success
   __ bind(ok_is_subtype);
-  do_oop_store(_masm, Address(T2, 0), FSR, IS_ARRAY);
+  do_oop_store(_masm, Address(A1, 0), FSR, IS_ARRAY);
   __ b(done);
 
-  // Have a NULL in FSR, T2=array, SSR=index.  Store NULL at ary[idx]
+  // Have a NULL in FSR, A1=array, T2=index.  Store NULL at ary[idx]
   __ bind(is_null);
   __ profile_null_seen(T4);
-  __ alsl_d(T2, SSR, T2, (UseCompressedOops? Address::times_4 : Address::times_8) - 1);
-  do_oop_store(_masm, Address(T2, arrayOopDesc::base_offset_in_bytes(T_OBJECT)), noreg, IS_ARRAY);
+  __ alsl_d(A1, T2, A1, (UseCompressedOops? Address::times_4 : Address::times_8) - 1);
+  do_oop_store(_masm, Address(A1, arrayOopDesc::base_offset_in_bytes(T_OBJECT)), noreg, IS_ARRAY);
 
   __ bind(done);
   __ addi_d(SP, SP, 3 * Interpreter::stackElementSize);
@@ -1044,12 +1041,12 @@ void TemplateTable::aastore() {
 
 void TemplateTable::bastore() {
   transition(itos, vtos);
-  __ pop_i(SSR);
-  index_check(T2, SSR);
+  __ pop_i(T2);
+  index_check(A1, T2);
 
   // Need to check whether array is boolean or byte
   // since both types share the bastore bytecode.
-  __ load_klass(T4, T2);
+  __ load_klass(T4, A1);
   __ ld_w(T4, T4, in_bytes(Klass::layout_helper_offset()));
 
   int diffbit = Klass::layout_helper_boolean_diffbit();
@@ -1061,16 +1058,16 @@ void TemplateTable::bastore() {
   __ andi(FSR, FSR, 0x1);
   __ bind(L_skip);
 
-  __ add_d(SSR, T2, SSR);
-  __ access_store_at(T_BYTE, IN_HEAP | IS_ARRAY, Address(SSR, arrayOopDesc::base_offset_in_bytes(T_BYTE)), FSR, noreg, noreg);
+  __ add_d(A1, A1, T2);
+  __ access_store_at(T_BYTE, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_BYTE)), FSR, noreg, noreg);
 }
 
 void TemplateTable::castore() {
   transition(itos, vtos);
-  __ pop_i(SSR);
-  index_check(T2, SSR);
-  __ alsl_d(SSR, SSR, T2, Address::times_2 - 1);
-  __ access_store_at(T_CHAR, IN_HEAP | IS_ARRAY, Address(SSR, arrayOopDesc::base_offset_in_bytes(T_CHAR)), FSR, noreg, noreg);
+  __ pop_i(T2);
+  index_check(A1, T2);
+  __ alsl_d(A1, T2, A1, Address::times_2 - 1);
+  __ access_store_at(T_CHAR, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_CHAR)), FSR, noreg, noreg);
 }
 
 void TemplateTable::sastore() {
@@ -1180,7 +1177,6 @@ void TemplateTable::dup2_x1() {
   // stack: ..., b, c, a, b, c
 }
 
-// blows FSR, SSR
 void TemplateTable::dup2_x2() {
   transition(vtos, vtos);
   // stack: ..., a, b, c, d
@@ -1218,35 +1214,33 @@ void TemplateTable::swap() {
 
 void TemplateTable::iop2(Operation op) {
   transition(itos, itos);
-
-  __ pop_i(SSR);
+  // FSR(A0) <== A1 op A0
+  __ pop_i(A1);
   switch (op) {
-    case add  : __ add_w(FSR, SSR, FSR); break;
-    case sub  : __ sub_w(FSR, SSR, FSR); break;
-    case mul  : __ mul_w(FSR, SSR, FSR);    break;
-    case _and : __ andr(FSR, SSR, FSR);   break;
-    case _or  : __ orr(FSR, SSR, FSR);    break;
-    case _xor : __ xorr(FSR, SSR, FSR);   break;
-    case shl  : __ sll_w(FSR, SSR, FSR);   break;
-    case shr  : __ sra_w(FSR, SSR, FSR);   break;
-    case ushr : __ srl_w(FSR, SSR, FSR);   break;
+    case add  : __ add_w(FSR, A1, FSR); break;
+    case sub  : __ sub_w(FSR, A1, FSR); break;
+    case mul  : __ mul_w(FSR, A1, FSR); break;
+    case _and : __ andr (FSR, A1, FSR); break;
+    case _or  : __ orr  (FSR, A1, FSR); break;
+    case _xor : __ xorr (FSR, A1, FSR); break;
+    case shl  : __ sll_w(FSR, A1, FSR); break;
+    case shr  : __ sra_w(FSR, A1, FSR); break;
+    case ushr : __ srl_w(FSR, A1, FSR); break;
     default   : ShouldNotReachHere();
   }
 }
 
-// the result stored in FSR, SSR,
-// used registers : T2, T3
 void TemplateTable::lop2(Operation op) {
   transition(ltos, ltos);
-  __ pop_l(T2);
-
+  // FSR(A0) <== A1 op A0
+  __ pop_l(A1);
   switch (op) {
-    case add : __ add_d(FSR, T2, FSR); break;
-    case sub : __ sub_d(FSR, T2, FSR); break;
-    case _and: __ andr(FSR, T2, FSR);  break;
-    case _or : __ orr(FSR, T2, FSR);   break;
-    case _xor: __ xorr(FSR, T2, FSR);  break;
-    default : ShouldNotReachHere();
+    case add  : __ add_d(FSR, A1, FSR); break;
+    case sub  : __ sub_d(FSR, A1, FSR); break;
+    case _and : __ andr (FSR, A1, FSR); break;
+    case _or  : __ orr  (FSR, A1, FSR); break;
+    case _xor : __ xorr (FSR, A1, FSR); break;
+    default   : ShouldNotReachHere();
   }
 }
 
@@ -1261,21 +1255,20 @@ void TemplateTable::idiv() {
   __ jmp(Interpreter::_throw_ArithmeticException_entry);
   __ bind(not_zero);
 
-  __ pop_i(SSR);
-  __ div_w(FSR, SSR, FSR);
+  __ pop_i(A1);
+  __ div_w(FSR, A1, FSR);
 }
 
 void TemplateTable::irem() {
   transition(itos, itos);
-  Label not_zero;
-  __ pop_i(SSR);
-
-  __ bne(FSR, R0, not_zero);
-  //__ brk(7);
+  // explicitly check for div0
+  Label no_div0;
+  __ bnez(FSR, no_div0);
   __ jmp(Interpreter::_throw_ArithmeticException_entry);
 
-  __ bind(not_zero);
-  __ mod_w(FSR, SSR, FSR);
+  __ bind(no_div0);
+  __ pop_i(A1);
+  __ mod_w(FSR, A1, FSR);
 }
 
 void TemplateTable::lmul() {
@@ -1785,26 +1778,26 @@ void TemplateTable::if_icmp(Condition cc) {
   transition(itos, vtos);
   // assume branch is more often taken than not (loops use backward branches)
   Label not_taken;
-
-  __ pop_i(SSR);
+  __ pop_i(A1);
+  __ add_w(FSR, FSR, R0);
   switch(cc) {
     case not_equal:
-      __ beq(SSR, FSR, not_taken);
+      __ beq(A1, FSR, not_taken);
       break;
     case equal:
-      __ bne(SSR, FSR, not_taken);
+      __ bne(A1, FSR, not_taken);
       break;
     case less:
-      __ bge(SSR, FSR, not_taken);
+      __ bge(A1, FSR, not_taken);
       break;
     case less_equal:
-      __ blt(FSR, SSR, not_taken);
+      __ blt(FSR, A1, not_taken);
       break;
     case greater:
-      __ bge(FSR, SSR, not_taken);
+      __ bge(FSR, A1, not_taken);
       break;
     case greater_equal:
-      __ blt(SSR, FSR, not_taken);
+      __ blt(A1, FSR, not_taken);
       break;
   }
 
@@ -1838,14 +1831,14 @@ void TemplateTable::if_acmp(Condition cc) {
   transition(atos, vtos);
   // assume branch is more often taken than not (loops use backward branches)
   Label not_taken;
-  //  __ ld_w(SSR, SP, 0);
-  __ pop_ptr(SSR);
+  __ pop_ptr(A1);
+
   switch(cc) {
     case not_equal:
-      __ beq(SSR, FSR, not_taken);
+      __ beq(A1, FSR, not_taken);
       break;
     case equal:
-      __ bne(SSR, FSR, not_taken);
+      __ bne(A1, FSR, not_taken);
       break;
     default:
       ShouldNotReachHere();
@@ -3192,7 +3185,7 @@ void TemplateTable::prepare_invoke(int byte_no,
      // Push the appendix as a trailing parameter.
      // This must be done before we get the receiver,
      // since the parameter_size includes it.
-     Register tmp = SSR;
+     Register tmp = T6;
      __ push(tmp);
      __ move(tmp, index);
      __ load_resolved_reference_at_index(index, tmp, recv);

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022, These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #ifndef SHARE_OOPS_STACKCHUNKOOP_INLINE_HPP
 #define SHARE_OOPS_STACKCHUNKOOP_INLINE_HPP
 
@@ -135,8 +141,8 @@ inline bool stackChunkOopDesc::is_in_chunk(void* p) const {
 }
 
 bool stackChunkOopDesc::is_usable_in_chunk(void* p) const {
-#if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
-  HeapWord* start = (HeapWord*)start_address() + sp() - frame::sender_sp_offset;
+#if (defined(X86) || defined(AARCH64) || defined(LOONGARCH64)) && !defined(ZERO)
+  HeapWord* start = (HeapWord*)start_address() + sp() - frame::sender_sp_offset LOONGARCH64_ONLY(- frame::metadata_words);
 #else
   Unimplemented();
   HeapWord* start = NULL;
@@ -324,7 +330,7 @@ inline void stackChunkOopDesc::copy_from_stack_to_chunk(intptr_t* from, intptr_t
   assert(to >= start_address(), "Chunk underflow");
   assert(to + size <= end_address(), "Chunk overflow");
 
-#if !defined(AMD64) || !defined(AARCH64) || defined(ZERO)
+#if !defined(AMD64) || !defined(AARCH64) || !defined(LOONGARCH64) || defined(ZERO)
   // Suppress compilation warning-as-error on unimplemented architectures
   // that stub out arch-specific methods. Some compilers are smart enough
   // to figure out the argument is always null and then warn about it.
@@ -343,7 +349,7 @@ inline void stackChunkOopDesc::copy_from_chunk_to_stack(intptr_t* from, intptr_t
   assert(from >= start_address(), "");
   assert(from + size <= end_address(), "");
 
-#if !defined(AMD64) || !defined(AARCH64) || defined(ZERO)
+#if !defined(AMD64) || !defined(AARCH64) || !defined(LOONGARCH64) || defined(ZERO)
   // Suppress compilation warning-as-error on unimplemented architectures
   // that stub out arch-specific methods. Some compilers are smart enough
   // to figure out the argument is always null and then warn about it.

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022, These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "precompiled.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
@@ -239,7 +245,7 @@ frame Continuation::continuation_parent_frame(RegisterMap* map) {
 
   map->set_stack_chunk(nullptr);
 
-#if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
+#if (defined(X86) || defined(AARCH64) || defined(LOONGARCH64)) && !defined(ZERO)
   frame sender(cont.entrySP(), cont.entryFP(), cont.entryPC());
 #else
   frame sender = frame();

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3119,7 +3119,7 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
       CodeBuffer buffer(buf);
 
       if (method->is_continuation_enter_intrinsic()) {
-        buffer.initialize_stubs_size(128);
+        buffer.initialize_stubs_size(NOT_LOONGARCH64(128) LOONGARCH64_ONLY(192));
       }
 
       struct { double data[20]; } locs_buf;

--- a/test/hotspot/jtreg/compiler/intrinsics/TestDoubleIsFinite.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestDoubleIsFinite.java
@@ -22,10 +22,16 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022. These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
 * @test
 * @summary Test intrinsic for Double.isFinite.
-* @requires os.arch == "riscv64"
+* @requires os.arch == "riscv64" | os.arch == "loongarch64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestDoubleIsFinite
 */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestDoubleIsInfinite.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestDoubleIsInfinite.java
@@ -22,10 +22,16 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022. These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
 * @test
 * @summary Test intrinsic for Double.isInfinite.
-* @requires vm.cpu.features ~= ".*avx512dq.*" | os.arch == "riscv64"
+* @requires vm.cpu.features ~= ".*avx512dq.*" | os.arch == "riscv64" | os.arch == "loongarch64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestDoubleIsInfinite
 */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestFloatIsFinite.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestFloatIsFinite.java
@@ -22,10 +22,16 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022. These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
 * @test
 * @summary Test intrinsics for Float.isFinite.
-* @requires os.arch == "riscv64"
+* @requires os.arch == "riscv64" | os.arch == "loongarch64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestFloatIsFinite
 */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestFloatIsInfinite.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestFloatIsInfinite.java
@@ -22,10 +22,16 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022. These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
 * @test
 * @summary Test intrinsics for Float.isInfinite.
-* @requires vm.cpu.features ~= ".*avx512dq.*" | os.arch == "riscv64"
+* @requires vm.cpu.features ~= ".*avx512dq.*" | os.arch == "riscv64" | os.arch == "loongarch64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestFloatIsInfinite
 */


### PR DESCRIPTION
26770: [Loom] Virtual Threads Running Stub Implementation
28316: [C2] Vitrual thread awared ThreadLocal node
28312: currentThread entry should be vthread awared
28548: Fix misleading-indentation warnings with minimal and core build
28061: Use Deoptimization::UnrollBlock::initial_info to get FP
28314: Misc crash dump improvements
28272: Delete b*_long()
28046: LA port of 8293035: Cleanup MacroAssembler::movoop code patching logic aarch64 riscv
27813: Inline cache buffer stub code size reduction
22999: Undefine SSR and SHIFT_count
28396: [C2] specify priority of register selection within phases of RA
28524: LA port of 8262074: Consolidate the default value of MetaspaceSize
28280: Implement isFinite intrinsic
28101: Implement isInfinite intrinsic