### PR TITLE
Update (2023.07.03)

### DIFF
--- a/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
@@ -1385,6 +1385,15 @@ class Assembler : public AbstractAssembler  {
   static int high6 (int x)        { return high(x, 6); }
 
 
+  static ALWAYSINLINE void patch(address a, int length, uint32_t val) {
+    guarantee(val < (1ULL << length), "Field too big for insn");
+    guarantee(length > 0, "length > 0");
+    unsigned target = *(unsigned *)a;
+    target = (target >> length) << length;
+    target |= val;
+    *(unsigned *)a = target;
+  }
+
  protected:
   // help methods for instruction ejection
 
@@ -2188,18 +2197,25 @@ public:
   void bceqz(ConditionalFlagRegister cj, Label& L)     { bceqz(cj, target(L)); }
   void bcnez(ConditionalFlagRegister cj, Label& L)     { bcnez(cj, target(L)); }
 
-  // Now Membar_mask_bits is 0,Need to fix it after LA6000
   typedef enum {
-    StoreStore = 0,
-    LoadStore  = 0,
-    StoreLoad  = 0,
-    LoadLoad   = 0,
-    AnyAny     = 0
+    // hint[4]
+    Completion = 0,
+    Ordering   = (1 << 4),
+
+    // The bitwise-not of the below constants is corresponding to the hint. This is convenient for OR operation.
+    // hint[3:2] and hint[1:0]
+    LoadLoad   = ((1 << 3) | (1 << 1)),
+    LoadStore  = ((1 << 3) | (1 << 0)),
+    StoreLoad  = ((1 << 2) | (1 << 1)),
+    StoreStore = ((1 << 2) | (1 << 0)),
+    AnyAny     = ((3 << 2) | (3 << 0)),
   } Membar_mask_bits;
 
   // Serializes memory and blows flags
   void membar(Membar_mask_bits hint) {
-    dbar(hint);
+    assert((hint & (3 << 0)) != 0, "membar mask unsupported!");
+    assert((hint & (3 << 2)) != 0, "membar mask unsupported!");
+    dbar(Ordering | (~hint & 0xf));
   }
 
   // LSX and LASX

--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -387,7 +387,7 @@ int LIR_Assembler::emit_unwind_handler() {
   if (method()->is_synchronized()) {
     monitor_address(0, FrameMap::a0_opr);
     stub = new MonitorExitStub(FrameMap::a0_opr, true, 0);
-    if (UseHeavyMonitors) {
+    if (LockingMode == LM_MONITOR) {
       __ b(*stub->entry());
     } else {
       __ unlock_object(A5, A4, A0, *stub->entry());
@@ -2818,7 +2818,7 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register obj = op->obj_opr()->as_register(); // may not be an oop
   Register hdr = op->hdr_opr()->as_register();
   Register lock = op->lock_opr()->as_register();
-  if (UseHeavyMonitors) {
+  if (LockingMode == LM_MONITOR) {
     if (op->info() != nullptr) {
       add_debug_info_for_null_check_here(op->info());
       __ null_check(obj, -1);

--- a/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
@@ -40,9 +40,8 @@
 int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr, Label& slow_case) {
   const int aligned_mask = BytesPerWord -1;
   const int hdr_offset = oopDesc::mark_offset_in_bytes();
-  assert(hdr != obj && hdr != disp_hdr && obj != disp_hdr, "registers must be different");
+  assert_different_registers(hdr, obj, disp_hdr);
   int null_check_offset = -1;
-  Label done;
 
   verify_oop(obj);
 
@@ -61,39 +60,44 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
 
   // Load object header
   ld_d(hdr, Address(obj, hdr_offset));
-  // and mark it as unlocked
-  ori(hdr, hdr, markWord::unlocked_value);
-  // save unlocked object header into the displaced header location on the stack
-  st_d(hdr, Address(disp_hdr, 0));
-  // test if object header is still the same (i.e. unlocked), and if so, store the
-  // displaced header address in the object header - if it is not the same, get the
-  // object header instead
-  lea(SCR2, Address(obj, hdr_offset));
-  cmpxchg(Address(SCR2, 0), hdr, disp_hdr, SCR1, true, false, done);
-  // if the object header was the same, we're done
-  // if the object header was not the same, it is now in the hdr register
-  // => test if it is a stack pointer into the same stack (recursive locking), i.e.:
-  //
-  // 1) (hdr & aligned_mask) == 0
-  // 2) sp <= hdr
-  // 3) hdr <= sp + page_size
-  //
-  // these 3 tests can be done by evaluating the following expression:
-  //
-  // (hdr - sp) & (aligned_mask - page_size)
-  //
-  // assuming both the stack pointer and page_size have their least
-  // significant 2 bits cleared and page_size is a power of 2
-  sub_d(hdr, hdr, SP);
-  li(SCR1, aligned_mask - os::vm_page_size());
-  andr(hdr, hdr, SCR1);
-  // for recursive locking, the result is zero => save it in the displaced header
-  // location (null in the displaced hdr location indicates recursive locking)
-  st_d(hdr, Address(disp_hdr, 0));
-  // otherwise we don't care about the result and handle locking via runtime call
-  bnez(hdr, slow_case);
-  // done
-  bind(done);
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    fast_lock(obj, hdr, SCR1, SCR2, slow_case);
+  } else if (LockingMode == LM_LEGACY) {
+    Label done;
+    // and mark it as unlocked
+    ori(hdr, hdr, markWord::unlocked_value);
+    // save unlocked object header into the displaced header location on the stack
+    st_d(hdr, Address(disp_hdr, 0));
+    // test if object header is still the same (i.e. unlocked), and if so, store the
+    // displaced header address in the object header - if it is not the same, get the
+    // object header instead
+    lea(SCR2, Address(obj, hdr_offset));
+    cmpxchg(Address(SCR2, 0), hdr, disp_hdr, SCR1, true, false, done);
+    // if the object header was the same, we're done
+    // if the object header was not the same, it is now in the hdr register
+    // => test if it is a stack pointer into the same stack (recursive locking), i.e.:
+    //
+    // 1) (hdr & aligned_mask) == 0
+    // 2) sp <= hdr
+    // 3) hdr <= sp + page_size
+    //
+    // these 3 tests can be done by evaluating the following expression:
+    //
+    // (hdr - sp) & (aligned_mask - page_size)
+    //
+    // assuming both the stack pointer and page_size have their least
+    // significant 2 bits cleared and page_size is a power of 2
+    sub_d(hdr, hdr, SP);
+    li(SCR1, aligned_mask - os::vm_page_size());
+    andr(hdr, hdr, SCR1);
+    // for recursive locking, the result is zero => save it in the displaced header
+    // location (null in the displaced hdr location indicates recursive locking)
+    st_d(hdr, Address(disp_hdr, 0));
+    // otherwise we don't care about the result and handle locking via runtime call
+    bnez(hdr, slow_case);
+    // done
+    bind(done);
+  }
   increment(Address(TREG, JavaThread::held_monitor_count_offset()), 1);
   return null_check_offset;
 }
@@ -104,27 +108,39 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
   assert(hdr != obj && hdr != disp_hdr && obj != disp_hdr, "registers must be different");
   Label done;
 
-  // load displaced header
-  ld_d(hdr, Address(disp_hdr, 0));
-  // if the loaded hdr is null we had recursive locking
-  // if we had recursive locking, we are done
-  beqz(hdr, done);
+  if (LockingMode != LM_LIGHTWEIGHT) {
+    // load displaced header
+    ld_d(hdr, Address(disp_hdr, 0));
+    // if the loaded hdr is null we had recursive locking
+    // if we had recursive locking, we are done
+    beqz(hdr, done);
+  }
+
   // load object
   ld_d(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
   verify_oop(obj);
-  // test if object header is pointing to the displaced header, and if so, restore
-  // the displaced header in the object - if the object header is not pointing to
-  // the displaced header, get the object header instead
-  // if the object header was not pointing to the displaced header,
-  // we do unlocking via runtime call
-  if (hdr_offset) {
-    lea(SCR1, Address(obj, hdr_offset));
-    cmpxchg(Address(SCR1, 0), disp_hdr, hdr, SCR2, false, false, done, &slow_case);
-  } else {
-    cmpxchg(Address(obj, 0), disp_hdr, hdr, SCR2, false, false, done, &slow_case);
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    ld_d(hdr, Address(obj, oopDesc::mark_offset_in_bytes()));
+    // We cannot use tbnz here, the target might be too far away and cannot
+    // be encoded.
+    andi(AT, hdr, markWord::monitor_value);
+    bnez(AT, slow_case);
+    fast_unlock(obj, hdr, SCR1, SCR2, slow_case);
+  } else if (LockingMode == LM_LEGACY) {
+    // test if object header is pointing to the displaced header, and if so, restore
+    // the displaced header in the object - if the object header is not pointing to
+    // the displaced header, get the object header instead
+    // if the object header was not pointing to the displaced header,
+    // we do unlocking via runtime call
+    if (hdr_offset) {
+      lea(SCR1, Address(obj, hdr_offset));
+      cmpxchg(Address(SCR1, 0), disp_hdr, hdr, SCR2, false, false, done, &slow_case);
+    } else {
+      cmpxchg(Address(obj, 0), disp_hdr, hdr, SCR2, false, false, done, &slow_case);
+    }
+    // done
+    bind(done);
   }
-  // done
-  bind(done);
   decrement(Address(TREG, JavaThread::held_monitor_count_offset()), 1);
 }
 

--- a/src/hotspot/cpu/loongarch/c1_Runtime1_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_Runtime1_loongarch_64.cpp
@@ -551,7 +551,7 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
   { Label L;
     __ get_thread(SCR1);
     __ beq(TREG, SCR1, L);
-    __ stop("StubAssembler::call_RT: rthread not callee saved?");
+    __ stop("StubAssembler::call_RT: TREG not callee saved?");
     __ bind(L);
   }
 #endif

--- a/src/hotspot/cpu/loongarch/c2_CodeStubs_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_CodeStubs_loongarch.cpp
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 #include "opto/c2_MacroAssembler.hpp"
 #include "opto/c2_CodeStubs.hpp"
+#include "runtime/objectMonitor.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 
@@ -59,6 +60,32 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ bind(guard());
   __ relocate(entry_guard_Relocation::spec());
   __ emit_int32(0);  // nmethod guard value
+}
+
+int C2HandleAnonOMOwnerStub::max_size() const {
+  // Max size of stub has been determined by testing with 0, in which case
+  // C2CodeStubList::emit() will throw an assertion and report the actual size that
+  // is needed.
+  return 24;
+}
+
+void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
+  __ bind(entry());
+  Register mon = monitor();
+  Register t = tmp();
+  assert(t != noreg, "need tmp register");
+  // Fix owner to be the current thread.
+  __ st_d(TREG, Address(mon, ObjectMonitor::owner_offset_in_bytes()));
+
+  // Pop owner object from lock-stack.
+  __ ld_wu(t, Address(TREG, JavaThread::lock_stack_top_offset()));
+  __ addi_w(t, t, -oopSize);
+#ifdef ASSERT
+  __ stx_d(R0, TREG, t);
+#endif
+  __ st_w(t, Address(TREG, JavaThread::lock_stack_top_offset()));
+
+  __ b(continuation());
 }
 
 #undef __

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
@@ -33,9 +33,9 @@ public:
   void cmp_branch_long(int flag, Register op1, Register op2, Label* L, bool is_signed);
   void cmp_branchEqNe_off21(int flag, Register op1, Label& L);
 
-  void fast_lock(Register oop, Register box, Register flag,
+  void fast_lock_c2(Register oop, Register box, Register flag,
                  Register disp_hdr, Register tmp);
-  void fast_unlock(Register oop, Register box, Register flag,
+  void fast_unlock_c2(Register oop, Register box, Register flag,
                    Register disp_hdr, Register tmp);
 
   // Compare strings.

--- a/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.cpp
@@ -283,7 +283,7 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
 }
 
 void G1BarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                                         Address dst, Register val, Register tmp1, Register tmp2) {
+                                         Address dst, Register val, Register tmp1, Register tmp2, Register tmp3) {
   bool in_heap = (decorators & IN_HEAP) != 0;
   bool as_normal = (decorators & AS_NORMAL) != 0;
   assert((decorators & IS_DEST_UNINITIALIZED) == 0, "unsupported");
@@ -291,7 +291,6 @@ void G1BarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet deco
   bool needs_pre_barrier = as_normal;
   bool needs_post_barrier = val != noreg && in_heap;
 
-  Register tmp3 = T3;
   // flatten object address if needed
   // We do it regardless of precise because we need the registers
   if (dst.index() == noreg && dst.disp() == 0) {
@@ -312,7 +311,7 @@ void G1BarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet deco
                          false /* expand_call */);
   }
   if (val == noreg) {
-    BarrierSetAssembler::store_at(masm, decorators, type, Address(tmp3, 0), val, noreg, noreg);
+    BarrierSetAssembler::store_at(masm, decorators, type, Address(tmp3, 0), val, noreg, noreg, noreg);
   } else {
     Register new_val = val;
     if (needs_post_barrier) {
@@ -322,7 +321,7 @@ void G1BarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet deco
         __ move(new_val, val);
       }
     }
-    BarrierSetAssembler::store_at(masm, decorators, type, Address(tmp3, 0), val, noreg, noreg);
+    BarrierSetAssembler::store_at(masm, decorators, type, Address(tmp3, 0), val, noreg, noreg, noreg);
     if (needs_post_barrier) {
       g1_write_barrier_post(masm /*masm*/,
                             tmp3 /* store_adr */,

--- a/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ class G1BarrierSetAssembler: public ModRefBarrierSetAssembler {
                              Register tmp2);
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                            Address dst, Register val, Register tmp1, Register tmp2);
+                            Address dst, Register val, Register tmp1, Register tmp2, Register tmp3);
 
  public:
   void gen_pre_barrier_stub(LIR_Assembler* ce, G1PreBarrierStub* stub);

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
@@ -85,7 +85,7 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
 }
 
 void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                                   Address dst, Register val, Register tmp1, Register tmp2) {
+                                   Address dst, Register val, Register tmp1, Register tmp2, Register tmp3) {
   bool in_heap = (decorators & IN_HEAP) != 0;
   bool in_native = (decorators & IN_NATIVE) != 0;
   bool is_not_null = (decorators & IS_NOT_NULL) != 0;

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.hpp
@@ -56,7 +56,7 @@ public:
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register dst, Address src, Register tmp1, Register tmp_thread);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                        Address dst, Register val, Register tmp1, Register tmp2);
+                        Address dst, Register val, Register tmp1, Register tmp2, Register tmp3);
 
 
   virtual void obj_equals(MacroAssembler* masm,

--- a/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.cpp
@@ -97,14 +97,14 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
 }
 
 void CardTableBarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                                                Address dst, Register val, Register tmp1, Register tmp2) {
+                                                Address dst, Register val, Register tmp1, Register tmp2, Register tmp3) {
   bool in_heap = (decorators & IN_HEAP) != 0;
   bool is_array = (decorators & IS_ARRAY) != 0;
   bool on_anonymous = (decorators & ON_UNKNOWN_OOP_REF) != 0;
   bool precise = is_array || on_anonymous;
 
   bool needs_post_barrier = val != noreg && in_heap;
-  BarrierSetAssembler::store_at(masm, decorators, type, dst, val, noreg, noreg);
+  BarrierSetAssembler::store_at(masm, decorators, type, dst, val, noreg, noreg, noreg);
   if (needs_post_barrier) {
     // flatten object address if needed
     if (!precise || (dst.index() == noreg && dst.disp() == 0)) {

--- a/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2018, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ protected:
                                                 RegSet saved_regs);
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                            Address dst, Register val, Register tmp1, Register tmp2);
+                            Address dst, Register val, Register tmp1, Register tmp2, Register tmp3);
 };
 
 #endif // CPU_LOONGARCH_GC_SHARED_CARDTABLEBARRIERSETASSEMBLER_LOONGARCH_HPP

