### PR TITLE
Update (2023.03.07)

### DIFF
--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,6 @@
 // C2_MacroAssembler contains high-level macros for C2
 
 public:
-  void emit_entry_barrier_stub(C2EntryBarrierStub* stub);
-  static int entry_barrier_stub_size();
-
   void cmp_branch_short(int flag, Register op1, Register op2, Label& L, bool is_signed);
   void cmp_branch_long(int flag, Register op1, Register op2, Label* L, bool is_signed);
   void cmp_branchEqNe_off21(int flag, Register op1, Label& L);

--- a/src/hotspot/cpu/loongarch/continuationFreezeThaw_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/continuationFreezeThaw_loongarch.inline.hpp
@@ -145,6 +145,7 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
 
   // at(frame::interpreter_frame_last_sp_offset) can be NULL at safepoint preempts
   *hf.addr_at(frame::interpreter_frame_last_sp_offset) = hf.unextended_sp() - hf.fp();
+  // this line can be changed into an assert when we have fixed the "frame padding problem", see JDK-8300197
   *hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + f.interpreter_frame_method()->max_locals() - 1;
 
   relativize_one(vfp, hfp, frame::interpreter_frame_initial_sp_offset); // == block_top == block_bottom
@@ -219,12 +220,12 @@ template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame&
     assert(frame_sp == unextended_sp, "");
     caller.set_sp(fp + frame::sender_sp_offset);
     frame f(frame_sp, frame_sp, fp, hf.pc());
-    // it's set again later in set_interpreter_frame_bottom, but we need to set the locals now so that
-    // we could call ContinuationHelper::InterpretedFrame::frame_bottom
+    // we need to set the locals so that the caller of new_stack_frame() can call
+    // ContinuationHelper::InterpretedFrame::frame_bottom
     intptr_t offset = *hf.addr_at(frame::interpreter_frame_locals_offset);
     assert((int)offset == frame::sender_sp_offset + locals - 1, "");
-    // derelativize locals
-    *(intptr_t**)f.addr_at(frame::interpreter_frame_locals_offset) = fp + offset;
+    // set relativized locals
+    *f.addr_at(frame::interpreter_frame_locals_offset) = offset;
     return f;
   } else {
     int fsize = FKind::size(hf);
@@ -285,7 +286,9 @@ inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, c
 }
 
 inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
-  *(intptr_t**)f.addr_at(frame::interpreter_frame_locals_offset) = bottom - 1;
+  // set relativized locals
+  // This line can be changed into an assert when we have fixed the "frame padding problem", see JDK-8300197
+  *f.addr_at(frame::interpreter_frame_locals_offset) = (bottom - 1) - f.fp();
 }
 
 #endif // CPU_LOONGARCH_CONTINUATIONFREEZETHAW_LOONGARCH_INLINE_HPP

--- a/src/hotspot/cpu/loongarch/continuationHelper_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/continuationHelper_loongarch.inline.hpp
@@ -131,7 +131,7 @@ inline intptr_t* ContinuationHelper::InterpretedFrame::frame_top(const frame& f,
 }
 
 inline intptr_t* ContinuationHelper::InterpretedFrame::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
