### PR TITLE
Update (2023.07.12)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_Runtime1_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_Runtime1_loongarch_64.cpp
@@ -471,6 +471,14 @@ void Runtime1::generate_unwind_exception(StubAssembler *sasm) {
   const Register exception_pc = A1;
   const Register handler_addr = A3;
 
+  if (AbortVMOnException) {
+    __ enter();
+    save_live_registers(sasm);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, check_abort_on_vm_exception), A0);
+    restore_live_registers(sasm);
+    __ leave();
+  }
+
   // verify that only A0, is valid at this time
   __ invalidate_registers(false, true, true, true, true, true);
 

--- a/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
@@ -30,7 +30,6 @@
 #include "code/codeCache.inline.hpp"
 #include "code/vmreg.inline.hpp"
 #include "interpreter/interpreter.hpp"
-#include "interpreter/oopMapCache.hpp"
 #include "runtime/sharedRuntime.hpp"
 
 // Inline functions for Loongson frames:


### PR DESCRIPTION
31414: LA port of 8264899: C1: -XX:AbortVMOnException does not work if all methods in the call stack are compiled with C1 and there are no exception handlers
31413: LA port of 8310225: Reduce inclusion of oopMapCache.hpp and generateOopMap.hpp