--- a/src/hotspot/cpu/loongarch/gc/shared/modRefBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/modRefBarrierSetAssembler_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2018, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,10 +44,10 @@ void ModRefBarrierSetAssembler::arraycopy_epilogue(MacroAssembler* masm, Decorat
 }
 
 void ModRefBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                                         Address dst, Register val, Register tmp1, Register tmp2) {
+                                         Address dst, Register val, Register tmp1, Register tmp2, Register tmp3) {
   if (type == T_OBJECT || type == T_ARRAY) {
-    oop_store_at(masm, decorators, type, dst, val, tmp1, tmp2);
+    oop_store_at(masm, decorators, type, dst, val, tmp1, tmp2, tmp3);
   } else {
-    BarrierSetAssembler::store_at(masm, decorators, type, dst, val, tmp1, tmp2);
+    BarrierSetAssembler::store_at(masm, decorators, type, dst, val, tmp1, tmp2, tmp3);
   }
 }

--- a/src/hotspot/cpu/loongarch/gc/shared/modRefBarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/modRefBarrierSetAssembler_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2018, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ protected:
   virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators,
                                                 Register addr, Register count, Register tmp, RegSet saved_regs) {}
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                            Address dst, Register val, Register tmp1, Register tmp2) = 0;
+                            Address dst, Register val, Register tmp1, Register tmp2, Register tmp3) = 0;
 public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
                                   Register src, Register dst, Register count, RegSet saved_regs);
