### PR TITLE
Update (2023.05.17)

### DIFF
--- a/src/hotspot/cpu/loongarch/globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globals_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@
 define_pd_global(bool, ImplicitNullChecks,       true);  // Generate code for implicit null checks
 define_pd_global(bool, TrapBasedNullChecks,      false);
 define_pd_global(bool, UncommonNullCast,         true);  // Uncommon-trap NULLs passed to check cast
+
+define_pd_global(bool, DelayCompilerStubsGeneration, COMPILER2_OR_JVMCI);
 
 define_pd_global(uintx, CodeCacheSegmentSize,    64 COMPILER1_AND_COMPILER2_PRESENT(+64)); // Tiered compilation has large code-entry alignment.
 

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
@@ -120,6 +120,8 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void get_cache_index_at_bcp(Register index, int bcp_offset, size_t index_size = sizeof(u2));
   void get_method_counters(Register method, Register mcs, Label& skip);
 
+  void load_resolved_indy_entry(Register cache, Register index);
+
   // load cpool->resolved_references(index);
   void load_resolved_reference_at_index(Register result, Register index, Register tmp);
 

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -323,6 +323,18 @@ void InterpreterMacroAssembler::get_method_counters(Register method,
   bind(has_counters);
 }
 
+void InterpreterMacroAssembler::load_resolved_indy_entry(Register cache, Register index) {
+  // Get index out of bytecode pointer, get_cache_entry_pointer_at_bcp
+  get_cache_index_at_bcp(index, 1, sizeof(u4));
+  // Get address of invokedynamic array
+  ld_d(cache, FP, frame::interpreter_frame_cache_offset * wordSize);
+  ld_d(cache, Address(cache, in_bytes(ConstantPoolCache::invokedynamic_entries_offset())));
+  // Scale the index to be the entry index * sizeof(ResolvedInvokeDynamicInfo)
+  slli_d(index, index, log2i_exact(sizeof(ResolvedIndyEntry)));
+  addi_d(cache, cache, Array<ResolvedIndyEntry>::base_offset_in_bytes());
+  add_d(cache, cache, index);
+}
+
 // Load object from cpool->resolved_references(index)
 void InterpreterMacroAssembler::load_resolved_reference_at_index(
                                            Register result, Register index, Register tmp) {

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1103,6 +1103,10 @@ const int Matcher::scalable_vector_reg_size(const BasicType bt) {
   return -1;
 }
 
+const int Matcher::superword_max_vector_size(const BasicType bt) {
+  return Matcher::max_vector_size(bt);
+}
+
 // Vector ideal reg
 const uint Matcher::vector_ideal_reg(int size) {
   assert(MaxVectorSize == 16 || MaxVectorSize == 32, "");

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
@@ -35,8 +35,11 @@ static bool returns_to_call_stub(address return_pc){
 }
 
 enum platform_dependent_constants {
-  code_size1 = 20000,    // simply increase if too small (assembler will crash if too small)
-  code_size2 = 60000    // simply increase if too small (assembler will crash if too small)
+  // simply increase sizes if too small (assembler will crash if too small)
+  _initial_stubs_code_size      = 20000,
+  _continuation_stubs_code_size =  2000,
+  _compiler_stubs_code_size     = 60000,
+  _final_stubs_code_size        = 60000
 };
 
 class la {


### PR DESCRIPTION
30554: LA port of 8301995: Move invokedynamic resolution information out of ConstantPoolCacheEntry
30553: LA port of 8304301: Remove the global option SuperWordMaxVectorSize
30552: LA port of 8231349: Move intrinsic stubs generation to compiler runtime initialization code