### PR TITLE
Update (2023.07.12)

### DIFF
--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -17171,56 +17171,6 @@ instruct cmpV32(vecY dst, vecY src1, vecY src2, immI cond)
   ins_pipe( pipe_slow );
 %}
 
-// ------------------------- Vector conditional move --------------------------
-
-instruct cmove4F(vecX dst, vecX src1, vecX src2, immI cond, cmpOp copnd)
-%{
-  match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
-  format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove4F" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare(fscratch, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 16);
-    __ vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cmove2D(vecX dst, vecX src1, vecX src2, immI cond, cmpOp copnd)
-%{
-  match(Set dst (CMoveVD (Binary copnd cond) (Binary src1 src2)));
-  format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove2D" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare(fscratch, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 16);
-    __ vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cmove8F(vecY dst, vecY src1, vecY src2, immI cond, cmpOp copnd)
-%{
-  match(Set dst (CMoveVF (Binary copnd cond) (Binary src1 src2)));
-  format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove8F" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare(fscratch, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 32);
-    __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cmove4D(vecY dst, vecY src1, vecY src2, immI cond, cmpOp copnd)
-%{
-  match(Set dst (CMoveVD (Binary copnd cond) (Binary src1 src2)));
-  format %{ "vcmove_$copnd    $dst, $src1, $src2, $cond\t# @cmove4D" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare(fscratch, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 32);
-    __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
 // ---------------------------- LOAD_IOTA_INDICES -----------------------------
 
 instruct loadconV16(vecX dst, immI_0 src) %{

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -929,7 +929,7 @@ static void verify_oop_args(MacroAssembler* masm,
                             const VMRegPair* regs) {
   if (VerifyOops) {
     // verify too many args may overflow the code buffer
-    int arg_size = MIN2(64, method->size_of_parameters());
+    int arg_size = MIN2(64, (int)(method->size_of_parameters()));
 
     for (int i = 0; i < arg_size; i++) {
       if (is_reference_type(sig_bt[i])) {

--- a/src/hotspot/cpu/loongarch/vmstorage_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/vmstorage_loongarch.hpp
@@ -69,7 +69,7 @@ constexpr inline VMStorage as_VMStorage(FloatRegister reg) {
   return VMStorage::reg_storage(StorageType::FLOAT, FLOAT64_MASK, reg->encoding());
 }
 
-inline VMStorage as_VMStorage(VMReg reg) {
+inline VMStorage as_VMStorage(VMReg reg, BasicType bt) {
   if (reg->is_Register()) {
     return as_VMStorage(reg->as_Register());
   } else if (reg->is_FloatRegister()) {


### PR DESCRIPTION
31170: Fix conflicting types for MIN2()
31168: LA port of 8303040: linux PPC64le: Implementation of Foreign Function & Memory API (Preview)
31096: LA port of 8306302: C2 Superword fix: use VectorMaskCmp and VectorBlend instead of CMoveVF/D