@@ -48,7 +48,7 @@ public:
                                   Register dst, Register count, Register scratch, RegSet saved_regs);
 
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                        Address dst, Register val, Register tmp1, Register tmp2);
+                        Address dst, Register val, Register tmp1, Register tmp2, Register tmp3);
 };
 
 #endif // CPU_LOONGARCH_GC_SHARED_MODREFBARRIERSETASSEMBLER_LOONGARCH_HPP

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2021, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public:
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register dst, Address src, Register tmp1, Register tmp_thread);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                        Address dst, Register val, Register tmp1, Register tmp2);
+                        Address dst, Register val, Register tmp1, Register tmp2, Register tmp3);
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);
   void cmpxchg_oop(MacroAssembler* masm, Register mem, Register expected, Register new_val,

--- a/src/hotspot/cpu/loongarch/gc/z/zBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/z/zBarrierSetAssembler_loongarch.cpp
@@ -123,7 +123,8 @@ void ZBarrierSetAssembler::store_at(MacroAssembler* masm,
                                         Address dst,
                                         Register val,
                                         Register tmp1,
-                                        Register tmp2) {
+                                        Register tmp2,
+                                        Register tmp3) {
   // Verify value
   if (is_reference_type(type)) {
     // Note that src could be noreg, which means we
@@ -131,7 +132,7 @@ void ZBarrierSetAssembler::store_at(MacroAssembler* masm,
     if (val != noreg) {
       Label done;
 
-      // tmp1 and tmp2 are often set to noreg.
+      // tmp1, tmp2 and tmp3 are often set to noreg.
 
       __ ld_d(AT, address_bad_mask_from_thread(TREG));
       __ andr(AT, val, AT);
@@ -143,7 +144,7 @@ void ZBarrierSetAssembler::store_at(MacroAssembler* masm,
   }
 
   // Store value
-  BarrierSetAssembler::store_at(masm, decorators, type, dst, val, tmp1, tmp2);
+  BarrierSetAssembler::store_at(masm, decorators, type, dst, val, tmp1, tmp2, noreg);
 }
 
 #endif // ASSERT

--- a/src/hotspot/cpu/loongarch/gc/z/zBarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/z/zBarrierSetAssembler_loongarch.hpp
@@ -60,7 +60,8 @@ public:
                         Address dst,
                         Register val,
                         Register tmp1,
-                        Register tmp2);
+                        Register tmp2,
+                        Register tmp3);
 #endif // ASSERT
 
   virtual void arraycopy_prologue(MacroAssembler* masm,

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -11478,7 +11478,7 @@ instruct cmpFastLock(FlagsReg cr, no_CR_mRegP object, no_CR_mRegP box, no_CR_mRe
   format %{ "FASTLOCK $cr <-- $object, $box, $tmp1, $tmp2 #@ cmpFastLock" %}
 
   ins_encode %{
-    __ fast_lock($object$$Register, $box$$Register, $cr$$Register, $tmp1$$Register, $tmp2$$Register);
+    __ fast_lock_c2($object$$Register, $box$$Register, $cr$$Register, $tmp1$$Register, $tmp2$$Register);
   %}
 
   ins_pipe( pipe_slow );
@@ -11491,7 +11491,7 @@ instruct cmpFastUnlock(FlagsReg cr, no_CR_mRegP object, no_CR_mRegP box, no_CR_m
   format %{ "FASTUNLOCK $cr <-- $object, $box, $tmp1, $tmp2 #@ cmpFastUnlock" %}
 
   ins_encode %{
-    __ fast_unlock($object$$Register, $box$$Register, $cr$$Register, $tmp1$$Register, $tmp2$$Register);
+    __ fast_unlock_c2($object$$Register, $box$$Register, $cr$$Register, $tmp1$$Register, $tmp2$$Register);
   %}
 
   ins_pipe( pipe_slow );

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -8236,6 +8236,23 @@ instruct cmpL3_reg_zero(mRegI dst, mRegL src1, immL_0 zero) %{
   ins_pipe( pipe_slow );
 %}
 
+// Manifest a CmpU result in an integer register.  Very painful.
+// This is the test to avoid.
+instruct cmpU3_reg_reg(mRegI dst, mRegI src1, mRegI src2) %{
+  match(Set dst (CmpU3 src1 src2));
+  format %{ "cmpU3  $dst, $src1, $src2 @ cmpU3_reg_reg" %}
+  ins_encode %{
+    Register opr1 = as_Register($src1$$reg);
+    Register opr2 = as_Register($src2$$reg);
+    Register dst  = as_Register($dst$$reg);
+
+    __ sltu(AT, opr1, opr2);
+    __ sltu(dst, opr2, opr1);
+    __ sub_d(dst, dst, AT);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 instruct cmpL3_reg_reg(mRegI dst, mRegL src1, mRegL src2) %{
   match(Set dst (CmpL3 src1 src2));
   ins_cost(1000);
@@ -8247,6 +8264,23 @@ instruct cmpL3_reg_reg(mRegI dst, mRegL src1, mRegL src2) %{
 
     __ slt(AT, opr1, opr2);
     __ slt(dst, opr2, opr1);
+    __ sub_d(dst, dst, AT);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+// Manifest a CmpUL result in an integer register.  Very painful.
+// This is the test to avoid.
+instruct cmpUL3_reg_reg(mRegI dst, mRegLorI2L src1, mRegLorI2L src2) %{
+  match(Set dst (CmpUL3 src1 src2));
+  format %{ "cmpUL3  $dst, $src1, $src2 @ cmpUL3_reg_reg" %}
+  ins_encode %{
+    Register opr1 = as_Register($src1$$reg);
+    Register opr2 = as_Register($src2$$reg);
+    Register dst  = as_Register($dst$$reg);
+
+    __ sltu(AT, opr1, opr2);
+    __ sltu(dst, opr2, opr1);
     __ sub_d(dst, dst, AT);
   %}
   ins_pipe( pipe_slow );

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -2064,7 +2064,7 @@ void MachPrologNode::format( PhaseRegAlloc *ra_, outputStream* st ) const {
   if (C->stub_function() == nullptr && BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
     st->print("\n\t");
     st->print("ld_d  T1, guard, 0\n\t");
-    st->print("dbar  0\n\t");
+    st->print("membar  LoadLoad\n\t");
     st->print("ld_d  T2, TREG, thread_disarmed_guard_value_offset\n\t");
     st->print("beq   T1, T2, skip\n\t");
     st->print("\n\t");

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -1708,14 +1708,14 @@ void MacroAssembler::access_load_at(BasicType type, DecoratorSet decorators, Reg
 }
 
 void MacroAssembler::access_store_at(BasicType type, DecoratorSet decorators, Address dst, Register val,
-                                     Register tmp1, Register tmp2) {
+                                     Register tmp1, Register tmp2, Register tmp3) {
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   decorators = AccessInternal::decorator_fixup(decorators, type);
   bool as_raw = (decorators & AS_RAW) != 0;
   if (as_raw) {
-    bs->BarrierSetAssembler::store_at(this, decorators, type, dst, val, tmp1, tmp2);
+    bs->BarrierSetAssembler::store_at(this, decorators, type, dst, val, tmp1, tmp2, tmp3);
   } else {
-    bs->store_at(this, decorators, type, dst, val, tmp1, tmp2);
+    bs->store_at(this, decorators, type, dst, val, tmp1, tmp2, tmp3);
   }
 }
 
@@ -1731,13 +1731,13 @@ void MacroAssembler::load_heap_oop_not_null(Register dst, Address src, Register 
 }
 
 void MacroAssembler::store_heap_oop(Address dst, Register val, Register tmp1,
-                                    Register tmp2, DecoratorSet decorators) {
-  access_store_at(T_OBJECT, IN_HEAP | decorators, dst, val, tmp1, tmp2);
+                                    Register tmp2, Register tmp3, DecoratorSet decorators) {
+  access_store_at(T_OBJECT, IN_HEAP | decorators, dst, val, tmp1, tmp2, tmp3);
 }
 
 // Used for storing NULLs.
 void MacroAssembler::store_heap_oop_null(Address dst) {
-  access_store_at(T_OBJECT, IN_HEAP, dst, noreg, noreg, noreg);
+  access_store_at(T_OBJECT, IN_HEAP, dst, noreg, noreg, noreg, noreg);
 }
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -697,6 +697,9 @@ class MacroAssembler: public Assembler {
     }
   }
 
+  void fast_lock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
+  void fast_unlock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
+
 private:
   void push(unsigned int bitset);
   void pop(unsigned int bitset);

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -267,14 +267,14 @@ class MacroAssembler: public Assembler {
   void access_load_at(BasicType type, DecoratorSet decorators, Register dst, Address src,
                       Register tmp1, Register thread_tmp);
   void access_store_at(BasicType type, DecoratorSet decorators, Address dst, Register val,
-                       Register tmp1, Register tmp2);
+                       Register tmp1, Register tmp2, Register tmp3);
 
   void load_heap_oop(Register dst, Address src, Register tmp1,
                      Register thread_tmp = noreg, DecoratorSet decorators = 0);
   void load_heap_oop_not_null(Register dst, Address src, Register tmp1 = noreg,
                               Register thread_tmp = noreg, DecoratorSet decorators = 0);
   void store_heap_oop(Address dst, Register val, Register tmp1 = noreg,
-                      Register tmp2 = noreg, DecoratorSet decorators = 0);
+                      Register tmp2 = noreg, Register tmp3 = noreg, DecoratorSet decorators = 0);
 
   // Used for storing null. All other oop constants should be
   // stored using routines that take a jobject.

--- a/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
@@ -38,9 +38,9 @@
     return false;
   }
 
-  // LoongArch doesn't support misaligned vectors store/load? FIXME
+  // LoongArch support misaligned vectors store/load
   static constexpr bool misaligned_vectors_ok() {
-    return false;
+    return true;
   }
 
   // Whether code generation need accurate ConvI2L types.

--- a/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
@@ -585,4 +585,10 @@ class NativeDeoptInstruction: public NativeInstruction {
   static void insert(address code_pos);
 };
 
+class NativeMembar : public NativeInstruction {
+public:
+  unsigned int get_hint() { return Assembler::low(insn_word(), 4); }
+  void set_hint(int hint) { Assembler::patch(addr_at(0), 4, hint); }
+};
+
 #endif // CPU_LOONGARCH_NATIVEINST_LOONGARCH_HPP

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -2508,7 +2508,7 @@ class StubGenerator: public StubCodeGenerator {
     __ align(OptoLoopAlignment);
 
     __ bind(L_store_element);
-    __ store_heap_oop(Address(to, 0), copied_oop, tmp1, tmp2, AS_RAW); // store the oop
+    __ store_heap_oop(Address(to, 0), copied_oop, tmp1, tmp2, noreg, AS_RAW); // store the oop
     __ addi_d(to, to, UseCompressedOops ? 4 : 8);
     __ addi_d(count, count, -1);
     __ beqz(count, L_do_card_marks);

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -2255,10 +2255,10 @@ void TemplateTable::load_field_cp_cache_entry(Register obj,
 
 // The Rmethod register is input and overwritten to be the adapter method for the
 // indy call. Return address (ra) is set to the return address for the adapter and
-// an appendix may be pushed to the stack. Registers A0-A3 are clobbered.
+// an appendix may be pushed to the stack. Registers A2-A3 are clobbered.
 void TemplateTable::load_invokedynamic_entry(Register method) {
   // setup registers
-  const Register appendix = A0;
+  const Register appendix = T2;
   const Register cache = A2;
   const Register index = A3;
   assert_different_registers(method, appendix, cache, index);

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -108,7 +108,7 @@ static void do_oop_store(InterpreterMacroAssembler* _masm,
                          Register val,
                          DecoratorSet decorators = 0) {
   assert(val == noreg || val == V0, "parameter is just for looks");
-  __ store_heap_oop(dst, val, T4, T1, decorators);
+  __ store_heap_oop(dst, val, T4, T1, T3, decorators);
 }
 
 static void do_oop_load(InterpreterMacroAssembler* _masm,
@@ -962,7 +962,7 @@ void TemplateTable::iastore() {
   __ pop_i(T2);
   index_check(A1, T2);
   __ alsl_d(A1, T2, A1, Address::times_4 - 1);
-  __ access_store_at(T_INT, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_INT)), FSR, noreg, noreg);
+  __ access_store_at(T_INT, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_INT)), FSR, noreg, noreg, noreg);
 }
 
 // used register T2, T3
@@ -971,7 +971,7 @@ void TemplateTable::lastore() {
   __ pop_i (T2);
   index_check(T3, T2);
   __ alsl_d(T3, T2, T3, Address::times_8 - 1);
-  __ access_store_at(T_LONG, IN_HEAP | IS_ARRAY, Address(T3, arrayOopDesc::base_offset_in_bytes(T_LONG)), FSR, noreg, noreg);
+  __ access_store_at(T_LONG, IN_HEAP | IS_ARRAY, Address(T3, arrayOopDesc::base_offset_in_bytes(T_LONG)), FSR, noreg, noreg, noreg);
 }
 
 // used register T2
@@ -980,7 +980,7 @@ void TemplateTable::fastore() {
   __ pop_i(T2);
   index_check(A1, T2);
   __ alsl_d(A1, T2, A1, Address::times_4 - 1);
-  __ access_store_at(T_FLOAT, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_FLOAT)), noreg, noreg, noreg);
+  __ access_store_at(T_FLOAT, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_FLOAT)), noreg, noreg, noreg, noreg);
 }
 
 // used register T2, T3
@@ -989,7 +989,7 @@ void TemplateTable::dastore() {
   __ pop_i (T2);
   index_check(T3, T2);
   __ alsl_d(T3, T2, T3, Address::times_8 - 1);
-  __ access_store_at(T_DOUBLE, IN_HEAP | IS_ARRAY, Address(T3, arrayOopDesc::base_offset_in_bytes(T_DOUBLE)), noreg, noreg, noreg);
+  __ access_store_at(T_DOUBLE, IN_HEAP | IS_ARRAY, Address(T3, arrayOopDesc::base_offset_in_bytes(T_DOUBLE)), noreg, noreg, noreg, noreg);
 }
 
 void TemplateTable::aastore() {
@@ -1056,7 +1056,7 @@ void TemplateTable::bastore() {
   __ bind(L_skip);
 
   __ add_d(A1, A1, T2);
-  __ access_store_at(T_BYTE, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_BYTE)), FSR, noreg, noreg);
+  __ access_store_at(T_BYTE, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_BYTE)), FSR, noreg, noreg, noreg);
 }
 
 void TemplateTable::castore() {
@@ -1064,7 +1064,7 @@ void TemplateTable::castore() {
   __ pop_i(T2);
   index_check(A1, T2);
   __ alsl_d(A1, T2, A1, Address::times_2 - 1);
-  __ access_store_at(T_CHAR, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_CHAR)), FSR, noreg, noreg);
+  __ access_store_at(T_CHAR, IN_HEAP | IS_ARRAY, Address(A1, arrayOopDesc::base_offset_in_bytes(T_CHAR)), FSR, noreg, noreg, noreg);
 }
 
 void TemplateTable::sastore() {
@@ -2697,7 +2697,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     pop_and_check_object(obj);
   }
   __ add_d(T4, obj, off);
-  __ access_store_at(T_BYTE, IN_HEAP, Address(T4), FSR, noreg, noreg);
+  __ access_store_at(T_BYTE, IN_HEAP, Address(T4), FSR, noreg, noreg, noreg);
 
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_bputfield, bc, off, true, byte_no);
@@ -2715,7 +2715,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
   }
   __ add_d(T4, obj, off);
   __ andi(FSR, FSR, 0x1);
