### PR TITLE
Update (2023.05.17)

### DIFF
--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -13430,11 +13430,10 @@ instruct div4D(vecY dst, vecY src1, vecY src2) %{
 instruct abs16B(vecX dst, vecX src) %{
   predicate(Matcher::vector_length(n) == 16);
   match(Set dst (AbsVB src));
-  effect(TEMP_DEF dst);
   format %{ "vabs    $dst, $src\t# @abs16B" %}
   ins_encode %{
-    __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ vabsd_b($dst$$FloatRegister, $src$$FloatRegister, $dst$$FloatRegister);
+    __ vxor_v(fscratch, fscratch, fscratch);
+    __ vabsd_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13442,11 +13441,10 @@ instruct abs16B(vecX dst, vecX src) %{
 instruct abs8S(vecX dst, vecX src) %{
   predicate(Matcher::vector_length(n) == 8);
   match(Set dst (AbsVS src));
-  effect(TEMP_DEF dst);
   format %{ "vabs    $dst, $src\t# @abs8S" %}
   ins_encode %{
-    __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ vabsd_h($dst$$FloatRegister, $src$$FloatRegister, $dst$$FloatRegister);
+    __ vxor_v(fscratch, fscratch, fscratch);
+    __ vabsd_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13454,11 +13452,10 @@ instruct abs8S(vecX dst, vecX src) %{
 instruct abs4I(vecX dst, vecX src) %{
   predicate(Matcher::vector_length(n) == 4);
   match(Set dst (AbsVI src));
-  effect(TEMP_DEF dst);
   format %{ "vabs    $dst, $src\t# @abs4I" %}
   ins_encode %{
-    __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ vabsd_w($dst$$FloatRegister, $src$$FloatRegister, $dst$$FloatRegister);
+    __ vxor_v(fscratch, fscratch, fscratch);
+    __ vabsd_w($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13466,11 +13463,10 @@ instruct abs4I(vecX dst, vecX src) %{
 instruct abs2L(vecX dst, vecX src) %{
   predicate(Matcher::vector_length(n) == 2);
   match(Set dst (AbsVL src));
-  effect(TEMP_DEF dst);
   format %{ "vabs    $dst, $src\t# @abs2L" %}
   ins_encode %{
-    __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ vabsd_d($dst$$FloatRegister, $src$$FloatRegister, $dst$$FloatRegister);
+    __ vxor_v(fscratch, fscratch, fscratch);
+    __ vabsd_d($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13498,11 +13494,10 @@ instruct abs2D(vecX dst, vecX src) %{
 instruct abs32B(vecY dst, vecY src) %{
   predicate(Matcher::vector_length(n) == 32);
   match(Set dst (AbsVB src));
-  effect(TEMP_DEF dst);
   format %{ "xvabs    $dst, $src\t# @abs32B" %}
   ins_encode %{
-    __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ xvabsd_b($dst$$FloatRegister, $src$$FloatRegister, $dst$$FloatRegister);
+    __ xvxor_v(fscratch, fscratch, fscratch);
+    __ xvabsd_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13510,11 +13505,10 @@ instruct abs32B(vecY dst, vecY src) %{
 instruct abs16S(vecY dst, vecY src) %{
   predicate(Matcher::vector_length(n) == 16);
   match(Set dst (AbsVS src));
-  effect(TEMP_DEF dst);
   format %{ "xvabs    $dst, $src\t# @abs16S" %}
   ins_encode %{
-    __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ xvabsd_h($dst$$FloatRegister, $src$$FloatRegister, $dst$$FloatRegister);
+    __ xvxor_v(fscratch, fscratch, fscratch);
+    __ xvabsd_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13522,11 +13516,10 @@ instruct abs16S(vecY dst, vecY src) %{
 instruct abs8I(vecY dst, vecY src) %{
   predicate(Matcher::vector_length(n) == 8);
   match(Set dst (AbsVI src));
-  effect(TEMP_DEF dst);
   format %{ "xvabs    $dst, $src\t# @abs8I" %}
   ins_encode %{
-    __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ xvabsd_w($dst$$FloatRegister, $src$$FloatRegister, $dst$$FloatRegister);
+    __ xvxor_v(fscratch, fscratch, fscratch);
+    __ xvabsd_w($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13534,11 +13527,10 @@ instruct abs8I(vecY dst, vecY src) %{
 instruct abs4L(vecY dst, vecY src) %{
   predicate(Matcher::vector_length(n) == 4);
   match(Set dst (AbsVL src));
-  effect(TEMP_DEF dst);
   format %{ "xvabs    $dst, $src\t# @abs4L" %}
   ins_encode %{
-    __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ xvabsd_d($dst$$FloatRegister, $src$$FloatRegister, $dst$$FloatRegister);
+    __ xvxor_v(fscratch, fscratch, fscratch);
+    __ xvabsd_d($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13647,32 +13639,32 @@ instruct max2L(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct max4F(vecX dst, vecX src1, vecX src2, vecX tmp1, vecX tmp2) %{
+instruct max4F(vecX dst, vecX src1, vecX src2, vecX tmp) %{
   predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (MaxV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "vfmax    $dst, $src1, $src2\t# TEMP($tmp1, $tmp2) @max4F" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "vfmax    $dst, $src1, $src2\t# TEMP($tmp) @max4F" %}
   ins_encode %{
     __ vfmax_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vxor_v($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ vfdiv_s($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ vfcmp_cun_s($tmp2$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ vfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ vfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct max2D(vecX dst, vecX src1, vecX src2, vecX tmp1, vecX tmp2) %{
+instruct max2D(vecX dst, vecX src1, vecX src2, vecX tmp) %{
   predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MaxV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "vfmax    $dst, $src1, $src2\t# TEMP($tmp1, $tmp2) @max2D" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "vfmax    $dst, $src1, $src2\t# TEMP($tmp) @max2D" %}
   ins_encode %{
     __ vfmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vxor_v($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ vfdiv_d($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ vfcmp_cun_d($tmp2$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ vfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ vfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13717,32 +13709,32 @@ instruct max4L(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct max8F(vecY dst, vecY src1, vecY src2, vecY tmp1, vecY tmp2) %{
+instruct max8F(vecY dst, vecY src1, vecY src2, vecY tmp) %{
   predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (MaxV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "xvfmax    $dst, $src1, $src2\t# TEMP($tmp1, $tmp2) @max8F" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "xvfmax    $dst, $src1, $src2\t# TEMP($tmp) @max8F" %}
   ins_encode %{
     __ xvfmax_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvxor_v($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ xvfdiv_s($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ xvfcmp_cun_s($tmp2$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ xvfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ xvfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct max4D(vecY dst, vecY src1, vecY src2, vecY tmp1, vecY tmp2) %{
+instruct max4D(vecY dst, vecY src1, vecY src2, vecY tmp) %{
   predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MaxV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "xvfmax    $dst, $src1, $src2\t# TEMP($tmp1, $tmp2) @max4D" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "xvfmax    $dst, $src1, $src2\t# TEMP($tmp) @max4D" %}
   ins_encode %{
     __ xvfmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvxor_v($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ xvfdiv_d($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ xvfcmp_cun_d($tmp2$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ xvfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ xvfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13789,32 +13781,32 @@ instruct min2L(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct min4F(vecX dst, vecX src1, vecX src2, vecX tmp1, vecX tmp2) %{
+instruct min4F(vecX dst, vecX src1, vecX src2, vecX tmp) %{
   predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (MinV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "vfmin    $dst, $src1, $src2\t# TEMP($tmp1, $tmp2) @min4F" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "vfmin    $dst, $src1, $src2\t# TEMP($tmp) @min4F" %}
   ins_encode %{
     __ vfmin_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vxor_v($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ vfdiv_s($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ vfcmp_cun_s($tmp2$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ vfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ vfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct min2D(vecX dst, vecX src1, vecX src2, vecX tmp1, vecX tmp2) %{
+instruct min2D(vecX dst, vecX src1, vecX src2, vecX tmp) %{
   predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MinV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "vfmin    $dst, $src1, $src2\t# TEMP($tmp1, $tmp2) @min2D" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "vfmin    $dst, $src1, $src2\t# TEMP($tmp) @min2D" %}
   ins_encode %{
     __ vfmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vxor_v($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ vfdiv_d($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ vfcmp_cun_d($tmp2$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ vfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ vfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -13859,32 +13851,32 @@ instruct min4L(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct min8F(vecY dst, vecY src1, vecY src2, vecY tmp1, vecY tmp2) %{
+instruct min8F(vecY dst, vecY src1, vecY src2, vecY tmp) %{
   predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (MinV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "xvfmin    $dst, $src1, $src2\t# TEMP($tmp1, $tmp2) @min8F" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "xvfmin    $dst, $src1, $src2\t# TEMP($tmp) @min8F" %}
   ins_encode %{
     __ xvfmin_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvxor_v($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ xvfdiv_s($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ xvfcmp_cun_s($tmp2$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ xvfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ xvfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct min4D(vecY dst, vecY src1, vecY src2, vecY tmp1, vecY tmp2) %{
+instruct min4D(vecY dst, vecY src1, vecY src2, vecY tmp) %{
   predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MinV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "xvfmin    $dst, $src1, $src2\t# TEMP($tmp1, $tmp2) @min4D" %}
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "xvfmin    $dst, $src1, $src2\t# TEMP($tmp) @min4D" %}
   ins_encode %{
     __ xvfmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvxor_v($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ xvfdiv_d($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ xvfcmp_cun_d($tmp2$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister);
+    __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ xvfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ xvfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14407,30 +14399,28 @@ instruct nmsub4D(vecY dst, vecY src1, vecY src2, vecY src3) %{
 
 // --------------- Vector Multiply-Add Shorts into Integer --------------------
 
-instruct muladd8Sto4I(vecX dst, vecX src1, vecX src2, vecX tmp) %{
+instruct muladd8Sto4I(vecX dst, vecX src1, vecX src2) %{
   predicate(Matcher::vector_length(n->in(1)) == 8 && Matcher::vector_element_basic_type(n->in(1)) == T_SHORT);
   match(Set dst (MulAddVS2VI src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "muladdvs2vi    $dst, $src1, $src2\t# TEMP($tmp) @muladd8Sto4I" %}
+  format %{ "muladdvs2vi    $dst, $src1, $src2\t# @muladd8Sto4I" %}
   ins_encode %{
     DEBUG_ONLY(Unimplemented()); // unverified
-    __ vmulwev_w_h($tmp$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ vmulwev_w_h(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
     __ vmulwod_w_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vadd_w($dst$$FloatRegister, $tmp$$FloatRegister, $dst$$FloatRegister);
+    __ vadd_w($dst$$FloatRegister, fscratch, $dst$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct muladd16Sto8I(vecY dst, vecY src1, vecY src2, vecY tmp) %{
+instruct muladd16Sto8I(vecY dst, vecY src1, vecY src2) %{
   predicate(Matcher::vector_length(n->in(1)) == 16 && Matcher::vector_element_basic_type(n->in(1)) == T_SHORT);
   match(Set dst (MulAddVS2VI src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "muladdvs2vi    $dst, $src1, $src2\t# TEMP($tmp) @muladd16Sto8I" %}
+  format %{ "muladdvs2vi    $dst, $src1, $src2\t# @muladd16Sto8I" %}
   ins_encode %{
     DEBUG_ONLY(Unimplemented()); // unverified
-    __ xvmulwev_w_h($tmp$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ xvmulwev_w_h(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
     __ xvmulwod_w_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvadd_w($dst$$FloatRegister, $tmp$$FloatRegister, $dst$$FloatRegister);
+    __ xvadd_w($dst$$FloatRegister, fscratch, $dst$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14461,15 +14451,14 @@ instruct shiftcntY(vecY dst, mRegI cnt) %{
 
 // ------------------------------ LeftShift -----------------------------------
 
-instruct sll16B(vecX dst, vecX src, vecX shift, vecX tmp) %{
+instruct sll16B(vecX dst, vecX src, vecX shift) %{
   predicate(Matcher::vector_length(n) == 16);
   match(Set dst (LShiftVB src shift));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vsll    $dst, $src, $shift\t# TEMP($tmp) @sll16B" %}
+  format %{ "vsll    $dst, $src, $shift\t# @sll16B" %}
   ins_encode %{
-    __ vsll_b($tmp$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
+    __ vsll_b(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
     __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister);
+    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14488,15 +14477,14 @@ instruct sll16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct sll8S(vecX dst, vecX src, vecX shift, vecX tmp) %{
+instruct sll8S(vecX dst, vecX src, vecX shift) %{
   predicate(Matcher::vector_length(n) == 8);
   match(Set dst (LShiftVS src shift));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vsll    $dst, $src, $shift\t# TEMP($tmp) @sll8S" %}
+  format %{ "vsll    $dst, $src, $shift\t# @sll8S" %}
   ins_encode %{
-    __ vsll_h($tmp$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
+    __ vsll_h(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
     __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister);
+    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14555,15 +14543,14 @@ instruct sll2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct sll32B(vecY dst, vecY src, vecY shift, vecY tmp) %{
+instruct sll32B(vecY dst, vecY src, vecY shift) %{
   predicate(Matcher::vector_length(n) == 32);
   match(Set dst (LShiftVB src shift));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "xvsll    $dst, $src, $shift\t# TEMP($tmp) @sll32B" %}
+  format %{ "xvsll    $dst, $src, $shift\t# @sll32B" %}
   ins_encode %{
-    __ xvsll_b($tmp$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
+    __ xvsll_b(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
     __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister);
+    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14582,15 +14569,14 @@ instruct sll32B_imm(vecY dst, vecY src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct sll16S(vecY dst, vecY src, vecY shift, vecY tmp) %{
+instruct sll16S(vecY dst, vecY src, vecY shift) %{
   predicate(Matcher::vector_length(n) == 16);
   match(Set dst (LShiftVS src shift));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "xvsll    $dst, $src, $shift\t# TEMP($tmp) @sll16S" %}
+  format %{ "xvsll    $dst, $src, $shift\t# @sll16S" %}
   ins_encode %{
-    __ xvsll_h($tmp$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
+    __ xvsll_h(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
     __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister);
+    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14651,15 +14637,14 @@ instruct sll4L_imm(vecY dst, vecY src, immI shift) %{
 
 // ----------------------- LogicalRightShift ----------------------------------
 
-instruct srl16B(vecX dst, vecX src, vecX shift, vecX tmp) %{
+instruct srl16B(vecX dst, vecX src, vecX shift) %{
   predicate(Matcher::vector_length(n) == 16);
   match(Set dst (URShiftVB src shift));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vsrl    $dst, $src, $shift\t# TEMP($tmp) @srl16B" %}
+  format %{ "vsrl    $dst, $src, $shift\t# @srl16B" %}
   ins_encode %{
-    __ vsrl_b($tmp$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
+    __ vsrl_b(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
     __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister);
+    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14678,15 +14663,14 @@ instruct srl16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct srl8S(vecX dst, vecX src, vecX shift, vecX tmp) %{
+instruct srl8S(vecX dst, vecX src, vecX shift) %{
   predicate(Matcher::vector_length(n) == 8);
   match(Set dst (URShiftVS src shift));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vsrl    $dst, $src, $shift\t# TEMP($tmp) @srl8S" %}
+  format %{ "vsrl    $dst, $src, $shift\t# @srl8S" %}
   ins_encode %{
-    __ vsrl_h($tmp$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
+    __ vsrl_h(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
     __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister);
+    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14745,15 +14729,14 @@ instruct srl2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct srl32B(vecY dst, vecY src, vecY shift, vecY tmp) %{
+instruct srl32B(vecY dst, vecY src, vecY shift) %{
   predicate(Matcher::vector_length(n) == 32);
   match(Set dst (URShiftVB src shift));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "xvsrl    $dst, $src, $shift\t# TEMP($tmp) @srl32B" %}
+  format %{ "xvsrl    $dst, $src, $shift\t# @srl32B" %}
   ins_encode %{
-    __ xvsrl_b($tmp$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
+    __ xvsrl_b(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
     __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister);
+    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14772,15 +14755,14 @@ instruct srl32B_imm(vecY dst, vecY src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct srl16S(vecY dst, vecY src, vecY shift, vecY tmp) %{
+instruct srl16S(vecY dst, vecY src, vecY shift) %{
   predicate(Matcher::vector_length(n) == 16);
   match(Set dst (URShiftVS src shift));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "xvsrl    $dst, $src, $shift\t# TEMP($tmp) @srl16S" %}
+  format %{ "xvsrl    $dst, $src, $shift\t# @srl16S" %}
   ins_encode %{
-    __ xvsrl_h($tmp$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
+    __ xvsrl_h(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
     __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister);
+    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14841,15 +14823,14 @@ instruct srl4L_imm(vecY dst, vecY src, immI shift) %{
 
 // ------------------------- ArithmeticRightShift -----------------------------
 
-instruct sra16B(vecX dst, vecX src, vecX shift, vecX tmp) %{
+instruct sra16B(vecX dst, vecX src, vecX shift) %{
   predicate(Matcher::vector_length(n) == 16);
   match(Set dst (RShiftVB src shift));
-  effect(TEMP tmp);
-  format %{ "vsra    $dst, $src, $shift\t# TEMP($tmp) @sra16B" %}
+  format %{ "vsra    $dst, $src, $shift\t# @sra16B" %}
   ins_encode %{
-    __ vslti_bu($tmp$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ vorn_v($tmp$$FloatRegister, $shift$$FloatRegister, $tmp$$FloatRegister);
-    __ vsra_b($dst$$FloatRegister, $src$$FloatRegister, $tmp$$FloatRegister);
+    __ vslti_bu(fscratch, $shift$$FloatRegister, 0x8);
+    __ vorn_v(fscratch, $shift$$FloatRegister, fscratch);
+    __ vsra_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14868,15 +14849,14 @@ instruct sra16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct sra8S(vecX dst, vecX src, vecX shift, vecX tmp) %{
+instruct sra8S(vecX dst, vecX src, vecX shift) %{
   predicate(Matcher::vector_length(n) == 8);
   match(Set dst (RShiftVS src shift));
-  effect(TEMP tmp);
-  format %{ "vsra    $dst, $src, $shift\t# TEMP($tmp) @sra8S" %}
+  format %{ "vsra    $dst, $src, $shift\t# @sra8S" %}
   ins_encode %{
-    __ vslti_bu($tmp$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ vorn_v($tmp$$FloatRegister, $shift$$FloatRegister, $tmp$$FloatRegister);
-    __ vsra_h($dst$$FloatRegister, $src$$FloatRegister, $tmp$$FloatRegister);
+    __ vslti_bu(fscratch, $shift$$FloatRegister, 0x10);
+    __ vorn_v(fscratch, $shift$$FloatRegister, fscratch);
+    __ vsra_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14935,15 +14915,14 @@ instruct sra2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct sra32B(vecY dst, vecY src, vecY shift, vecY tmp) %{
+instruct sra32B(vecY dst, vecY src, vecY shift) %{
   predicate(Matcher::vector_length(n) == 32);
   match(Set dst (RShiftVB src shift));
-  effect(TEMP tmp);
-  format %{ "xvsra    $dst, $src, $shift\t# TEMP($tmp) @sra32B" %}
+  format %{ "xvsra    $dst, $src, $shift\t# @sra32B" %}
   ins_encode %{
-    __ xvslti_bu($tmp$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ xvorn_v($tmp$$FloatRegister, $shift$$FloatRegister, $tmp$$FloatRegister);
-    __ xvsra_b($dst$$FloatRegister, $src$$FloatRegister, $tmp$$FloatRegister);
+    __ xvslti_bu(fscratch, $shift$$FloatRegister, 0x8);
+    __ xvorn_v(fscratch, $shift$$FloatRegister, fscratch);
+    __ xvsra_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14962,15 +14941,14 @@ instruct sra32B_imm(vecY dst, vecY src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct sra16S(vecY dst, vecY src, vecY shift, vecY tmp) %{
+instruct sra16S(vecY dst, vecY src, vecY shift) %{
   predicate(Matcher::vector_length(n) == 16);
   match(Set dst (RShiftVS src shift));
-  effect(TEMP tmp);
-  format %{ "xvsra    $dst, $src, $shift\t# TEMP($tmp) @sra16S" %}
+  format %{ "xvsra    $dst, $src, $shift\t# @sra16S" %}
   ins_encode %{
-    __ xvslti_bu($tmp$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ xvorn_v($tmp$$FloatRegister, $shift$$FloatRegister, $tmp$$FloatRegister);
-    __ xvsra_h($dst$$FloatRegister, $src$$FloatRegister, $tmp$$FloatRegister);
+    __ xvslti_bu(fscratch, $shift$$FloatRegister, 0x10);
+    __ xvorn_v(fscratch, $shift$$FloatRegister, fscratch);
+    __ xvsra_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -15113,14 +15091,13 @@ instruct rotr4L_imm(vecY dst, vecY src, immI shift) %{
 
 // ------------------------------ RotateLeftV ---------------------------------
 
-instruct rotl4I(vecX dst, vecX src, vecX shift, vecX tmp) %{
+instruct rotl4I(vecX dst, vecX src, vecX shift) %{
   predicate(Matcher::vector_length(n) == 4);
   match(Set dst (RotateLeftV src shift));
-  effect(TEMP tmp);
-  format %{ "vrotl    $dst, $src, $shift\t# TEMP($tmp) @rotl4I" %}
+  format %{ "vrotl    $dst, $src, $shift\t# @rotl4I" %}
   ins_encode %{
-    __ vneg_w($tmp$$FloatRegister, $shift$$FloatRegister);
-    __ vrotr_w($dst$$FloatRegister, $src$$FloatRegister, $tmp$$FloatRegister);
+    __ vneg_w(fscratch, $shift$$FloatRegister);
+    __ vrotr_w($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -15135,14 +15112,13 @@ instruct rotl4I_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rotl2L(vecX dst, vecX src, vecX shift, vecX tmp) %{
+instruct rotl2L(vecX dst, vecX src, vecX shift) %{
   predicate(Matcher::vector_length(n) == 2);
   match(Set dst (RotateLeftV src shift));
-  effect(TEMP tmp);
-  format %{ "vrotl    $dst, $src, $shift\t# TEMP($tmp) @rotl2L" %}
+  format %{ "vrotl    $dst, $src, $shift\t# @rotl2L" %}
   ins_encode %{
-    __ vneg_d($tmp$$FloatRegister, $shift$$FloatRegister);
-    __ vrotr_d($dst$$FloatRegister, $src$$FloatRegister, $tmp$$FloatRegister);
+    __ vneg_d(fscratch, $shift$$FloatRegister);
+    __ vrotr_d($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -15157,14 +15133,13 @@ instruct rotl2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rotl8I(vecY dst, vecY src, vecY shift, vecY tmp) %{
+instruct rotl8I(vecY dst, vecY src, vecY shift) %{
   predicate(Matcher::vector_length(n) == 8);
   match(Set dst (RotateLeftV src shift));
-  effect(TEMP tmp);
-  format %{ "xvrotl    $dst, $src, $shift\t# TEMP($tmp) @rotl8I" %}
+  format %{ "xvrotl    $dst, $src, $shift\t# @rotl8I" %}
   ins_encode %{
-    __ xvneg_w($tmp$$FloatRegister, $shift$$FloatRegister);
-    __ xvrotr_w($dst$$FloatRegister, $src$$FloatRegister, $tmp$$FloatRegister);
+    __ xvneg_w(fscratch, $shift$$FloatRegister);
+    __ xvrotr_w($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -15179,14 +15154,13 @@ instruct rotl8I_imm(vecY dst, vecY src, immI shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rotl4L(vecY dst, vecY src, vecY shift, vecY tmp) %{
+instruct rotl4L(vecY dst, vecY src, vecY shift) %{
   predicate(Matcher::vector_length(n) == 4);
   match(Set dst (RotateLeftV src shift));
-  effect(TEMP tmp);
-  format %{ "xvrotl    $dst, $src, $shift\t# TEMP($tmp) @rotl4L" %}
+  format %{ "xvrotl    $dst, $src, $shift\t# @rotl4L" %}
   ins_encode %{
-    __ xvneg_d($tmp$$FloatRegister, $shift$$FloatRegister);
-    __ xvrotr_d($dst$$FloatRegister, $src$$FloatRegister, $tmp$$FloatRegister);
+    __ xvneg_d(fscratch, $shift$$FloatRegister);
+    __ xvrotr_d($dst$$FloatRegister, $src$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -16292,11 +16266,10 @@ instruct cvt4Lto4I(vecX dst, vecY src) %{
 instruct cvt4Lto4F(vecX dst, vecY src) %{
   predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (VectorCastL2X src));
-  effect(TEMP_DEF dst);
   format %{ "vconvert    $dst, $src\t# @cvt4Lto4F" %}
   ins_encode %{
-    __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0x01);
-    __ xvffint_s_l($dst$$FloatRegister, $dst$$FloatRegister, $src$$FloatRegister);
+    __ xvpermi_q(fscratch, $src$$FloatRegister, 0x01);
+    __ xvffint_s_l($dst$$FloatRegister, fscratch, $src$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -16323,15 +16296,15 @@ instruct cvt4Lto4D(vecY dst, vecY src) %{
 
 // ----------------------------- Vector Cast F2X ------------------------------
 
-instruct cvt8Fto8S(vecX dst, vecY src, vecY tmp) %{
+instruct cvt8Fto8S(vecX dst, vecY src) %{
   predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (VectorCastF2X src));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vconvert    $dst, $src\t# TEMP($tmp) @cvt8Fto8S" %}
+  effect(TEMP_DEF dst);
+  format %{ "vconvert    $dst, $src\t# @cvt8Fto8S" %}
   ins_encode %{
-    __ xvftintrz_w_s($tmp$$FloatRegister, $src$$FloatRegister);
-    __ xvpermi_q($dst$$FloatRegister, $tmp$$FloatRegister, 0x01);
-    __ vsrlni_h_w($dst$$FloatRegister, $tmp$$FloatRegister, 0);
+    __ xvftintrz_w_s(fscratch, $src$$FloatRegister);
+    __ xvpermi_q($dst$$FloatRegister, fscratch, 0x01);
+    __ vsrlni_h_w($dst$$FloatRegister, fscratch, 0);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -16547,26 +16520,24 @@ instruct insert2L(vecX dst, mRegL val, immIU1 idx) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct insert4F(vecX dst, regF val, immIU2 idx, mRegI tmp) %{
+instruct insert4F(vecX dst, regF val, immIU2 idx) %{
   predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (VectorInsert (Binary dst val) idx));
-  effect(TEMP tmp);
-  format %{ "vinsert    $dst, $val, $idx\t# TEMP($tmp) @insert4F" %}
+  format %{ "vinsert    $dst, $val, $idx\t# @insert4F" %}
   ins_encode %{
-    __ vpickve2gr_w($tmp$$Register, $val$$FloatRegister, 0);
-    __ vinsgr2vr_w($dst$$FloatRegister, $tmp$$Register, $idx$$constant);
+    __ vpickve2gr_w(AT, $val$$FloatRegister, 0);
+    __ vinsgr2vr_w($dst$$FloatRegister, AT, $idx$$constant);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct insert2D(vecX dst, regD val, immIU1 idx, mRegI tmp) %{
+instruct insert2D(vecX dst, regD val, immIU1 idx) %{
   predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorInsert (Binary dst val) idx));
-  effect(TEMP tmp);
-  format %{ "vinsert    $dst, $val, $idx\t# TEMP($tmp) @insert2D" %}
+  format %{ "vinsert    $dst, $val, $idx\t# @insert2D" %}
   ins_encode %{
-    __ vpickve2gr_d($tmp$$Register, $val$$FloatRegister, 0);
-    __ vinsgr2vr_d($dst$$FloatRegister, $tmp$$Register, $idx$$constant);
+    __ vpickve2gr_d(AT, $val$$FloatRegister, 0);
+    __ vinsgr2vr_d($dst$$FloatRegister, AT, $idx$$constant);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -16722,15 +16693,14 @@ instruct storemask32B(vecY dst, vecY src, immI_1 size) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct storemask16S(vecX dst, vecY src, immI_2 size, vecX tmp) %{
+instruct storemask16S(vecX dst, vecY src, immI_2 size) %{
   predicate(Matcher::vector_length(n) == 16);
   match(Set dst (VectorStoreMask src size));
-  effect(TEMP tmp);
-  format %{ "vstoremask    $dst, $src\t# TEMP($tmp) @storemask16S" %}
+  format %{ "vstoremask    $dst, $src\t# @storemask16S" %}
   ins_encode %{
-    __ xvpermi_d($tmp$$FloatRegister, $src$$FloatRegister, 0b00001110);
-    __ vsrlni_b_h($tmp$$FloatRegister, $src$$FloatRegister, 0);
-    __ vneg_b($dst$$FloatRegister, $tmp$$FloatRegister);
+    __ xvpermi_d(fscratch, $src$$FloatRegister, 0b00001110);
+    __ vsrlni_b_h(fscratch, $src$$FloatRegister, 0);
+    __ vneg_b($dst$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -16947,45 +16917,43 @@ instruct CMoveI_alltrue_in_maskV32(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, 
 
 // ----------------------------- VectorMaskTrueCount ----------------------------
 
-instruct vmask_truecount16B(mRegI dst, vecX src, vecX tmp) %{
+instruct vmask_truecount16B(mRegI dst, vecX src) %{
   predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
   match(Set dst (VectorMaskTrueCount src));
-  effect(TEMP tmp);
-  format %{ "vmask_truecount   $dst, $src\t# TEMP($tmp) @vmask_truecount16B" %}
+  format %{ "vmask_truecount   $dst, $src\t# @vmask_truecount16B" %}
   ins_encode %{
     // Input "src" is a vector of boolean represented as bytes with
     // 0x00/0x01 as element values.
-    __ vpcnt_d($tmp$$FloatRegister, $src$$FloatRegister);
-    __ vhaddw_q_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ vpickve2gr_b($dst$$Register, $tmp$$FloatRegister, 0);
+    __ vpcnt_d(fscratch, $src$$FloatRegister);
+    __ vhaddw_q_d(fscratch, fscratch, fscratch);
+    __ vpickve2gr_b($dst$$Register, fscratch, 0);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct vmask_truecount32B(mRegI dst, vecY src, vecY tmp1, vecY tmp2) %{
+instruct vmask_truecount32B(mRegI dst, vecY src, vecY tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
   match(Set dst (VectorMaskTrueCount src));
-  effect(TEMP tmp1, TEMP tmp2);
-  format %{ "vmask_truecount   $dst, $src\t# TEMP($tmp1, $tmp2) @vmask_truecount32B" %}
+  effect(TEMP tmp);
+  format %{ "vmask_truecount   $dst, $src\t# TEMP($tmp) @vmask_truecount32B" %}
   ins_encode %{
     // Input "src" is a vector of boolean represented as bytes with
     // 0x00/0x01 as element values.
-    __ xvpcnt_d($tmp1$$FloatRegister, $src$$FloatRegister);
-    __ xvhaddw_q_d($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp1$$FloatRegister);
-    __ xvpermi_d($tmp2$$FloatRegister, $tmp1$$FloatRegister, 0b00001110);
-    __ vadd_b($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister);
-    __ vpickve2gr_b($dst$$Register, $tmp1$$FloatRegister, 0);
+    __ xvpcnt_d($tmp$$FloatRegister, $src$$FloatRegister);
+    __ xvhaddw_q_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+    __ xvpermi_d(fscratch, $tmp$$FloatRegister, 0b00001110);
+    __ vadd_b($tmp$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    __ vpickve2gr_b($dst$$Register, $tmp$$FloatRegister, 0);
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ----------------------------- VectorMaskFirstTrue ----------------------------
 
-instruct vmask_firsttrue16B(mRegI dst, vecX src, mRegI tmp) %{
+instruct vmask_firsttrue16B(mRegI dst, vecX src) %{
   predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
   match(Set dst (VectorMaskFirstTrue src));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vmask_firsttrue    $dst, $src\t# TEMP($tmp) @vmask_firsttrue16B" %}
+  format %{ "vmask_firsttrue    $dst, $src\t# @vmask_firsttrue16B" %}
   ins_encode %{
     // Returns the index of the first active lane of the
     // vector mask, or 16 (VLENGTH) if no lane is active.
@@ -16997,27 +16965,26 @@ instruct vmask_firsttrue16B(mRegI dst, vecX src, mRegI tmp) %{
 
     // Try to compute the result from lower 64 bits.
     __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-    __ li($tmp$$Register, (long)0);
+    __ li(AT, (long)0);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
     // Compute the result from the higher 64 bits.
     __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-    __ li($tmp$$Register, (long)8);
+    __ li(AT, (long)8);
 
     // Count the Trailing zero bytes.
     __ bind(FIRST_TRUE_INDEX);
     __ ctz_d($dst$$Register, $dst$$Register);
     __ srli_w($dst$$Register, $dst$$Register, 3);
-    __ add_w($dst$$Register, $tmp$$Register, $dst$$Register);
+    __ add_w($dst$$Register, AT, $dst$$Register);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct vmask_firsttrue32B(mRegI dst, vecY src, mRegI tmp) %{
+instruct vmask_firsttrue32B(mRegI dst, vecY src) %{
   predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
   match(Set dst (VectorMaskFirstTrue src));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vmask_firsttrue    $dst, $src\t# TEMP($tmp) @vmask_firsttrue32B" %}
+  format %{ "vmask_firsttrue    $dst, $src\t# @vmask_firsttrue32B" %}
   ins_encode %{
     // Returns the index of the first active lane of the
     // vector mask, or 32 (VLENGTH) if no lane is active.
@@ -17029,39 +16996,38 @@ instruct vmask_firsttrue32B(mRegI dst, vecY src, mRegI tmp) %{
 
     // Try to compute the result from lower 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-    __ li($tmp$$Register, (long)0);
+    __ li(AT, (long)0);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
     // Compute the result from the mid-lower 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-    __ li($tmp$$Register, (long)8);
+    __ li(AT, (long)8);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
     // Compute the result from the mid-higher 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 2);
-    __ li($tmp$$Register, (long)16);
+    __ li(AT, (long)16);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
     // Compute the result from the higher 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 3);
-    __ li($tmp$$Register, (long)24);
+    __ li(AT, (long)24);
 
     // Count the Trailing zero bytes.
     __ bind(FIRST_TRUE_INDEX);
     __ ctz_d($dst$$Register, $dst$$Register);
     __ srli_w($dst$$Register, $dst$$Register, 3);
-    __ add_w($dst$$Register, $tmp$$Register, $dst$$Register);
+    __ add_w($dst$$Register, AT, $dst$$Register);
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ----------------------------- VectorMaskLastTrue ----------------------------
 
-instruct vmask_lasttrue16B(mRegI dst, vecX src, mRegI tmp) %{
+instruct vmask_lasttrue16B(mRegI dst, vecX src) %{
   predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
   match(Set dst (VectorMaskLastTrue src));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vmask_lasttrue    $dst, $src\t# TEMP($tmp) @vmask_lasttrue16B" %}
+  format %{ "vmask_lasttrue    $dst, $src\t# @vmask_lasttrue16B" %}
   ins_encode %{
     // Returns the index of the last active lane of the
     // vector mask, or -1 if no lane is active.
@@ -17073,27 +17039,26 @@ instruct vmask_lasttrue16B(mRegI dst, vecX src, mRegI tmp) %{
 
     // Try to compute the result from higher 64 bits.
     __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-    __ li($tmp$$Register, (long)16 - 1);
+    __ li(AT, (long)16 - 1);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
     // Compute the result from the lower 64 bits.
     __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-    __ li($tmp$$Register, (long)8 - 1);
+    __ li(AT, (long)8 - 1);
 
     // Count the Trailing zero bytes.
     __ bind(FIRST_TRUE_INDEX);
     __ clz_d($dst$$Register, $dst$$Register);
     __ srli_w($dst$$Register, $dst$$Register, 3);
-    __ sub_w($dst$$Register, $tmp$$Register, $dst$$Register);
+    __ sub_w($dst$$Register, AT, $dst$$Register);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct vmask_lasttrue32B(mRegI dst, vecY src, mRegI tmp) %{
+instruct vmask_lasttrue32B(mRegI dst, vecY src) %{
   predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
   match(Set dst (VectorMaskLastTrue src));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vmask_lasttrue    $dst, $src\t# TEMP($tmp) @vmask_lasttrue32B" %}
+  format %{ "vmask_lasttrue    $dst, $src\t# @vmask_lasttrue32B" %}
   ins_encode %{
     // Returns the index of the last active lane of the
     // vector mask, or -1 if no lane is active.
@@ -17105,28 +17070,28 @@ instruct vmask_lasttrue32B(mRegI dst, vecY src, mRegI tmp) %{
 
     // Try to compute the result from higher 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 3);
-    __ li($tmp$$Register, (long)32 - 1);
+    __ li(AT, (long)32 - 1);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
     // Compute the result from the mid-higher 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 2);
-    __ li($tmp$$Register, (long)24 - 1);
+    __ li(AT, (long)24 - 1);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
     // Compute the result from the mid-lower 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-    __ li($tmp$$Register, (long)16 - 1);
+    __ li(AT, (long)16 - 1);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
     // Compute the result from the lower 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-    __ li($tmp$$Register, (long)8 - 1);
+    __ li(AT, (long)8 - 1);
 
     // Count the Trailing zero bytes.
     __ bind(FIRST_TRUE_INDEX);
     __ clz_d($dst$$Register, $dst$$Register);
     __ srli_w($dst$$Register, $dst$$Register, 3);
-    __ sub_w($dst$$Register, $tmp$$Register, $dst$$Register);
+    __ sub_w($dst$$Register, AT, $dst$$Register);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -17162,12 +17127,11 @@ instruct cmpV32(vecY dst, vecY src1, vecY src2, immI cond)
 instruct cmove4F(vecX dst, vecX src1, vecX src2, immI cond, cmpOp copnd)
 %{
   match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
-  effect(TEMP_DEF dst);
   format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove4F" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 16);
-    __ vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $dst$$FloatRegister);
+    __ vector_compare(fscratch, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 16);
+    __ vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -17175,12 +17139,11 @@ instruct cmove4F(vecX dst, vecX src1, vecX src2, immI cond, cmpOp copnd)
 instruct cmove2D(vecX dst, vecX src1, vecX src2, immI cond, cmpOp copnd)
 %{
   match(Set dst (CMoveVD (Binary copnd cond) (Binary src1 src2)));
-  effect(TEMP_DEF dst);
   format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove2D" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 16);
-    __ vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $dst$$FloatRegister);
+    __ vector_compare(fscratch, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 16);
+    __ vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -17188,12 +17151,11 @@ instruct cmove2D(vecX dst, vecX src1, vecX src2, immI cond, cmpOp copnd)
 instruct cmove8F(vecY dst, vecY src1, vecY src2, immI cond, cmpOp copnd)
 %{
   match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
-  effect(TEMP_DEF dst);
   format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove8F" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 32);
-    __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $dst$$FloatRegister);
+    __ vector_compare(fscratch, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 32);
+    __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -17201,12 +17163,11 @@ instruct cmove8F(vecY dst, vecY src1, vecY src2, immI cond, cmpOp copnd)
 instruct cmove4D(vecY dst, vecY src1, vecY src2, immI cond, cmpOp copnd)
 %{
   match(Set dst (CMoveVD (Binary copnd cond) (Binary src1 src2)));
-  effect(TEMP_DEF dst);
   format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove4D" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 32);
-    __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $dst$$FloatRegister);
+    __ vector_compare(fscratch, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 32);
+    __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, fscratch);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -17291,28 +17252,28 @@ instruct rearrange16B(vecX dst, vecX src, vecX shuffle) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rearrange32B(vecY dst, vecY src, vecY shuffle, vecY tmp) %{
+instruct rearrange32B(vecY dst, vecY src, vecY shuffle) %{
   predicate(Matcher::vector_length(n) == 32 && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorRearrange src shuffle));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "xvrearrange    $dst, $src, $shuffle\t# TEMP($tmp) @rearrange32B" %}
+  effect(TEMP_DEF dst);
+  format %{ "xvrearrange    $dst, $src, $shuffle\t# @rearrange32B" %}
   ins_encode %{
-    __ xvpermi_q($tmp$$FloatRegister, $src$$FloatRegister, 0x00);
+    __ xvpermi_q(fscratch, $src$$FloatRegister, 0x00);
     __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0x11);
-    __ xvshuf_b($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, $shuffle$$FloatRegister);
+    __ xvshuf_b($dst$$FloatRegister, $dst$$FloatRegister, fscratch, $shuffle$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct rearrange16S(vecY dst, vecY src, vecY tmp1, vecY tmp2) %{
+instruct rearrange16S(vecY dst, vecY src, vecY tmp) %{
   predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (VectorRearrange src dst));
-  effect(TEMP tmp1, TEMP tmp2);
-  format %{ "xvrearrange    $dst, $src, $dst\t# TEMP($tmp1, $tmp2) @rearrange16S" %}
+  effect(TEMP tmp);
+  format %{ "xvrearrange    $dst, $src, $dst\t# TEMP($tmp) @rearrange16S" %}
   ins_encode %{
-    __ xvpermi_q($tmp1$$FloatRegister, $src$$FloatRegister, 0x00);
-    __ xvpermi_q($tmp2$$FloatRegister, $src$$FloatRegister, 0x11);
-    __ xvshuf_h($dst$$FloatRegister, $tmp2$$FloatRegister, $tmp1$$FloatRegister);
+    __ xvpermi_q($tmp$$FloatRegister, $src$$FloatRegister, 0x00);
+    __ xvpermi_q(fscratch, $src$$FloatRegister, 0x11);
+    __ xvshuf_h($dst$$FloatRegister, fscratch, $tmp$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -11489,15 +11489,13 @@ instruct cmpFastUnlock(FlagsReg cr, no_CR_mRegP object, no_CR_mRegP box, no_CR_m
   ins_pipe( pipe_slow );
 %}
 
-// Store CMS card-mark Immediate 0
+// Store card-mark Immediate 0
 instruct storeImmCM(memory mem, immI_0 zero) %{
   match(Set mem (StoreCM mem zero));
 
   ins_cost(150);
-  format %{ "StoreCM MEMBAR loadstore\n\t"
-            "st_b   $mem, zero\t! CMS card-mark imm0" %}
+  format %{ "st_b $mem, zero\t! card-mark imm0" %}
   ins_encode %{
-    __ membar(__ StoreStore);
     __ loadstore_enc(R0, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::STORE_BYTE);
   %}
   ins_pipe( pipe_serial );

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -17063,6 +17063,60 @@ instruct cmpV32(vecY dst, vecY src1, vecY src2, immI cond)
   ins_pipe( pipe_slow );
 %}
 
+// ------------------------- Vector conditional move --------------------------
+
+instruct cmove4F(vecX dst, vecX src1, vecX src2, immI cond, cmpOp copnd)
+%{
+  match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
+  effect(TEMP_DEF dst);
+  format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove4F" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 16);
+    __ vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $dst$$FloatRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct cmove2D(vecX dst, vecX src1, vecX src2, immI cond, cmpOp copnd)
+%{
+  match(Set dst (CMoveVD (Binary copnd cond) (Binary src1 src2)));
+  effect(TEMP_DEF dst);
+  format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove2D" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 16);
+    __ vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $dst$$FloatRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct cmove8F(vecY dst, vecY src1, vecY src2, immI cond, cmpOp copnd)
+%{
+  match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
+  effect(TEMP_DEF dst);
+  format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove8F" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 32);
+    __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $dst$$FloatRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct cmove4D(vecY dst, vecY src1, vecY src2, immI cond, cmpOp copnd)
+%{
+  match(Set dst (CMoveVD (Binary copnd cond) (Binary src1 src2)));
+  effect(TEMP_DEF dst);
+  format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove4D" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 32);
+    __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $dst$$FloatRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 // ---------------------------- LOAD_IOTA_INDICES -----------------------------
 
 instruct loadconV16(vecX dst, immI_0 src) %{

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -16737,119 +16737,213 @@ instruct storemask16S(vecX dst, vecY src, immI_2 size, vecX tmp) %{
 
 // ----------------------------- VectorTest -----------------------------------
 
-/*
-instruct anytrue_in_maskV16(mRegI dst, vecX src1, vecX src2)
-%{
-  predicate(UseCF2GR && static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
-  match(Set dst (VectorTest src1 src2));
-  format %{ "vtest    $dst, $src1, $src2(not used)\t# @anytrue_in_maskV16" %}
+instruct anytrue_in_maskV16_branch(cmpOp cop, vecX op1, vecX op2, label labl) %{
+  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::ne);
+  match(If cop (VectorTest op1 op2));
+  effect(USE labl);
+  format %{ "b$cop   $op1, $op2(not used), $labl\t# @anytrue_in_maskV16__branch" %}
+
   ins_encode %{
-    // No need to use src2, src2 is all ones.
-    __ vsetnez_v(FCC0, $src1$$FloatRegister);
-    __ movcf2gr($dst$$Register, FCC0);
+    Label    &L  = *($labl$$label);
+    // No need to use op2, op2 is all ones.
+    __ vseteqz_v(FCC0, $op1$$FloatRegister);
+    switch($cop$$cmpcode) {
+      case 0x01: // EQ
+        __ bcnez(FCC0, L);
+        break;
+      case 0x02: // NE
+        __ bceqz(FCC0, L);
+        break;
+      default:
+        Unimplemented();
+    }
+  %}
+
+  ins_pc_relative(1);
+  ins_pipe( pipe_slow );
+%}
+
+instruct alltrue_in_maskV16_branch(cmpOp cop, vecX op1, vecX op2, label labl) %{
+  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::overflow);
+  match(If cop (VectorTest op1 op2));
+  effect(USE labl);
+  format %{ "b$cop   $op1, $op2(not used), $labl\t# @alltrue_in_maskV16__branch" %}
+
+  ins_encode %{
+    Label    &L  = *($labl$$label);
+    // No need to use op2, op2 is all ones.
+    __ vsetallnez_b(FCC0, $op1$$FloatRegister);
+    switch($cop$$cmpcode) {
+      case 0x01: // EQ
+        __ bcnez(FCC0, L);
+        break;
+      case 0x02: // NE
+        __ bceqz(FCC0, L);
+        break;
+      default:
+        Unimplemented();
+    }
+  %}
+
+  ins_pc_relative(1);
+  ins_pipe( pipe_slow );
+%}
+
+instruct CMoveI_anytrue_in_maskV16(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vecX op1, vecX op2, cmpOp cop, regF tmp1, regF tmp2)
+%{
+  predicate(static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::ne);
+  match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary src1 src2)));
+  effect(TEMP tmp1, TEMP tmp2);
+  format %{ "cmovei_vtest($cop)    $dst, $src1, $src2, $op1, $op2(not used)\t# TEMP($tmp1, $tmp2) @CMoveI_anytrue_in_maskV16" %}
+  ins_encode %{
+    // No need to use op2, op2 is all ones.
+    __ vseteqz_v(FCC0, $op1$$FloatRegister);
+    __ movgr2fr_w($tmp1$$FloatRegister, $src1$$Register);
+    __ movgr2fr_w($tmp2$$FloatRegister, $src2$$Register);
+    switch($cop$$cmpcode) {
+      case 0x01: // EQ
+        __ fsel($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, FCC0);
+        break;
+      case 0x02: // NE
+        __ fsel($tmp1$$FloatRegister, $tmp2$$FloatRegister, $tmp1$$FloatRegister, FCC0);
+        break;
+      default:
+        Unimplemented();
+    }
+    __ movfr2gr_s($dst$$Register, $tmp1$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct anytrue_in_maskV16_indir(mRegI dst, vecX src1, vecX src2, regF tmp)
+instruct CMoveI_alltrue_in_maskV16(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vecX op1, vecX op2, cmpOp cop, regF tmp1, regF tmp2)
 %{
-  predicate(!UseCF2GR && static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
-  match(Set dst (VectorTest src1 src2));
-  effect(TEMP tmp);
-  format %{ "vtest    $dst, $src1, $src2(not used)\t# TEMP($tmp) @anytrue_in_maskV16" %}
+  predicate(static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::overflow);
+  match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary src1 src2)));
+  effect(TEMP tmp1, TEMP tmp2);
+  format %{ "cmovei_vtest($cop)    $dst, $src1, $src2, $op1, $op2(not used)\t# TEMP($tmp1, $tmp2) @CMoveI_alltrue_in_maskV16" %}
   ins_encode %{
-    // No need to use src2, src2 is all ones.
-    __ vsetnez_v(FCC0, $src1$$FloatRegister);
-    __ movcf2fr($tmp$$FloatRegister, FCC0);
-    __ movfr2gr_s($dst$$Register, $tmp$$FloatRegister);
+    // No need to use op2, op2 is all ones.
+    __ vsetallnez_b(FCC0, $op1$$FloatRegister);
+    __ movgr2fr_w($tmp1$$FloatRegister, $src1$$Register);
+    __ movgr2fr_w($tmp2$$FloatRegister, $src2$$Register);
+    switch($cop$$cmpcode) {
+      case 0x01: // EQ
+        __ fsel($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, FCC0);
+        break;
+      case 0x02: // NE
+        __ fsel($tmp1$$FloatRegister, $tmp2$$FloatRegister, $tmp1$$FloatRegister, FCC0);
+        break;
+      default:
+        Unimplemented();
+    }
+    __ movfr2gr_s($dst$$Register, $tmp1$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct alltrue_in_maskV16(mRegI dst, vecX src1, vecX src2)
-%{
-  predicate(UseCF2GR && static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
-  match(Set dst (VectorTest src1 src2));
-  format %{ "vtest    $dst, $src1, $src2(not used)\t# @alltrue_in_maskV16" %}
+instruct anytrue_in_maskV32_branch(cmpOp cop, vecY op1, vecY op2, label labl) %{
+  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::ne);
+  match(If cop (VectorTest op1 op2));
+  effect(USE labl);
+  format %{ "b$cop   $op1, $op2(not used), $labl\t# @anytrue_in_maskV32__branch" %}
+
   ins_encode %{
-    // No need to use src2, src2 is all ones.
-    __ vsetallnez_b(FCC0, $src1$$FloatRegister);
-    __ movcf2gr($dst$$Register, FCC0);
+    Label &L  = *($labl$$label);
+    // No need to use op2, op2 is all ones.
+    __ xvseteqz_v(FCC0, $op1$$FloatRegister);
+    switch($cop$$cmpcode) {
+      case 0x01: // EQ
+        __ bcnez(FCC0, L);
+        break;
+      case 0x02: // NE
+        __ bceqz(FCC0, L);
+        break;
+      default:
+        Unimplemented();
+    }
+  %}
+
+  ins_pc_relative(1);
+  ins_pipe( pipe_slow );
+%}
+
+instruct alltrue_in_maskV32_branch(cmpOp cop, vecY op1, vecY op2, label labl) %{
+  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::overflow);
+  match(If cop (VectorTest op1 op2));
+  effect(USE labl);
+  format %{ "b$cop   $op1, $op2(not used), $labl\t# @alltrue_in_maskV32__branch" %}
+
+  ins_encode %{
+    Label &L  = *($labl$$label);
+    // No need to use op2, op2 is all ones.
+    __ xvsetallnez_b(FCC0, $op1$$FloatRegister);
+    switch($cop$$cmpcode) {
+      case 0x01: // EQ
+        __ bcnez(FCC0, L);
+        break;
+      case 0x02: // NE
+        __ bceqz(FCC0, L);
+        break;
+      default:
+        Unimplemented();
+    }
+  %}
+
+  ins_pc_relative(1);
+  ins_pipe( pipe_slow );
+%}
+
+instruct CMoveI_anytrue_in_maskV32(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vecY op1, vecY op2, cmpOp cop, regF tmp1, regF tmp2)
+%{
+  predicate(static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::ne);
+  match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary src1 src2)));
+  effect(TEMP tmp1, TEMP tmp2);
+  format %{ "cmovei_xvtest($cop)    $dst, $src1, $src2, $op1, $op2(not used)\t# TEMP($tmp1, $tmp2) @CMoveI_anytrue_in_maskV32" %}
+  ins_encode %{
+    // No need to use op2, op2 is all ones.
+    __ xvseteqz_v(FCC0, $op1$$FloatRegister);
+    __ movgr2fr_w($tmp1$$FloatRegister, $src1$$Register);
+    __ movgr2fr_w($tmp2$$FloatRegister, $src2$$Register);
+    switch($cop$$cmpcode) {
+      case 0x01: // EQ
+        __ fsel($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, FCC0);
+        break;
+      case 0x02: // NE
+        __ fsel($tmp1$$FloatRegister, $tmp2$$FloatRegister, $tmp1$$FloatRegister, FCC0);
+        break;
+      default:
+        Unimplemented();
+    }
+    __ movfr2gr_s($dst$$Register, $tmp1$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct alltrue_in_maskV16_indir(mRegI dst, vecX src1, vecX src2, regF tmp)
+instruct CMoveI_alltrue_in_maskV32(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vecY op1, vecY op2, cmpOp cop, regF tmp1, regF tmp2)
 %{
-  predicate(!UseCF2GR && static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
-  match(Set dst (VectorTest src1 src2));
-  effect(TEMP tmp);
-  format %{ "vtest    $dst, $src1, $src2(not used)\t# TEMP($tmp) @alltrue_in_maskV16" %}
+  predicate(static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::overflow);
+  match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary src1 src2)));
+  effect(TEMP tmp1, TEMP tmp2);
+  format %{ "cmovei_xvtest($cop)    $dst, $src1, $src2, $op1, $op2(not used)\t# TEMP($tmp1, $tmp2) @CMoveI_alltrue_in_maskV32" %}
   ins_encode %{
-    // No need to use src2, src2 is all ones.
-    __ vsetallnez_b(FCC0, $src1$$FloatRegister);
-    __ movcf2fr($tmp$$FloatRegister, FCC0);
-    __ movfr2gr_s($dst$$Register, $tmp$$FloatRegister);
+    // No need to use op2, op2 is all ones.
+    __ xvsetallnez_b(FCC0, $op1$$FloatRegister);
+    __ movgr2fr_w($tmp1$$FloatRegister, $src1$$Register);
+    __ movgr2fr_w($tmp2$$FloatRegister, $src2$$Register);
+    switch($cop$$cmpcode) {
+      case 0x01: // EQ
+        __ fsel($tmp1$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, FCC0);
+        break;
+      case 0x02: // NE
+        __ fsel($tmp1$$FloatRegister, $tmp2$$FloatRegister, $tmp1$$FloatRegister, FCC0);
+        break;
+      default:
+        Unimplemented();
+    }
+    __ movfr2gr_s($dst$$Register, $tmp1$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
-
-instruct anytrue_in_maskV32(mRegI dst, vecY src1, vecY src2)
-%{
-  predicate(UseCF2GR && static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
-  match(Set dst (VectorTest src1 src2));
-  format %{ "xvtest    $dst, $src1, $src2(not used)\t# @anytrue_in_maskV32" %}
-  ins_encode %{
-    // No need to use src2, src2 is all ones.
-    __ xvsetnez_v(FCC0, $src1$$FloatRegister);
-    __ movcf2gr($dst$$Register, FCC0);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct anytrue_in_maskV32_indir(mRegI dst, vecY src1, vecY src2, regF tmp)
-%{
-  predicate(!UseCF2GR && static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
-  match(Set dst (VectorTest src1 src2));
-  effect(TEMP tmp);
-  format %{ "xvtest    $dst, $src1, $src2(not used)\t# TEMP($tmp) @anytrue_in_maskV32" %}
-  ins_encode %{
-    // No need to use src2, src2 is all ones.
-    __ xvsetnez_v(FCC0, $src1$$FloatRegister);
-    __ movcf2fr($tmp$$FloatRegister, FCC0);
-    __ movfr2gr_s($dst$$Register, $tmp$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct alltrue_in_maskV32(mRegI dst, vecY src1, vecY src2)
-%{
-  predicate(UseCF2GR && static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
-  match(Set dst (VectorTest src1 src2));
-  format %{ "xvtest    $dst, $src1, $src2(not used)\t# @alltrue_in_maskV32" %}
-  ins_encode %{
-    // No need to use src2, src2 is all ones.
-    __ xvsetallnez_b(FCC0, $src1$$FloatRegister);
-    __ movcf2gr($dst$$Register, FCC0);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct alltrue_in_maskV32_indir(mRegI dst, vecY src1, vecY src2, regF tmp)
-%{
-  predicate(!UseCF2GR && static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
-  match(Set dst (VectorTest src1 src2));
-  effect(TEMP tmp);
-  format %{ "xvtest    $dst, $src1, $src2(not used)\t# TEMP($tmp) @alltrue_in_maskV32" %}
-  ins_encode %{
-    // No need to use src2, src2 is all ones.
-    __ xvsetallnez_b(FCC0, $src1$$FloatRegister);
-    __ movcf2fr($tmp$$FloatRegister, FCC0);
-    __ movfr2gr_s($dst$$Register, $tmp$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-*/
 
 // ----------------------------- VectorMaskTrueCount ----------------------------
 

--- a/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
@@ -147,14 +147,14 @@
   // Implements a variant of EncodeISOArrayNode that encode ASCII only
   static const bool supports_encode_ascii_array = true;
 
-  // Some architecture needs a helper to check for alltrue vector
+  // No mask is used for the vector test
   static constexpr bool vectortest_needs_second_argument(bool is_alltrue, bool is_predicate) {
     return false;
   }
 
   // BoolTest mask for vector test intrinsics
   static constexpr BoolTest::mask vectortest_mask(bool is_alltrue, bool is_predicate, int vlen) {
-    return BoolTest::illegal;
+    return is_alltrue ? BoolTest::eq : BoolTest::ne;
   }
 
   // Returns pre-selection estimated size of a vector operation.

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -429,9 +429,10 @@ void VM_Version::get_processor_features() {
         warning("UseActiveCoresMP disabled because active processors are more than one.");
       FLAG_SET_DEFAULT(UseActiveCoresMP, false);
     }
-  } else {
-    if (!os::is_MP())
+  } else { // !UseActiveCoresMP
+    if (FLAG_IS_DEFAULT(UseActiveCoresMP) && !os::is_MP()) {
       FLAG_SET_DEFAULT(UseActiveCoresMP, true);
+    }
   }
 }
 

--- a/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public:
 
   void do_oop(narrowOop* ref) {
     assert(ref != NULL, "invariant");
-    assert(is_aligned(ref, HeapWordSize), "invariant");
+    assert(is_aligned(ref, sizeof(narrowOop)), "invariant");
     if (!CompressedOops::is_null(*ref)) {
       _delegate->do_root(UnifiedOopRef::encode_as_raw(ref));
     }

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -23,6 +23,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2018, 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #ifndef SHARE_RUNTIME_JAVATHREAD_INLINE_HPP
 #define SHARE_RUNTIME_JAVATHREAD_INLINE_HPP
 
@@ -138,7 +144,7 @@ inline JavaThread::NoAsyncExceptionDeliveryMark::~NoAsyncExceptionDeliveryMark()
 }
 
 inline JavaThreadState JavaThread::thread_state() const    {
-#if defined(PPC64) || defined (AARCH64) || defined(RISCV64)
+#if defined(PPC64) || defined (AARCH64) || defined(RISCV64) || defined(LOONGARCH64)
   // Use membars when accessing volatile _thread_state. See
   // Threads::create_vm() for size checks.
   return Atomic::load_acquire(&_thread_state);
@@ -150,7 +156,7 @@ inline JavaThreadState JavaThread::thread_state() const    {
 inline void JavaThread::set_thread_state(JavaThreadState s) {
   assert(current_or_null() == nullptr || current_or_null() == this,
          "state change should only be called by the current thread");
-#if defined(PPC64) || defined (AARCH64) || defined(RISCV64)
+#if defined(PPC64) || defined (AARCH64) || defined(RISCV64) || defined(LOONGARCH64)
   // Use membars when accessing volatile _thread_state. See
   // Threads::create_vm() for size checks.
   Atomic::release_store(&_thread_state, s);

--- a/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
@@ -23,11 +23,17 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @library /test/lib /
  * @bug 8281467
  * @requires vm.flagless
- * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="loongarch64"
  *
  * @summary Test large CodeEntryAlignments are accepted
  * @run driver compiler.arguments.TestCodeEntryAlignment

--- a/test/hotspot/jtreg/compiler/arguments/TestOptoLoopAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestOptoLoopAlignment.java
@@ -22,17 +22,11 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2023, These
- * modifications are Copyright (c) 2023, Loongson Technology, and are made
- * available on the same license terms set forth above.
- */
-
-/*
  * @test
  * @library /test/lib /
  * @bug 8281467
  * @requires vm.flagless
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="loongarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
  *
  * @summary Test large OptoLoopAlignments are accepted
  * @run driver compiler.arguments.TestOptoLoopAlignment

--- a/test/hotspot/jtreg/compiler/arguments/TestOptoLoopAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestOptoLoopAlignment.java
@@ -22,11 +22,17 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @library /test/lib /
  * @bug 8281467
  * @requires vm.flagless
- * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="loongarch64"
  *
  * @summary Test large OptoLoopAlignments are accepted
  * @run driver compiler.arguments.TestOptoLoopAlignment

--- a/test/hotspot/jtreg/compiler/c2/TestBit.java
+++ b/test/hotspot/jtreg/compiler/c2/TestBit.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.c2;
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -33,7 +39,7 @@ import jdk.test.lib.process.ProcessTools;
  * @library /test/lib /
  *
  * @requires vm.flagless
- * @requires os.arch=="aarch64" | os.arch=="amd64" | os.arch == "ppc64le" | os.arch == "riscv64"
+ * @requires os.arch=="aarch64" | os.arch=="amd64" | os.arch == "ppc64le" | os.arch == "riscv64" | os.arch=="loongarch64"
  * @requires vm.debug == true & vm.compiler2.enabled
  *
  * @run driver compiler.c2.TestBit

--- a/test/hotspot/jtreg/compiler/c2/irTests/CmpUWithZero.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/CmpUWithZero.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.c2.irTests;
 
 import compiler.lib.ir_framework.*;
@@ -29,7 +35,7 @@ import compiler.lib.ir_framework.*;
  * @test
  * bug 8290529
  * @summary verify that x <u 1 is transformed to x == 0
- * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="loongarch64"
  * @library /test/lib /
  * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.CmpUWithZero

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVecCountingDownLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVecCountingDownLoop.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.c2.irTests;
 
 import compiler.lib.ir_framework.*;
@@ -29,7 +35,7 @@ import compiler.lib.ir_framework.*;
  * @test
  * @bug 8284981
  * @summary Auto-vectorization enhancement for special counting down loops
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="loongarch64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestAutoVecCountingDownLoop
  */

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRAbs.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRAbs.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.c2.irTests;
 
 import jdk.test.lib.Asserts;
@@ -30,7 +36,7 @@ import compiler.lib.ir_framework.*;
  * @test
  * @bug 8276673 8280089
  * @summary Test abs nodes optimization in C2.
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="loongarch64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestIRAbs
  */

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.c2.irTests;
 
 import compiler.lib.ir_framework.*;
@@ -33,7 +39,7 @@ import jdk.test.lib.Utils;
  * @bug 8289422
  * @key randomness
  * @summary Auto-vectorization enhancement to support vector conditional move on AArch64
- * @requires os.arch=="aarch64"
+ * @requires os.arch=="aarch64" | os.arch == "loongarch64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorConditionalMove
  */

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.c2.irTests;
 
 import compiler.lib.ir_framework.*;
@@ -32,7 +38,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8300256
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "loongarch64")
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorizationNotRun

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.c2.irTests;
 
 import compiler.lib.ir_framework.*;
@@ -32,7 +38,7 @@ import jdk.test.lib.Utils;
  * @test
  * @bug 8283091
  * @summary Auto-vectorization enhancement for type conversion between different data sizes.
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch=="aarch64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch=="aarch64" | os.arch=="loongarch64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorizeTypeConversion
  */

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
@@ -22,6 +22,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.c2.irTests;
 
 import compiler.lib.ir_framework.*;
@@ -34,7 +40,7 @@ import jdk.test.lib.Utils;
  * @bug 8283307
  * @key randomness
  * @summary Auto-vectorization enhancement for unsigned shift right on signed subword types
- * @requires ((os.arch=="amd64" | os.arch=="x86_64") & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3)) | os.arch=="aarch64"
+ * @requires ((os.arch=="amd64" | os.arch=="x86_64") & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3)) | os.arch=="aarch64" | os.arch=="loongarch64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorizeURShiftSubword
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestBitShuffleOpers.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestBitShuffleOpers.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
  * @test
  * @bug 8283894
@@ -31,7 +37,8 @@
  *            (vm.cpu.features ~= ".*bmi2.*" & vm.cpu.features ~= ".*bmi1.*" &
  *             vm.cpu.features ~= ".*sse2.*")) |
  *            ((vm.opt.UseSVE == "null" | vm.opt.UseSVE > 1) &
- *             os.arch=="aarch64" & vm.cpu.features ~= ".*svebitperm.*"))
+ *             os.arch=="aarch64" & vm.cpu.features ~= ".*svebitperm.*") |
+ *             os.arch=="loongarch64")
  * @library /test/lib /
  * @run driver compiler.intrinsics.TestBitShuffleOpers
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestCompareUnsigned.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestCompareUnsigned.java
@@ -20,6 +20,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.intrinsics;
 
 import compiler.lib.ir_framework.*;
@@ -30,7 +37,7 @@ import jdk.test.lib.Utils;
  * @test
  * @key randomness
  * @bug 8283726 8287925
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="loongarch64"
  * @summary Test the intrinsics implementation of Integer/Long::compareUnsigned
  * @library /test/lib /
  * @run driver compiler.intrinsics.TestCompareUnsigned

--- a/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
@@ -21,10 +21,16 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
 * @test
 * @summary Test x86_64 intrinsic for divideUnsigned() and remainderUnsigned() methods for Long
-* @requires os.arch=="amd64" | os.arch=="x86_64"
+* @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="loongarch64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestLongUnsignedDivMod
 */

--- a/test/hotspot/jtreg/compiler/loopopts/superword/ReductionPerf.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/ReductionPerf.java
@@ -21,11 +21,17 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
  * @test
  * @bug 8074981
  * @summary Add C2 x86 Superword support for scalar product reduction optimizations : int test
- * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="riscv64"
+ * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="riscv64" | os.arch=="loongarch64"
  *
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:LoopUnrollLimit=250 -XX:CompileThresholdScaling=0.1

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
@@ -22,11 +22,17 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @bug 8289996
  * @summary Test range check hoisting for some scaled iv at array index
  * @library /test/lib /
- * @requires vm.debug & vm.compiler2.enabled & (os.simpleArch == "x64" | os.arch == "aarch64")
+ * @requires vm.debug & vm.compiler2.enabled & (os.simpleArch == "x64" | os.arch == "aarch64" | os.arch == "loongarch64")
  * @modules jdk.incubator.vector
  * @compile --enable-preview -source ${jdk.version} TestRangeCheckHoistingScaledIV.java
  * @run main/othervm --enable-preview compiler.rangechecks.TestRangeCheckHoistingScaledIV

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorTest.java
@@ -20,6 +20,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.vectorapi;
 
 import compiler.lib.ir_framework.*;
@@ -34,7 +41,7 @@ import jdk.incubator.vector.VectorMask;
  * @modules jdk.incubator.vector
  * @library /test/lib /
  * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*sse4.*" & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3))
- *           | os.arch == "aarch64"
+ *           | os.arch == "aarch64" | os.arch == "loongarch64"
  * @run driver compiler.vectorapi.TestVectorTest
  */
 public class TestVectorTest {

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
@@ -22,6 +22,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.vectorapi;
 
 import compiler.lib.ir_framework.*;
@@ -45,7 +51,7 @@ import jdk.test.lib.Utils;
  * @key randomness
  * @library /test/lib /
  * @summary Add identity transformations for vector logic operations
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx.*") | os.arch=="aarch64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx.*") | os.arch=="aarch64" | os.arch=="loongarch64"
  * @modules jdk.incubator.vector
  *
  * @run driver compiler.vectorapi.VectorLogicalOpIdentityTest

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorReverseBytesTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorReverseBytesTest.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.vectorapi;
 
 import compiler.lib.ir_framework.*;
@@ -42,7 +48,7 @@ import jdk.test.lib.Utils;
  * @library /test/lib /
  * @summary [vectorapi] REVERSE_BYTES for byte type should not emit any instructions
  * @requires vm.compiler2.enabled
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch == "aarch64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch == "aarch64" | os.arch == "loongarch64"
  * @modules jdk.incubator.vector
  *
  * @run driver compiler.vectorapi.VectorReverseBytesTest

--- a/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.c2.irTests;
 
 import compiler.lib.ir_framework.*;
@@ -34,7 +40,7 @@ import jdk.test.lib.Utils;
  * @library /test/lib /
  * @requires vm.compiler2.enabled
  * @requires (os.simpleArch == "x64" & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3))
- *           | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseRVV == true)
+ *           | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseRVV == true) | os.arch=="loongarch64"
  * @run driver compiler.c2.irTests.TestAutoVecIntMinMax
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
  * @test
  * @bug 8257531
@@ -29,7 +35,7 @@
  *
  * @requires vm.flagless
  * @requires vm.compiler2.enabled & vm.debug == true
- * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="loongarch64"
  *
  * @run driver compiler.vectorization.TestBufferVectorization array
  * @run driver compiler.vectorization.TestBufferVectorization arrayOffset

--- a/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
@@ -21,13 +21,20 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
 * @test
 * @key randomness
 * @summary Test vectorization of numberOfTrailingZeros/numberOfLeadingZeros for Long
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0))
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0)) |
+*           (os.simpleArch == "loongarch64")
 * @library /test/lib /
 * @run driver compiler.vectorization.TestNumberOfContinuousZeros
 */

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
@@ -21,13 +21,20 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
 * @test
 * @bug 8286972
 * @summary Test vectorization of loop induction variable usage in the loop
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0))
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0)) |
+*           (os.simpleArch == "loongarch64")
 * @library /test/lib /
 * @run driver compiler.vectorization.TestPopulateIndex
 */

--- a/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
@@ -20,12 +20,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
  * @test
  * @bug 8290034
  * @summary Auto-vectorization of Reverse bit operation.
  * @requires vm.compiler2.enabled
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch == "aarch64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch == "aarch64" | os.arch=="loongarch64"
  * @library /test/lib /
  * @run driver compiler.vectorization.TestReverseBitsVector
  */

--- a/test/hotspot/jtreg/compiler/vectorization/TestReverseBytes.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReverseBytes.java
@@ -20,12 +20,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
  * @test
  * @bug 8288112
  * @summary Auto-vectorization of ReverseBytes operations.
  * @requires vm.compiler2.enabled
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.simpleArch == "AArch64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.simpleArch == "AArch64" | os.simpleArch == "loongarch64"
  * @library /test/lib /
  * @run driver compiler.vectorization.TestReverseBytes
  */

--- a/test/hotspot/jtreg/compiler/vectorization/TestSignumVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestSignumVector.java
@@ -21,12 +21,18 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
  * @test
  * @bug 8282711 8290249
  * @summary Accelerate Math.signum function for AVX, AVX512 and aarch64 (Neon and SVE)
  * @requires vm.compiler2.enabled
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx.*") | os.arch == "aarch64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx.*") | os.arch == "aarch64" | os.arch == "loongarch64"
  * @library /test/lib /
  * @run driver compiler.vectorization.TestSignumVector
  */

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @summary Vectorization test on array index fill
  * @library /test/lib /
@@ -35,7 +41,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.ArrayIndexFillTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "loongarch64")
  * @requires vm.compiler2.enabled & vm.flagless
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayInvariantFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayInvariantFillTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @summary Vectorization test on array invariant fill
  * @library /test/lib /
@@ -36,7 +42,7 @@
  *                   -XX:-OptimizeFill
  *                   compiler.vectorization.runner.ArrayInvariantFillTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "loongarch64")
  * @requires vm.compiler2.enabled & vm.flagless
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @summary Vectorization test on bug-prone shift operation
  * @library /test/lib /
@@ -35,7 +41,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.ArrayShiftOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "loongarch64")
  * @requires vm.compiler2.enabled & vm.flagless
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @summary Vectorization test on basic double operations
  * @library /test/lib /
@@ -35,7 +41,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicDoubleOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "loongarch64")
  * @requires vm.compiler2.enabled & vm.flagless
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @summary Vectorization test on basic float operations
  * @library /test/lib /
@@ -35,7 +41,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicFloatOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "loongarch64")
  * @requires vm.compiler2.enabled & vm.flagless
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
@@ -23,6 +23,12 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @summary Vectorization test on basic long operations
  * @library /test/lib /
@@ -36,7 +42,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicLongOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "loongarch64")
  * @requires vm.compiler2.enabled & vm.flagless
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopArrayIndexComputeTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopArrayIndexComputeTest.java
@@ -23,6 +23,12 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @summary Vectorization test on loop array index computation
  * @library /test/lib /
@@ -36,7 +42,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.LoopArrayIndexComputeTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "loongarch64")
  * @requires vm.compiler2.enabled & vm.flagless
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @summary Vectorization test on reduction operations
  * @library /test/lib /
@@ -35,7 +41,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.LoopReductionOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "loongarch64")
  * @requires vm.compiler2.enabled & vm.flagless
  *
  */

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 /**
  * @test
  * @enablePreview
@@ -28,7 +34,7 @@
  * @summary guarantee(loc != NULL) failed: missing saved register with native invoke
  *
  * @requires vm.flavor == "server"
- * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch=="loongarch64"
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm --enable-native-access=ALL-UNNAMED -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test id=no-options
  * @summary Run test with no arguments apart from the ones required by
  *          the test.
@@ -38,7 +44,7 @@
  * @library /test/lib
  * @build jdk.test.lib.Platform
  * @requires os.family == "linux"
- * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="loongarch64"
  * @requires vm.gc != "Z"
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx128m -Xlog:pagesize:ps-%p.log -XX:+UseLargePages -XX:LargePageSizeInBytes=2m TestTracePageSizes
  * @run main/othervm -XX:+AlwaysPreTouch -Xmx2g -Xlog:pagesize:ps-%p.log -XX:+UseLargePages -XX:LargePageSizeInBytes=1g TestTracePageSizes

--- a/test/hotspot/jtreg/serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java
+++ b/test/hotspot/jtreg/serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java
@@ -22,6 +22,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package MyPackage;
 
 /**
@@ -29,7 +35,7 @@ package MyPackage;
  * @summary Verifies that AsyncGetCallTrace is call-able and provides sane information.
  * @compile ASGCTBaseTest.java
  * @requires os.family == "linux"
- * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64"
+ * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390" | os.arch=="riscv64" | os.arch=="loongarch64"
  * @requires vm.jvmti
  * @run main/othervm/native -agentlib:AsyncGetCallTraceTest MyPackage.ASGCTBaseTest
  */


### PR DESCRIPTION
30647: Optimize temporary register usage of vectorNode
30702: remove test TestOptoLoopAlignment.java for LoongArch
28218: Fix skiping JTReg tests
30520: UseActiveCoresMP should be able to be turned off on a single-core machine
30278: 8305944: assert(is_aligned(ref, HeapWordSize)) failed: invariant
30039: Fix VectorTest beacause of 8292289
30396: CMoveVF, CMoveVD support
30457: Use membars when accessing volatile _thread_state
30400: LA port of 8232365: Implementation for JEP 363: Remove the Concurrent Mark Sweep (CMS) Garbage Collector