-  return (intptr_t*)f.at(frame::interpreter_frame_locals_offset) + 1; // exclusive, so we add 1 word
+  return (intptr_t*)f.at_relative(frame::interpreter_frame_locals_offset) + 1; // exclusive, so we add 1 word
 }
 
 inline intptr_t* ContinuationHelper::InterpretedFrame::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {

--- a/src/hotspot/cpu/loongarch/frame_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -289,6 +289,13 @@ intptr_t* frame::entry_frame_argument_at(int offset) const {
   return &unextended_sp()[index];
 }
 
+// locals
+void frame::interpreter_frame_set_locals(intptr_t* locs)  {
+  assert(is_interpreted_frame(), "interpreted frame expected");
+  // set relativized locals
+  ptr_at_put(interpreter_frame_locals_offset, (intptr_t) (locs - fp()));
+}
+
 // sender_sp
 intptr_t* frame::interpreter_frame_sender_sp() const {
   assert(is_interpreted_frame(), "interpreted frame expected");
@@ -498,7 +505,7 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   }
 
   // validate locals
-  address locals = (address) *interpreter_frame_locals_addr();
+  address locals = (address)interpreter_frame_locals();
   if (locals > thread->stack_base() /*|| locals < (address) fp() */) {
     return false;
   }

--- a/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -245,8 +245,9 @@ inline address* frame::sender_pc_addr() const     { return (address*) addr_at(re
 inline address  frame::sender_pc() const          { return *sender_pc_addr(); }
 inline intptr_t* frame::sender_sp() const         { return addr_at(sender_sp_offset); }
 
-inline intptr_t** frame::interpreter_frame_locals_addr() const {
-  return (intptr_t**)addr_at(interpreter_frame_locals_offset);
+inline intptr_t* frame::interpreter_frame_locals() const {
+  intptr_t n = *addr_at(interpreter_frame_locals_offset);
+  return &fp()[n]; // return relativized locals
 }
 
 inline intptr_t* frame::interpreter_frame_last_sp() const {

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
@@ -83,6 +83,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
   void restore_locals() {
     ld_d(LVP, FP, frame::interpreter_frame_locals_offset * wordSize);
+    alsl_d(LVP, LVP, FP, LogBytesPerWord-1);
   }
 
   void get_dispatch();

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1303,6 +1303,14 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   __ bind(pinned); // pinned -- return to caller
 
+  // handle pending exception thrown by freeze
+  __ ld_d(AT, Address(TREG, in_bytes(Thread::pending_exception_offset())));
+  Label ok;
+  __ beqz(AT, ok);
+  __ leave();
+  __ jmp(StubRoutines::forward_exception_entry(), relocInfo::runtime_call_type);
+  __ bind(ok);
+
   __ leave();
   __ jr(RA);
 

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -864,7 +864,10 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
   __ addi_d(FP, SP, (frame_size) * wordSize);
   __ st_d(Rsender, FP, (-++i) * wordSize);  // save sender's sp
   __ st_d(R0, FP,(-++i) * wordSize);       //save last_sp as null
-  __ st_d(LVP, FP, (-++i) * wordSize);  // save locals offset
+  __ sub_d(AT, LVP, FP);
+  __ srli_d(AT, AT, Interpreter::logStackElementSize);
+  // Store relativized LVP, see frame::interpreter_frame_locals().
+  __ st_d(AT, FP, (-++i) * wordSize);  // save locals offset
   __ ld_d(BCP, Rmethod, in_bytes(Method::const_offset())); // get constMethodOop
   __ addi_d(BCP, BCP, in_bytes(ConstMethod::codes_offset())); // get codebase
   __ st_d(Rmethod, FP, (-++i) * wordSize);                              // save Method*

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/loongarch64/LOONGARCH64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/loongarch64/LOONGARCH64Frame.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2001, 2015, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2018, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -411,7 +411,8 @@ public class LOONGARCH64Frame extends Frame {
   }
 
   public Address addressOfInterpreterFrameLocals() {
-    return addressOfStackSlot(INTERPRETER_FRAME_LOCALS_OFFSET);
+    long n = addressOfStackSlot(INTERPRETER_FRAME_LOCALS_OFFSET).getCIntegerAt(0, VM.getVM().getAddressSize(), false);
+    return getFP().addOffsetTo(n * VM.getVM().getAddressSize());
   }
 
   private Address addressOfInterpreterFrameBCX() {


### PR DESCRIPTION
29715: LA port of 8301346: Remove dead emit_entry_barrier_stub definition
29714: LA port of 8299795: Relativize locals in interpreter frames
29713: LA port of 8298400: Virtual thread instability when stack overflows