-  __ access_store_at(T_BOOLEAN, IN_HEAP, Address(T4), FSR, noreg, noreg);
+  __ access_store_at(T_BOOLEAN, IN_HEAP, Address(T4), FSR, noreg, noreg, noreg);
 
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_zputfield, bc, off, true, byte_no);
@@ -2732,7 +2732,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     pop_and_check_object(obj);
   }
   __ add_d(T4, obj, off);
-  __ access_store_at(T_INT, IN_HEAP, Address(T4), FSR, noreg, noreg);
+  __ access_store_at(T_INT, IN_HEAP, Address(T4), FSR, noreg, noreg, noreg);
 
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_iputfield, bc, off, true, byte_no);
@@ -2766,7 +2766,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     pop_and_check_object(obj);
   }
   __ add_d(T4, obj, off);
-  __ access_store_at(T_CHAR, IN_HEAP, Address(T4), FSR, noreg, noreg);
+  __ access_store_at(T_CHAR, IN_HEAP, Address(T4), FSR, noreg, noreg, noreg);
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_cputfield, bc, off, true, byte_no);
   }
@@ -2782,7 +2782,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     pop_and_check_object(obj);
   }
   __ add_d(T4, obj, off);
-  __ access_store_at(T_SHORT, IN_HEAP, Address(T4), FSR, noreg, noreg);
+  __ access_store_at(T_SHORT, IN_HEAP, Address(T4), FSR, noreg, noreg, noreg);
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_sputfield, bc, off, true, byte_no);
   }
