### PR TITLE
Update (2023.08.02)

### DIFF
--- a/src/hotspot/cpu/loongarch/globalDefinitions_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globalDefinitions_loongarch.hpp
@@ -29,6 +29,7 @@
 const int BytesPerInstWord = 4;
 
 const int StackAlignmentInBytes = (2*wordSize);
+const size_t pd_segfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are properly extended to 64 bits.

--- a/src/hotspot/cpu/loongarch/jvmciCodeInstaller_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/jvmciCodeInstaller_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 #include "jvmci/jvmciRuntime.hpp"
 #include "jvmci/jvmciCompilerToVM.hpp"
 #include "jvmci/jvmciJavaClasses.hpp"
+#include "oops/compressedKlass.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/jniHandles.hpp"

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1609,7 +1609,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           __ st_d(as_Register(Matcher::_regEncode[src_first]), Address(SP, offset));
 #ifndef PRODUCT
         } else {
-          st->print("\tst_d    %s, [SP + #%d] # spill 8",
+          st->print("\tst_d    %s, [SP + #%d]\t# spill 8",
                     Matcher::regName[src_first],
                     offset);
 #endif
@@ -1659,8 +1659,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
               __ add_d(as_Register(Matcher::_regEncode[dst_first]), as_Register(Matcher::_regEncode[src_first]), R0);
 #ifndef PRODUCT
         } else {
-          st->print("\n\t");
-          st->print("move(32-bit)    %s <-- %s\t# spill 11",
+          st->print("\tmove(32-bit)    %s <-- %s\t# spill 11",
                     Matcher::regName[dst_first],
                     Matcher::regName[src_first]);
 #endif
@@ -1677,8 +1676,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           __ movgr2fr_d(as_FloatRegister(Matcher::_regEncode[dst_first]), as_Register(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
-          st->print("\n\t");
-          st->print("movgr2fr_d   %s, %s\t# spill 12",
+          st->print("\tmovgr2fr_d   %s, %s\t# spill 12",
                     Matcher::regName[dst_first],
                     Matcher::regName[src_first]);
 #endif
@@ -1692,8 +1690,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           __ movgr2fr_w(as_FloatRegister(Matcher::_regEncode[dst_first]), as_Register(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
-          st->print("\n\t");
-          st->print("movgr2fr_w   %s, %s\t# spill 13",
+          st->print("\tmovgr2fr_w   %s, %s\t# spill 13",
                     Matcher::regName[dst_first],
                     Matcher::regName[src_first]);
 #endif
@@ -1714,8 +1711,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           __ fst_d( as_FloatRegister(Matcher::_regEncode[src_first]), Address(SP, offset) );
 #ifndef PRODUCT
         } else {
-          st->print("\n\t");
-          st->print("fst_d   %s, [SP + #%d]\t# spill 14",
+          st->print("\tfst_d   %s, [SP + #%d]\t# spill 14",
                     Matcher::regName[src_first],
                     offset);
 #endif
@@ -1730,8 +1726,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           __ fst_s(as_FloatRegister(Matcher::_regEncode[src_first]), Address(SP, offset));
 #ifndef PRODUCT
         } else {
-          st->print("\n\t");
-          st->print("fst_s   %s, [SP + #%d]\t# spill 15",
+          st->print("\tfst_s   %s, [SP + #%d]\t# spill 15",
                     Matcher::regName[src_first],
                     offset);
 #endif
@@ -1748,8 +1743,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           __ movfr2gr_d( as_Register(Matcher::_regEncode[dst_first]), as_FloatRegister(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
-          st->print("\n\t");
-          st->print("movfr2gr_d   %s, %s\t# spill 16",
+          st->print("\tmovfr2gr_d   %s, %s\t# spill 16",
                     Matcher::regName[dst_first],
                     Matcher::regName[src_first]);
 #endif
@@ -1763,8 +1757,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           __ movfr2gr_s( as_Register(Matcher::_regEncode[dst_first]), as_FloatRegister(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
-          st->print("\n\t");
-          st->print("movfr2gr_s   %s, %s\t# spill 17",
+          st->print("\tmovfr2gr_s   %s, %s\t# spill 17",
                     Matcher::regName[dst_first],
                     Matcher::regName[src_first]);
 #endif
@@ -1781,8 +1774,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           __ fmov_d( as_FloatRegister(Matcher::_regEncode[dst_first]), as_FloatRegister(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
-          st->print("\n\t");
-          st->print("fmov_d  %s <-- %s\t# spill 18",
+          st->print("\tfmov_d  %s <-- %s\t# spill 18",
                     Matcher::regName[dst_first],
                     Matcher::regName[src_first]);
 #endif
@@ -1796,8 +1788,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           __ fmov_s( as_FloatRegister(Matcher::_regEncode[dst_first]), as_FloatRegister(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
-          st->print("\n\t");
-          st->print("fmov_s  %s <-- %s\t# spill 19",
+          st->print("\tfmov_s  %s <-- %s\t# spill 19",
                     Matcher::regName[dst_first],
                     Matcher::regName[src_first]);
 #endif

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -38,6 +38,7 @@
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "nativeInst_loongarch.hpp"
+#include "oops/compressedKlass.inline.hpp"
 #include "oops/compressedOops.inline.hpp"
 #include "oops/klass.inline.hpp"
 #include "prims/methodHandles.hpp"


### PR DESCRIPTION
31782: Fix the failure of TestIRMatching.java
31743: LA port of 8312014: [s390x] TestSigInfoInHsErrFile.java Failure
31742: LA port of 8303134: JFR: Missing stack trace during chunk rotation stress
31741: LA port of 8311870: Split CompressedKlassPointers from compressedOops.hpp