### PR TITLE
Update (2023.03.03)

### DIFF
--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1673,18 +1673,4 @@ bool C2_MacroAssembler::in_scratch_emit_size() {
     }
   }
   return MacroAssembler::in_scratch_emit_size();
-}
-
-void C2_MacroAssembler::emit_entry_barrier_stub(C2EntryBarrierStub* stub) {
-  bind(stub->slow_path());
-  call_long(StubRoutines::la::method_entry_barrier());
-  b(stub->continuation());
-
-  bind(stub->guard());
-  relocate(entry_guard_Relocation::spec());
-  emit_int32(0);  // nmethod guard value
-}
-
-int C2_MacroAssembler::entry_barrier_stub_size() {
-  return 5 * 4;
 }

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1860,7 +1860,9 @@ void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     Label dummy_label;
     Label* code_stub = &dummy_label;
     if (!C->output()->in_scratch_emit_size()) {
-      code_stub = &C->output()->safepoint_poll_table()->add_safepoint(__ offset());
+      C2SafepointPollStub* stub = new (C->comp_arena()) C2SafepointPollStub(__ offset());
+      C->output()->add_stub(stub);
+      code_stub = &stub->entry();
     }
     __ relocate(relocInfo::poll_return_type);
     __ safepoint_poll(*code_stub, TREG, true /* at_return */, false /* acquire */, true /* in_nmethod */);
@@ -2108,8 +2110,9 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
       Label* guard = &dummy_guard;
       if (!Compile::current()->output()->in_scratch_emit_size()) {
         // Use real labels from actual stub when not emitting code for purpose of measuring its size
-        C2EntryBarrierStub* stub = Compile::current()->output()->entry_barrier_table()->add_entry_barrier();
-        slow_path = &stub->slow_path();
+        C2EntryBarrierStub* stub = new (Compile::current()->comp_arena()) C2EntryBarrierStub();
+        Compile::current()->output()->add_stub(stub);
+        slow_path = &stub->entry();
         continuation = &stub->continuation();
         guard = &stub->guard();
       }

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -16672,6 +16672,7 @@ instruct storemask16S(vecX dst, vecY src, immI_2 size, vecX tmp) %{
 
 // ----------------------------- VectorTest -----------------------------------
 
+/*
 instruct anytrue_in_maskV16(mRegI dst, vecX src1, vecX src2)
 %{
   predicate(UseCF2GR && static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
@@ -16783,6 +16784,7 @@ instruct alltrue_in_maskV32_indir(mRegI dst, vecY src1, vecY src2, regF tmp)
   %}
   ins_pipe( pipe_slow );
 %}
+*/
 
 // ----------------------------- VectorMaskTrueCount ----------------------------
 

--- a/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
@@ -147,6 +147,16 @@
   // Implements a variant of EncodeISOArrayNode that encode ASCII only
   static const bool supports_encode_ascii_array = true;
 
+  // Some architecture needs a helper to check for alltrue vector
+  static constexpr bool vectortest_needs_second_argument(bool is_alltrue, bool is_predicate) {
+    return false;
+  }
+
+  // BoolTest mask for vector test intrinsics
+  static constexpr BoolTest::mask vectortest_mask(bool is_alltrue, bool is_predicate, int vlen) {
+    return BoolTest::illegal;
+  }
+
   // Returns pre-selection estimated size of a vector operation.
   static int vector_op_pre_select_sz_estimate(int vopc, BasicType ety, int vlen) {
     switch(vopc) {


### PR DESCRIPTION
29668: Delete VectorTest temporarily beacause of 8292289
29667: LA port of 8297036: Generalize C2 stub mechanism