### PR TITLE
Update (2023.03.01)

### DIFF
--- a/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
@@ -2111,7 +2111,7 @@ public:
   void dbar(int hint)      {
     assert(is_uimm(hint, 15), "not a unsigned 15-bit int");
 
-    if (os::is_ActiveCoresMP())
+    if (UseActiveCoresMP)
       andi(R0, R0, 0);
     else
       emit_int32(insn_I15(dbar_op, hint));

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -5314,12 +5314,30 @@ instruct  jmpLoopEnd_long(cmpOp cop, mRegI src1, mRegI src2, label labl) %{
   ins_pc_relative(1);
 %}
 
+instruct  jmpLoopEnd_reg_imm12_long(cmpOp cop, mRegI src1, immI12 src2, label labl) %{
+  match(CountedLoopEnd cop (CmpI src1 src2));
+  effect(USE labl);
+
+  ins_cost(300);
+  format %{ "J$cop  $src1, $src2,  $labl\t# Loop end @ jmpLoopEnd_reg_imm12_long" %}
+  ins_encode %{
+    Register op1 = $src1$$Register;
+    Label*     L = $labl$$label;
+    int     flag = $cop$$cmpcode;
+
+    __ addi_d(AT, R0, $src2$$constant);
+    __ cmp_branch_long(flag, op1, AT, L, true /* signed */);
+  %}
+  ins_pipe( pipe_jump );
+  ins_pc_relative(1);
+%}
+
 instruct  jmpLoopEnd_reg_zero_long(cmpOp cop, mRegI src1, immI_0 zero, label labl) %{
   match(CountedLoopEnd cop (CmpI src1 zero));
   effect(USE labl);
 
   ins_cost(300);
-  format %{ "J$cop  $src1, $zero,  $labl\t# Loop end @ jmpLoopEnd_reg_immI_long" %}
+  format %{ "J$cop  $src1, $zero,  $labl\t# Loop end @ jmpLoopEnd_reg_zero_long" %}
   ins_encode %{
     Register op1 = $src1$$Register;
     Label*     L = $labl$$label;
@@ -5460,6 +5478,24 @@ instruct cmpN_reg_branch_long(cmpOp cmp, mRegN op1, mRegN op2, label labl) %{
   ins_pipe( pipe_alu_branch );
 %}
 
+instruct branchConIU_reg_imm12_long(cmpOp cmp, mRegI src1, immI12 src2, label labl) %{
+  match( If cmp (CmpU src1 src2) );
+  effect(USE labl);
+  format %{ "BR$cmp   $src1, $src2, $labl #@branchConIU_reg_imm12_long" %}
+
+  ins_encode %{
+    Register op1 = $src1$$Register;
+    Label*     L = $labl$$label;
+    int     flag = $cmp$$cmpcode;
+    int       imm = $src2$$constant;
+    __ addi_d(AT, R0, imm);
+    __ cmp_branch_long(flag, op1, AT, L, false /* unsigned*/);
+  %}
+
+  ins_pc_relative(1);
+  ins_pipe( pipe_alu_branch );
+%}
+
 instruct branchConIU_reg_reg_long(cmpOp cmp, mRegI src1, mRegI src2, label labl) %{
   match( If cmp (CmpU src1 src2) );
   effect(USE labl);
@@ -5482,7 +5518,7 @@ instruct branchConIU_reg_reg_long(cmpOp cmp, mRegI src1, mRegI src2, label labl)
 instruct branchConIU_reg_zero_long(cmpOp cmp, mRegI src1, immI_0 zero, label labl) %{
   match( If cmp (CmpU src1 zero) );
   effect(USE labl);
-  format %{ "BR$cmp   $src1, $zero, $labl #@branchConIU_reg_imm_long" %}
+  format %{ "BR$cmp   $src1, $zero, $labl #@branchConIU_reg_zero_long" %}
 
   ins_encode %{
     Register op1 = $src1$$Register;
@@ -5518,7 +5554,7 @@ instruct branchConI_reg_zero_long(cmpOp cmp, mRegI src1, immI_0 zero, label labl
   match( If cmp (CmpI src1 zero) );
   effect(USE labl);
   ins_cost(200);
-  format %{ "BR$cmp   $src1, $zero, $labl #@branchConI_reg_imm_long" %}
+  format %{ "BR$cmp   $src1, $zero, $labl #@branchConI_reg_zero_long" %}
 
   ins_encode %{
     Register op1 = $src1$$Register;

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -258,9 +258,6 @@ class StubGenerator: public StubCodeGenerator {
     __ jalr(A4);
     return_address = __ pc();
 
-    Label common_return;
-    __ bind(common_return);
-
     // store result depending on type (everything that is not
     // T_OBJECT, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
     // n.b. this assumes Java returns an integral result in V0
@@ -323,9 +320,6 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(is_double);
     __ fst_d(FA0, T0, 0);
     __ b(exit);
-
-    StubRoutines::la::set_call_stub_compiled_return(__ pc());
-    __ b(common_return);
 
     return start;
   }

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,8 @@
 // definition. See stubRoutines.hpp for a description on how to
 // extend it.
 
-static bool    returns_to_call_stub(address return_pc){
-  return return_pc == _call_stub_return_address||return_pc == la::get_call_stub_compiled_return();
+static bool returns_to_call_stub(address return_pc){
+  return return_pc == _call_stub_return_address;
 }
 
 enum platform_dependent_constants {
@@ -47,7 +47,6 @@ class la {
   // need to adjust the return back to the call stub to a specialized
   // piece of code that can handle compiled results and cleaning the fpu
   // stack. The variable holds that location.
-  static address _call_stub_compiled_return;
   static address _vector_iota_indices;
   static juint   _crc_table[];
   static address _method_entry_barrier;
@@ -66,8 +65,6 @@ class la {
 
 public:
   // Call back points for traps in compiled code
-  static address get_call_stub_compiled_return()    { return _call_stub_compiled_return; }
-  static void set_call_stub_compiled_return(address ret){ _call_stub_compiled_return = ret; }
   static address vector_iota_indices()              { return _vector_iota_indices; }
 
   static address method_entry_barrier() {

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
 // a description of how to extend it, see the stubRoutines.hpp file.
 
 //find the last fp value
-address StubRoutines::la::_call_stub_compiled_return = NULL;
 address StubRoutines::la::_method_entry_barrier      = NULL;
 address StubRoutines::la::_vector_iota_indices       = NULL;
 address StubRoutines::la::_string_indexof_linear_ll  = NULL;

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -31,6 +31,7 @@
 #include "runtime/java.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "runtime/vm_version.hpp"
+#include "os_linux.hpp"
 #ifdef TARGET_OS_FAMILY_linux
 # include "os_linux.inline.hpp"
 #endif
@@ -419,6 +420,17 @@ void VM_Version::get_processor_features() {
     if (!FLAG_IS_DEFAULT(UseBigIntegerShiftIntrinsic))
       warning("Intrinsic for BigInteger.shiftLeft/Right() employs LASX.");
     FLAG_SET_DEFAULT(UseBigIntegerShiftIntrinsic, false);
+  }
+
+  if (UseActiveCoresMP) {
+    if (os::Linux::sched_active_processor_count() != 1) {
+      if (!FLAG_IS_DEFAULT(UseActiveCoresMP))
+        warning("UseActiveCoresMP disabled because active processors are more than one.");
+      FLAG_SET_DEFAULT(UseActiveCoresMP, false);
+    }
+  } else {
+    if (!os::is_MP())
+      FLAG_SET_DEFAULT(UseActiveCoresMP, true);
   }
 }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -24,8 +24,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2022. These
- * modifications are Copyright (c) 2021, 2022, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2021, 2023, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -2078,6 +2078,12 @@ bool os::Linux::query_process_memory_info(os::Linux::meminfo_t* info) {
     return true;
   }
   return false;
+}
+
+int os::Linux::sched_active_processor_count() {
+  if (OSContainer::is_containerized())
+    return OSContainer::active_processor_count();
+  return os::Linux::active_processor_count();
 }
 
 #ifdef __GLIBC__

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #ifndef OS_LINUX_OS_LINUX_HPP
 #define OS_LINUX_OS_LINUX_HPP
 
@@ -192,6 +198,8 @@ class os::Linux {
   // Stack repair handling
 
   // none present
+
+  static int sched_active_processor_count();
 
  private:
   static void numa_init();

--- a/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,8 @@
 // Included in orderAccess.hpp header file.
 
 // Implementation of class OrderAccess.
-#define inlasm_sync() if (os::is_ActiveCoresMP()) \
-                        __asm__ __volatile__ ("nop"   : : : "memory"); \
-                      else \
-                        __asm__ __volatile__ ("dbar 0"   : : : "memory");
+#define inlasm_sync() if (!UseActiveCoresMP) \
+                       __asm__ __volatile__ ("dbar 0"   : : : "memory");
 #define inlasm_synci() __asm__ __volatile__ ("ibar 0"   : : : "memory");
 
 inline void OrderAccess::loadload()   { inlasm_sync(); }

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -474,8 +474,4 @@ void os::verify_stack_alignment() {
 int os::extra_bang_size_in_bytes() {
   // LA does not require the additional stack bang.
   return 0;
-}
-
-bool os::is_ActiveCoresMP() {
-  return UseActiveCoresMP && _initial_active_processor_count == 1;
 }

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -22,12 +22,6 @@
  *
  */
 
-/*
- * This file has been modified by Loongson Technology in 2022, These
- * modifications are Copyright (c) 2022, Loongson Technology, and are made
- * available on the same license terms set forth above.
- */
-
 #ifndef SHARE_RUNTIME_OS_HPP
 #define SHARE_RUNTIME_OS_HPP
 
@@ -317,9 +311,6 @@ class os: AllStatic {
     // in place until called after initialization has occurred.
     return (_processor_count != 1);
   }
-
-  // Used only on LoongArch64.
-  static bool is_ActiveCoresMP();
 
   static julong available_memory();
   static julong physical_memory();

--- a/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
@@ -729,7 +729,7 @@ public abstract class AbstractThrowingPushPromises implements HttpServerAdapters
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(5000);
         try {
             http2TestServer.stop();
             https2TestServer.stop();

--- a/test/jdk/java/net/httpclient/ByteArrayPublishers.java
+++ b/test/jdk/java/net/httpclient/ByteArrayPublishers.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8222968
  * @summary ByteArrayPublisher is not thread-safe resulting in broken re-use of HttpRequests
- * @run main/othervm ByteArrayPublishers
+ * @run main/othervm -Dsun.net.httpserver.idleInterval=50000 ByteArrayPublishers
  */
 
 import java.net.InetAddress;

--- a/test/jdk/java/net/httpclient/DigestEchoClient.java
+++ b/test/jdk/java/net/httpclient/DigestEchoClient.java
@@ -513,7 +513,7 @@ public class DigestEchoClient {
                 System.gc();
                 if (queue.remove(100) == ref) break;
             }
-            var error = TRACKER.checkShutdown(500);
+            var error = TRACKER.checkShutdown(900);
             if (error != null) throw error;
         }
         System.out.println("OK");

--- a/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
@@ -66,11 +66,13 @@ import java.util.function.Predicate;
  * @run testng/othervm
  *      -Djdk.httpclient.HttpClient.log=frames,ssl,requests,responses,errors
  *      -Djdk.internal.httpclient.debug=true
+ *      -Dsun.net.httpserver.idleInterval=50000
  *      HttpClientLocalAddrTest
  *
  * @run testng/othervm/java.security.policy=httpclient-localaddr-security.policy
  *      -Djdk.httpclient.HttpClient.log=frames,ssl,requests,responses,errors
  *      -Djdk.internal.httpclient.debug=true
+ *      -Dsun.net.httpserver.idleInterval=50000
  *      HttpClientLocalAddrTest
  *
  */

--- a/test/jdk/java/net/httpclient/ManyRequestsLegacy.java
+++ b/test/jdk/java/net/httpclient/ManyRequestsLegacy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,10 @@
  * @compile ../../../com/sun/net/httpserver/LogFilter.java
  * @compile ../../../com/sun/net/httpserver/EchoHandler.java
  * @compile ../../../com/sun/net/httpserver/FileServerHandler.java
- * @run main/othervm/timeout=40 ManyRequestsLegacy
- * @run main/othervm/timeout=40 -Dtest.insertDelay=true ManyRequestsLegacy
- * @run main/othervm/timeout=40 -Dtest.chunkSize=64 ManyRequestsLegacy
- * @run main/othervm/timeout=40 -Dtest.insertDelay=true
+ * @run main/othervm/timeout=80 -Dsun.net.httpserver.idleInterval=50000 ManyRequestsLegacy
+ * @run main/othervm/timeout=80 -Dtest.insertDelay=true -Dsun.net.httpserver.idleInterval=50000 ManyRequestsLegacy
+ * @run main/othervm/timeout=80 -Dtest.chunkSize=64 -Dsun.net.httpserver.idleInterval=50000 ManyRequestsLegacy
+ * @run main/othervm/timeout=80 -Dtest.insertDelay=true -Dsun.net.httpserver.idleInterval=50000
  *                              -Dtest.chunkSize=64 ManyRequestsLegacy
  * @summary Send a large number of requests asynchronously using the legacy
  *          URL.openConnection(), to help sanitize results of the test

--- a/test/jdk/java/net/httpclient/Response204V2Test.java
+++ b/test/jdk/java/net/httpclient/Response204V2Test.java
@@ -291,7 +291,7 @@ public class Response204V2Test implements HttpServerAdapters {
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(5000);
         try {
             http2TestServer.stop();
             https2TestServer.stop();

--- a/test/jdk/java/net/httpclient/SpecialHeadersTest.java
+++ b/test/jdk/java/net/httpclient/SpecialHeadersTest.java
@@ -35,6 +35,7 @@
  * @library /test/lib http2/server
  * @build Http2TestServer HttpServerAdapters SpecialHeadersTest
  * @build jdk.test.lib.net.SimpleSSLContext
+ * @requires (vm.compMode != "Xcomp")
  * @run testng/othervm
  *       -Djdk.httpclient.HttpClient.log=requests,headers,errors
  *       SpecialHeadersTest

--- a/test/jdk/java/net/vthread/HttpALot.java
+++ b/test/jdk/java/net/vthread/HttpALot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@
  *     --enable-preview
  *     -Dsun.net.httpserver.nodelay=true
  *     -Dsun.net.client.defaultConnectTimeout=5000
- *     -Dsun.net.client.defaultReadTimeout=5000
  *     HttpALot
  */
 

--- a/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
+++ b/test/jdk/java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java
@@ -31,6 +31,7 @@ import java.rmi.UnmarshalException;
 import java.rmi.server.UnicastRemoteObject;
 
 import java.util.Objects;
+import java.lang.ref.Reference;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -76,6 +77,7 @@ public class FilterUROTest {
             int count = client.filterCount(obj);
             System.out.printf("count: %d, obj: %s%n", count, obj);
             Assert.assertEquals(count, expectedFilterCount, "wrong number of filter calls");
+            Reference.reachabilityFence(impl);
         } catch (RemoteException rex) {
             if (expectedFilterCount == -1 &&
                     UnmarshalException.class.equals(rex.getCause().getClass()) &&
@@ -103,6 +105,7 @@ public class FilterUROTest {
             int count = client.filterCount(obj);
             System.out.printf("count: %d, obj: %s%n", count, obj);
             Assert.assertEquals(count, expectedFilterCount, "wrong number of filter calls");
+            Reference.reachabilityFence(impl);
         } catch (RemoteException rex) {
             if (expectedFilterCount == -1 &&
                     UnmarshalException.class.equals(rex.getCause().getClass()) &&

--- a/test/jdk/jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java
+++ b/test/jdk/jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -614,7 +614,7 @@ public class StructuredTaskScopeTest {
     public void testInterruptJoinUntil1(ThreadFactory factory) throws Exception {
         try (var scope = new StructuredTaskScope(null, factory)) {
             Future<String> future = scope.fork(() -> {
-                Thread.sleep(Duration.ofMillis(100));
+                Thread.sleep(Duration.ofSeconds(2));
                 return "foo";
             });
 


### PR DESCRIPTION
29437: [C2] Add branch instruct with immI12 for reduce spill_code
28247: 8301942: java/net/httpclient/DigestEchoClientSSL.java fail with -Xcomp
29763: Draw out StubRoutines::la::_call_stub_compiled_return
29546: 8301737: java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java fail with -Xcomp
29524: java/net/httpclient/* fail with -Xcomp
29539: jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java failed with -Xcomp
27906: Inline ActiveCoresMP