@@ -2798,7 +2798,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     pop_and_check_object(obj);
   }
   __ add_d(T4, obj, off);
-  __ access_store_at(T_LONG, IN_HEAP, Address(T4), FSR, noreg, noreg);
+  __ access_store_at(T_LONG, IN_HEAP, Address(T4), FSR, noreg, noreg, noreg);
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_lputfield, bc, off, true, byte_no);
   }
@@ -2814,7 +2814,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     pop_and_check_object(obj);
   }
   __ add_d(T4, obj, off);
-  __ access_store_at(T_FLOAT, IN_HEAP, Address(T4), noreg, noreg, noreg);
+  __ access_store_at(T_FLOAT, IN_HEAP, Address(T4), noreg, noreg, noreg, noreg);
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_fputfield, bc, off, true, byte_no);
   }
@@ -2833,7 +2833,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     pop_and_check_object(obj);
   }
   __ add_d(T4, obj, off);
-  __ access_store_at(T_DOUBLE, IN_HEAP, Address(T4), noreg, noreg, noreg);
+  __ access_store_at(T_DOUBLE, IN_HEAP, Address(T4), noreg, noreg, noreg, noreg);
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_dputfield, bc, off, true, byte_no);
   }
@@ -2976,28 +2976,28 @@ void TemplateTable::fast_storefield(TosState state) {
   switch (bytecode()) {
     case Bytecodes::_fast_zputfield:
       __ andi(FSR, FSR, 0x1);  // boolean is true if LSB is 1
-      __ access_store_at(T_BOOLEAN, IN_HEAP, Address(T2), FSR, noreg, noreg);
+      __ access_store_at(T_BOOLEAN, IN_HEAP, Address(T2), FSR, noreg, noreg, noreg);
       break;
     case Bytecodes::_fast_bputfield:
-      __ access_store_at(T_BYTE, IN_HEAP, Address(T2), FSR, noreg, noreg);
+      __ access_store_at(T_BYTE, IN_HEAP, Address(T2), FSR, noreg, noreg, noreg);
       break;
     case Bytecodes::_fast_sputfield:
-      __ access_store_at(T_SHORT, IN_HEAP, Address(T2), FSR, noreg, noreg);
+      __ access_store_at(T_SHORT, IN_HEAP, Address(T2), FSR, noreg, noreg, noreg);
       break;
     case Bytecodes::_fast_cputfield:
-      __ access_store_at(T_CHAR, IN_HEAP, Address(T2), FSR, noreg, noreg);
+      __ access_store_at(T_CHAR, IN_HEAP, Address(T2), FSR, noreg, noreg, noreg);
       break;
     case Bytecodes::_fast_iputfield:
-      __ access_store_at(T_INT, IN_HEAP, Address(T2), FSR, noreg, noreg);
+      __ access_store_at(T_INT, IN_HEAP, Address(T2), FSR, noreg, noreg, noreg);
       break;
     case Bytecodes::_fast_lputfield:
-      __ access_store_at(T_LONG, IN_HEAP, Address(T2), FSR, noreg, noreg);
+      __ access_store_at(T_LONG, IN_HEAP, Address(T2), FSR, noreg, noreg, noreg);
       break;
     case Bytecodes::_fast_fputfield:
-      __ access_store_at(T_FLOAT, IN_HEAP, Address(T2), noreg, noreg, noreg);
+      __ access_store_at(T_FLOAT, IN_HEAP, Address(T2), noreg, noreg, noreg, noreg);
       break;
     case Bytecodes::_fast_dputfield:
-      __ access_store_at(T_DOUBLE, IN_HEAP, Address(T2), noreg, noreg, noreg);
+      __ access_store_at(T_DOUBLE, IN_HEAP, Address(T2), noreg, noreg, noreg, noreg);
       break;
     case Bytecodes::_fast_aputfield:
       do_oop_store(_masm, Address(T3, T2, Address::no_scale, 0), FSR);

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -2144,38 +2144,6 @@ void TemplateTable::_return(TosState state) {
   __ jr(RA);
 }
 
-// ----------------------------------------------------------------------------
-// Volatile variables demand their effects be made known to all CPU's
-// in order.  Store buffers on most chips allow reads & writes to
-// reorder; the JMM's ReadAfterWrite.java test fails in -Xint mode
-// without some kind of memory barrier (i.e., it's not sufficient that
-// the interpreter does not reorder volatile references, the hardware
-// also must not reorder them).
-//
-// According to the new Java Memory Model (JMM):
-// (1) All volatiles are serialized wrt to each other.  ALSO reads &
-//     writes act as acquire & release, so:
-// (2) A read cannot let unrelated NON-volatile memory refs that
-//     happen after the read float up to before the read.  It's OK for
-//     non-volatile memory refs that happen before the volatile read to
-//     float down below it.
-// (3) Similar a volatile write cannot let unrelated NON-volatile
-//     memory refs that happen BEFORE the write float down to after the
-//     write.  It's OK for non-volatile memory refs that happen after the
-//     volatile write to float up before it.
-//
-// We only put in barriers around volatile refs (they are expensive),
-// not _between_ memory refs (that would require us to track the
-// flavor of the previous memory refs).  Requirements (2) and (3)
-// require some barriers before volatile stores and after volatile
-// loads.  These nearly cover requirement (1) but miss the
-// volatile-store-volatile-load case.  This final case is placed after
-// volatile-stores although it could just as well go before
-// volatile-loads.
-void TemplateTable::volatile_barrier() {
-  if(os::is_MP()) __ membar(__ StoreLoad);
-}
-
 // we dont shift left 2 bits in get_cache_and_index_at_bcp
 // for we always need shift the index we use it. the ConstantPoolCacheEntry
 // is 16-byte long, index is the index in
@@ -2448,7 +2416,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(MacroAssembler::AnyAny);
     __ bind(notVolatile);
   }
 
@@ -2594,7 +2562,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
     __ bind(notVolatile);
   }
 }
