### PR TITLE
Update (2023.03.06)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
@@ -167,7 +167,9 @@ void BarrierSetAssembler::obj_equals(MacroAssembler* masm,
 
 void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                                         Register obj, Register tmp, Label& slowpath) {
-  __ clear_jweak_tag(obj);
+  STATIC_ASSERT(JNIHandles::tag_mask == 3);
+  __ addi_d(AT, R0, ~(int)JNIHandles::tag_mask);
+  __ andr(obj, obj, AT);
   __ ld_d(obj, Address(obj, 0));
 }
 

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2018, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,7 +261,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
         // instruction patching is synchronized with global icache_flush() by
         // the write hart on riscv. So here we can do a plain conditional
         // branch with no fencing.
-        Address thread_disarmed_addr(TREG, in_bytes(bs_nm->thread_disarmed_offset()));
+        Address thread_disarmed_addr(TREG, in_bytes(bs_nm->thread_disarmed_guard_value_offset()));
         __ ld_wu(SCR2, thread_disarmed_addr);
         break;
       }
@@ -286,7 +286,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
         __ slli_d(SCR2, SCR2, 32);
         __ orr(SCR1, SCR1, SCR2);
         // Compare the global values with the thread-local values
-        Address thread_disarmed_and_epoch_addr(TREG, in_bytes(bs_nm->thread_disarmed_offset()));
+        Address thread_disarmed_and_epoch_addr(TREG, in_bytes(bs_nm->thread_disarmed_guard_value_offset()));
         __ ld_d(SCR2, thread_disarmed_and_epoch_addr);
         break;
       }

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetNMethod_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetNMethod_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2019, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,33 +161,12 @@ static NativeNMethodBarrier* native_nmethod_barrier(nmethod* nm) {
   return barrier;
 }
 
-void BarrierSetNMethod::disarm(nmethod* nm) {
+void BarrierSetNMethod::set_guard_value(nmethod* nm, int value) {
   if (!supports_entry_barrier(nm)) {
     return;
   }
 
-  // The patching epoch is incremented before the nmethod is disarmed. Disarming
-  // is performed with a release store. In the nmethod entry barrier, the values
-  // are read in the opposite order, such that the load of the nmethod guard
-  // acquires the patching epoch. This way, the guard is guaranteed to block
-  // entries to the nmethod, util it has safely published the requirement for
-  // further fencing by mutators, before they are allowed to enter.
-  BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs_asm->increment_patching_epoch();
-
-  // Disarms the nmethod guard emitted by BarrierSetAssembler::nmethod_entry_barrier.
-  // Symmetric "LD.W; DBAR" is in the nmethod barrier.
-  NativeNMethodBarrier* barrier = native_nmethod_barrier(nm);
-
-  barrier->set_value(nm, disarmed_value());
-}
-
-void BarrierSetNMethod::arm(nmethod* nm, int arm_value) {
-  if (!supports_entry_barrier(nm)) {
-    return;
-  }
-
-  if (arm_value == disarmed_value()) {
+  if (value == disarmed_guard_value()) {
     // The patching epoch is incremented before the nmethod is disarmed. Disarming
     // is performed with a release store. In the nmethod entry barrier, the values
     // are read in the opposite order, such that the load of the nmethod guard
@@ -199,14 +178,14 @@ void BarrierSetNMethod::arm(nmethod* nm, int arm_value) {
   }
 
   NativeNMethodBarrier* barrier = native_nmethod_barrier(nm);
-  barrier->set_value(nm, arm_value);
+  barrier->set_value(nm, value);
 }
 
-bool BarrierSetNMethod::is_armed(nmethod* nm) {
+int BarrierSetNMethod::guard_value(nmethod* nm) {
   if (!supports_entry_barrier(nm)) {
-    return false;
+    return disarmed_guard_value();
   }
 
   NativeNMethodBarrier* barrier = native_nmethod_barrier(nm);
-  return barrier->get_value(nm) != disarmed_value();
+  return barrier->get_value(nm);
 }

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -2053,7 +2053,7 @@ void MachPrologNode::format( PhaseRegAlloc *ra_, outputStream* st ) const {
     st->print("\n\t");
     st->print("ld_d  T1, guard, 0\n\t");
     st->print("dbar  0\n\t");
-    st->print("ld_d  T2, TREG, thread_disarmed_offset\n\t");
+    st->print("ld_d  T2, TREG, thread_disarmed_guard_value_offset\n\t");
     st->print("beq   T1, T2, skip\n\t");
     st->print("\n\t");
     st->print("jalr  #nmethod_entry_barrier_stub\n\t");

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -237,8 +237,8 @@ class MacroAssembler: public Assembler {
   void reset_last_Java_frame(bool clear_fp);
 
   // jobjects
-  void clear_jweak_tag(Register possibly_jweak);
   void resolve_jobject(Register value, Register thread, Register tmp);
+  void resolve_global_jobject(Register value, Register tmp1, Register tmp2);
 
   // C 'boolean' to Java boolean: x == 0 ? 0 : 1
   void c2bool(Register x);

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -3120,7 +3120,7 @@ class StubGenerator: public StubCodeGenerator {
 
     if (bs_asm->nmethod_patching_type() == NMethodPatchingType::conc_instruction_and_data_patch) {
       BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-      Address thread_epoch_addr(TREG, in_bytes(bs_nm->thread_disarmed_offset()) + 4);
+      Address thread_epoch_addr(TREG, in_bytes(bs_nm->thread_disarmed_guard_value_offset()) + 4);
       __ lea(SCR1, ExternalAddress(bs_asm->patching_epoch_addr()));
       __ ld_wu(SCR1, SCR1, 0);
       __ st_w(SCR1, thread_epoch_addr);

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -4936,17 +4936,9 @@ class StubGenerator: public StubCodeGenerator {
     __ move(c_rarg0, TREG);
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::write_checkpoint), 1);
     __ reset_last_Java_frame(true);
-
     // A0 is jobject handle result, unpack and process it through a barrier.
-    Label null_jobject;
-    __ beqz(A0, null_jobject);
-
-    DecoratorSet decorators = ACCESS_READ | IN_NATIVE;
-    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
     // For zBarrierSet, tmp1 shall not be SCR1 or same as dst
-    bs->load_at(_masm, decorators, T_OBJECT, A0, Address(A0, 0), /* tmp1 */ SCR2, noreg);
-
-    __ bind(null_jobject);
+    __ resolve_global_jobject(A0, SCR2, noreg);
 
     __ leave();
     __ jr(RA);


### PR DESCRIPTION
29691: LA port of 8299089: Instrument global jni handles with tag to make them distinguishable
29690: LA port of 8299312: Clean up BarrierSetNMethod