### PR TITLE
Update (2023.03.04)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_Defs_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_Defs_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,10 @@ enum {
 // LoongArch64 where floats and doubles are stored in their native form.
 enum {
   pd_float_saved_as_double = false
+};
+
+enum {
+  pd_two_operand_lir_form = false
 };
 
 #endif // CPU_LOONGARCH_C1_DEFS_LOONGARCH_HPP

--- a/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,5 @@ define_pd_global(bool, UseTypeProfile,               false);
 
 define_pd_global(bool, OptimizeSinglePrecision,      true );
 define_pd_global(bool, CSEArrayLength,               false);
-define_pd_global(bool, TwoOperandLIRForm,            false );
 
 #endif // CPU_LOONGARCH_C1_GLOBALS_LOONGARCH_HPP


### PR DESCRIPTION
29677: LA port of 8283740: C1: Convert flag TwoOperandLIRForm to a constant on all platforms