@@ -2710,7 +2678,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ StoreStore | __ LoadStore));
     __ bind(notVolatile);
   }
 
@@ -2882,7 +2850,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ StoreLoad | __ StoreStore));
     __ bind(notVolatile);
   }
 }
@@ -2992,7 +2960,7 @@ void TemplateTable::fast_storefield(TosState state) {
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ StoreStore | __ LoadStore));
     __ bind(notVolatile);
   }
 
@@ -3041,7 +3009,7 @@ void TemplateTable::fast_storefield(TosState state) {
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ StoreLoad | __ StoreStore));
     __ bind(notVolatile);
   }
 }
@@ -3092,7 +3060,7 @@ void TemplateTable::fast_accessfield(TosState state) {
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(MacroAssembler::AnyAny);
     __ bind(notVolatile);
   }
 
@@ -3136,7 +3104,7 @@ void TemplateTable::fast_accessfield(TosState state) {
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
     __ bind(notVolatile);
   }
 }
@@ -3166,7 +3134,7 @@ void TemplateTable::fast_xaccess(TosState state) {
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(MacroAssembler::AnyAny);
     __ bind(notVolatile);
   }
 
@@ -3191,7 +3159,7 @@ void TemplateTable::fast_xaccess(TosState state) {
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
     __ bind(notVolatile);
   }
 }

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -434,6 +434,12 @@ void VM_Version::get_processor_features() {
       FLAG_SET_DEFAULT(UseActiveCoresMP, true);
     }
   }
+
+#ifdef COMPILER2
+  if (FLAG_IS_DEFAULT(AlignVector)) {
+    AlignVector = false;
+  }
+#endif // COMPILER2
 }
 
 void VM_Version::initialize() {

--- a/src/hotspot/os_cpu/linux_loongarch/atomic_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/atomic_linux_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,7 +175,7 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
       "   sc.w %[temp], %[dest]     \n\t"
       "   beqz %[temp], 1b          \n\t"
       "   b    3f                   \n\t"
-      "2: dbar 0                    \n\t"
+      "2: dbar 0x700                 \n\t"
       "3:                           \n\t"
       : [prev] "=&r" (prev), [temp] "=&r" (temp)
       : [_old] "r" (compare_value), [_new] "r" (exchange_value), [dest] "ZC" (*dest)
@@ -205,7 +205,7 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
       "   sc.d %[temp], %[dest]     \n\t"
       "   beqz %[temp], 1b          \n\t"
       "   b    3f                   \n\t"
-      "2: dbar 0                    \n\t"
+      "2: dbar 0x700                 \n\t"
       "3:                           \n\t"
       : [prev] "=&r" (prev), [temp] "=&r" (temp)
       : [_old] "r" (compare_value), [_new] "r" (exchange_value), [dest] "ZC" (*dest)

--- a/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
@@ -31,18 +31,18 @@
 // Included in orderAccess.hpp header file.
 
 // Implementation of class OrderAccess.
-#define inlasm_sync() if (!UseActiveCoresMP) \
-                       __asm__ __volatile__ ("dbar 0"   : : : "memory");
+#define inlasm_sync(v) if (!UseActiveCoresMP) \
+                       __asm__ __volatile__ ("dbar %0"   : :"K"(v) : "memory");
 #define inlasm_synci() __asm__ __volatile__ ("ibar 0"   : : : "memory");
 
-inline void OrderAccess::loadload()   { inlasm_sync(); }
-inline void OrderAccess::storestore() { inlasm_sync(); }
-inline void OrderAccess::loadstore()  { inlasm_sync(); }
-inline void OrderAccess::storeload()  { inlasm_sync(); }
+inline void OrderAccess::loadload()   { inlasm_sync(0x15); }
+inline void OrderAccess::storestore() { inlasm_sync(0x1a); }
+inline void OrderAccess::loadstore()  { inlasm_sync(0x16); }
+inline void OrderAccess::storeload()  { inlasm_sync(0x19); }
 
-inline void OrderAccess::acquire() { inlasm_sync(); }
-inline void OrderAccess::release() { inlasm_sync(); }
-inline void OrderAccess::fence()   { inlasm_sync(); }
+inline void OrderAccess::acquire() { inlasm_sync(0x14); }
+inline void OrderAccess::release() { inlasm_sync(0x12); }
+inline void OrderAccess::fence()   { inlasm_sync(0x10); }
 inline void OrderAccess::cross_modify_fence_impl() { inlasm_synci(); }
 
 #undef inlasm_sync

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -23,8 +23,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2022, These
- * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2022, 2023, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -1933,7 +1933,7 @@ bool Arguments::check_vm_args_consistency() {
 #endif
 
 
-#if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM)
+#if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM) && !defined(LOONGARCH64)
   if (LockingMode == LM_LIGHTWEIGHT) {
     FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);
     warning("New lightweight locking not supported on this platform");
@@ -1949,7 +1949,7 @@ bool Arguments::check_vm_args_consistency() {
     FLAG_SET_CMDLINE(LockingMode, LM_MONITOR);
   }
 
-#if !defined(X86) && !defined(AARCH64) && !defined(PPC64) && !defined(RISCV64)
+#if !defined(X86) && !defined(AARCH64) && !defined(PPC64) && !defined(RISCV64) && !defined(LOONGARCH64)
   if (LockingMode == LM_MONITOR) {
     jio_fprintf(defaultStream::error_stream(),
                 "LockingMode == 0 (LM_MONITOR) is not fully implemented on this architecture");

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/loongarch64/linux/LinuxLoongArch64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/loongarch64/linux/LinuxLoongArch64CallArranger.java
@@ -152,7 +152,7 @@ public class LinuxLoongArch64CallArranger {
         // Aggregates or scalars passed on the stack are aligned to the greater of
         // the type alignment and XLEN bits, but never more than the stack alignment.
         void alignStack(long alignment) {
-            alignment = Utils.alignUp(Math.min(Math.max(alignment, STACK_SLOT_SIZE), 16), STACK_SLOT_SIZE);
+            alignment = Utils.alignUp(Math.clamp(alignment, STACK_SLOT_SIZE, 16), STACK_SLOT_SIZE);
             stackOffset = Utils.alignUp(stackOffset, alignment);
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/loongarch64/linux/LinuxLoongArch64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/loongarch64/linux/LinuxLoongArch64CallArranger.java
@@ -303,7 +303,7 @@ public class LinuxLoongArch64CallArranger {
                         if (offset + copy < layout.byteSize()) {
                             bindings.dup();
                         }
-                        bindings.bufferLoad(offset, type)
+                        bindings.bufferLoad(offset, type, (int) copy)
                                 .vmStore(storage, type);
                         offset += copy;
                     }
@@ -414,7 +414,7 @@ public class LinuxLoongArch64CallArranger {
                         VMStorage storage = locations[locIndex++];
                         Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
                         bindings.dup().vmLoad(storage, type)
-                                .bufferStore(offset, type);
+                                .bufferStore(offset, type, (int) copy);
                         offset += copy;
                     }
                 }

--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -20,6 +20,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ *
+ */
+
 package jdk.internal.util;
 
 import jdk.internal.vm.annotation.ForceInline;
@@ -38,6 +46,7 @@ public enum Architecture {
     X86,
     AARCH64,
     RISCV64,
+    LOONGARCH64,
     S390,
     PPC64,
     ;
@@ -66,6 +75,14 @@ public enum Architecture {
     @ForceInline
     public static boolean isRISCV64() {
         return PlatformProps.TARGET_ARCH_IS_RISCV64;
+    }
+
+    /**
+     * {@return {@code true} if the current architecture is LOONGARCH64}
+     */
+    @ForceInline
+    public static boolean isLOONGARCH64() {
+        return PlatformProps.TARGET_ARCH_IS_LOONGARCH64;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -20,6 +20,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ *
+ */
+
 package jdk.internal.util;
 
 /**
@@ -54,6 +62,7 @@ class PlatformProps {
     static final boolean TARGET_ARCH_IS_X86     = "@@OPENJDK_TARGET_CPU@@" == "x86";
     static final boolean TARGET_ARCH_IS_AARCH64 = "@@OPENJDK_TARGET_CPU@@" == "aarch64";
     static final boolean TARGET_ARCH_IS_RISCV64 = "@@OPENJDK_TARGET_CPU@@" == "riscv64";
+    static final boolean TARGET_ARCH_IS_LOONGARCH64 = "@@OPENJDK_TARGET_CPU@@" == "loongarch64";
     static final boolean TARGET_ARCH_IS_S390    = "@@OPENJDK_TARGET_CPU@@" == "s390";
     static final boolean TARGET_ARCH_IS_PPC64   = "@@OPENJDK_TARGET_CPU@@" == "ppc64";
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/LoongArch64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/LoongArch64HotSpotJVMCIBackendFactory.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/LoongArch64HotSpotRegisterConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/LoongArch64HotSpotRegisterConfig.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/LoongArch64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/LoongArch64HotSpotVMConfig.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/package-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,6 @@
  */
 
 /**
- * The LoongArch64 platform independent portions of the JVMCI API.
+ * The LoongArch64 HotSpot specific portions of the JVMCI API.
  */
-package jdk.vm.ci.loongarch64;
+package jdk.vm.ci.hotspot.loongarch64;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/loongarch64/LoongArch64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/loongarch64/LoongArch64.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/loongarch64/LoongArch64Kind.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/loongarch64/LoongArch64Kind.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/loongarch64/package-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/loongarch64/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,6 @@
  */
 
 /**
- * The LoongArch64 HotSpot specific portions of the JVMCI API.
+ * The LoongArch64 platform independent portions of the JVMCI API.
  */
-package jdk.vm.ci.hotspot.loongarch64;
+package jdk.vm.ci.loongarch64;

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/CodeInstallationTest.java
@@ -22,24 +22,24 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2022, These
- * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2022, 2023, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
 package jdk.vm.ci.code.test;
 
 import jdk.vm.ci.aarch64.AArch64;
-import jdk.vm.ci.loongarch64.LoongArch64;
 import jdk.vm.ci.amd64.AMD64;
+import jdk.vm.ci.loongarch64.LoongArch64;
 import jdk.vm.ci.riscv64.RISCV64;
 import jdk.vm.ci.code.Architecture;
 import jdk.vm.ci.code.CodeCacheProvider;
 import jdk.vm.ci.code.InstalledCode;
 import jdk.vm.ci.code.TargetDescription;
-import jdk.vm.ci.code.test.loongarch64.LoongArch64TestAssembler;
 import jdk.vm.ci.code.test.aarch64.AArch64TestAssembler;
 import jdk.vm.ci.code.test.amd64.AMD64TestAssembler;
+import jdk.vm.ci.code.test.loongarch64.LoongArch64TestAssembler;
 import jdk.vm.ci.code.test.riscv64.RISCV64TestAssembler;
 import jdk.vm.ci.hotspot.HotSpotCodeCacheProvider;
 import jdk.vm.ci.hotspot.HotSpotCompiledCode;

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -20,6 +20,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ *
+ */
+
 import java.util.Locale;
 import java.util.stream.Stream;
 
@@ -30,6 +38,7 @@ import static jdk.internal.util.Architecture.OTHER;
 import static jdk.internal.util.Architecture.AARCH64;
 import static jdk.internal.util.Architecture.PPC64;
 import static jdk.internal.util.Architecture.RISCV64;
+import static jdk.internal.util.Architecture.LOONGARCH64;
 import static jdk.internal.util.Architecture.S390;
 import static jdk.internal.util.Architecture.X64;
 import static jdk.internal.util.Architecture.X86;
@@ -68,6 +77,7 @@ public class ArchTest {
             case "x86", "i386" -> X86;
             case "aarch64" -> AARCH64;
             case "riscv64" -> RISCV64;
+            case "loongarch64" -> LOONGARCH64;
             case "s390x", "s390" -> S390;
             case "ppc64", "ppc64le" -> PPC64;
             default -> OTHER;
@@ -85,6 +95,7 @@ public class ArchTest {
                 Arguments.of(X86, Architecture.isX86()),
                 Arguments.of(AARCH64, Architecture.isAARCH64()),
                 Arguments.of(RISCV64, Architecture.isRISCV64()),
+                Arguments.of(LOONGARCH64, Architecture.isLOONGARCH64()),
                 Arguments.of(S390, Architecture.isS390()),
                 Arguments.of(PPC64, Architecture.isPPC64())
         );

--- a/test/micro/org/openjdk/bench/loongarch/MisAlignVector.java
+++ b/test/micro/org/openjdk/bench/loongarch/MisAlignVector.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Loongson Technology. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.loongarch;
+
+import org.openjdk.jmh.annotations.*;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+
+@State(Scope.Thread)
+public class MisAlignVector {
+
+    public static final double fval = 2.00;
+    public static double[] D;
+    public static int[] I;
+
+    @Param({"100", "1000", "10000", "30000"})
+    public static int size;
+
+    @Setup(Level.Iteration)
+    public void up() throws Throwable {
+      D = new double[size];
+      I = new int[size];
+   }
+
+   @TearDown(Level.Iteration)
+   public void down() throws Throwable {
+       D = null;
+       I = null;
+   }
+
+   @Benchmark
+   public void testFPUAndALU(){
+        for (int i=0; i<size; i++) {
+           D[i] += D[i] * fval;
+           D[i] += D[i] / fval;
+           I[i] += I[i]*2;
+           I[i] += I[i]/2;
+        }
+    }
+}


### PR DESCRIPTION
23738: [C2][LA] enable misaligned vectors store/load
29261: LA intrinsics for compareUnsigned method in Integer and Long
29201: LA port of 8283186: Explicitly pass a third temp register to MacroAssembler::store_heap_oop
31010: LA port of 8304915: Create jdk.internal.util.Architecture enum and apply
30943: LA port of 8303588: [JVMCI] make JVMCI source directories conform with standard layout
30829: LA port of 8291555: Implement alternative fast-locking scheme
30358: Add support for ordering memory barriers
30777: testlibrary_tests/ir_framework/tests/TestDFlags.java fail with VerifyOops
30895: LA port of 8302815: Use new Math.clamp method in core libraries
30894: TestArrayStructs.java fails after JDK-8303604