### PR TITLE
Update (2023.08.15)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -1511,12 +1511,16 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
 
 void LIR_Assembler::casw(Register addr, Register newval, Register cmpval, Register result, bool sign) {
   __ cmpxchg32(Address(addr, 0), cmpval, newval, result, sign,
-               /* retold */ false, /* barrier */ true, /* weak */ false, /* exchange */ false);
+               /* retold */ false, /* acquire */ true, /* weak */ false, /* exchange */ false);
+  // LA SC equals store-conditional dbar, so no need AnyAny after CAS.
+  //__ membar(__ AnyAny);
 }
 
 void LIR_Assembler::casl(Register addr, Register newval, Register cmpval, Register result) {
   __ cmpxchg(Address(addr, 0), cmpval, newval, result,
-             /* retold */ false, /* barrier */ true, /* weak */ false, /* exchange */ false);
+             /* retold */ false, /* acquire */ true, /* weak */ false, /* exchange */ false);
+  // LA SC equals store-conditional dbar, so no need AnyAny after CAS.
+  //__ membar(__ AnyAny);
 }
 
 void LIR_Assembler::emit_compare_and_swap(LIR_OpCompareAndSwap* op) {

--- a/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
@@ -72,7 +72,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
     // displaced header address in the object header - if it is not the same, get the
     // object header instead
     lea(SCR2, Address(obj, hdr_offset));
-    cmpxchg(Address(SCR2, 0), hdr, disp_hdr, SCR1, true, false, done);
+    cmpxchg(Address(SCR2, 0), hdr, disp_hdr, SCR1, true, true /* acquire */, done);
     // if the object header was the same, we're done
     // if the object header was not the same, it is now in the hdr register
     // => test if it is a stack pointer into the same stack (recursive locking), i.e.:
@@ -134,9 +134,9 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
     // we do unlocking via runtime call
     if (hdr_offset) {
       lea(SCR1, Address(obj, hdr_offset));
-      cmpxchg(Address(SCR1, 0), disp_hdr, hdr, SCR2, false, false, done, &slow_case);
+      cmpxchg(Address(SCR1, 0), disp_hdr, hdr, SCR2, false, true /* acquire */, done, &slow_case);
     } else {
-      cmpxchg(Address(obj, 0), disp_hdr, hdr, SCR2, false, false, done, &slow_case);
+      cmpxchg(Address(obj, 0), disp_hdr, hdr, SCR2, false, true /* acquire */, done, &slow_case);
     }
     // done
     bind(done);

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -72,7 +72,7 @@ void C2_MacroAssembler::fast_lock_c2(Register oop, Register box, Register flag,
     st_d(tmp, box, BasicLock::displaced_header_offset_in_bytes());
 
     // If cmpxchg is succ, then flag = 1
-    cmpxchg(Address(oop, 0), tmp, box, flag, true, false);
+    cmpxchg(Address(oop, 0), tmp, box, flag, true, true /* acquire */);
     bnez(flag, cont);
 
     // If the compare-and-exchange succeeded, then we found an unlocked
@@ -106,7 +106,7 @@ void C2_MacroAssembler::fast_lock_c2(Register oop, Register box, Register flag,
   // Try to CAS m->owner from null to current thread.
   move(AT, R0);
   addi_d(tmp, disp_hdr, in_bytes(ObjectMonitor::owner_offset()) - markWord::monitor_value);
-  cmpxchg(Address(tmp, 0), AT, TREG, flag, true, false);
+  cmpxchg(Address(tmp, 0), AT, TREG, flag, true, true /* acquire */);
   if (LockingMode != LM_LIGHTWEIGHT) {
     // Store a non-null value into the box to avoid looking like a re-entrant
     // lock. The fast-path monitor unlock code checks for
@@ -166,7 +166,7 @@ void C2_MacroAssembler::fast_unlock_c2(Register oop, Register box, Register flag
     // Check if it is still a light weight lock, this is true if we
     // see the stack address of the basicLock in the markWord of the
     // object.
-    cmpxchg(Address(oop, 0), box, disp_hdr, flag, false, false);
+    cmpxchg(Address(oop, 0), box, disp_hdr, flag, false, false /* acquire */);
     b(cont);
   } else {
     assert(LockingMode == LM_LIGHTWEIGHT, "must be");

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.cpp
@@ -463,7 +463,7 @@ void ShenandoahBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler
 //
 // Clobbers SCR1, SCR2
 void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
-                                                Register mem,
+                                                Address addr,
                                                 Register expected,
                                                 Register new_val,
                                                 bool acquire, bool is_cae,
@@ -472,10 +472,9 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
   Register tmp2 = SCR1;
   bool is_narrow = UseCompressedOops;
 
-  assert_different_registers(mem, expected, tmp1, tmp2);
-  assert_different_registers(mem, new_val,  tmp1, tmp2);
+  assert_different_registers(addr.base(), expected, tmp1, tmp2);
+  assert_different_registers(addr.base(), new_val,  tmp1, tmp2);
 
-  Address  addr(mem);
   Label step4, done_succ, done_fail, done;
 
   // There are two ways to reach this label.  Initial entry into the

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.cpp
@@ -513,9 +513,9 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
 
   if (is_narrow) {
     __ cmpxchg32(addr, expected, new_val, tmp2, false /* sign */, false /* retold */,
-                 acquire /* barrier */, false /* weak */, true /* exchange */);
+                 acquire /* acquire */, false /* weak */, true /* exchange */);
   } else {
-    __ cmpxchg(addr, expected, new_val, tmp2, false /* retold */, acquire /* barrier */,
+    __ cmpxchg(addr, expected, new_val, tmp2, false /* retold */, acquire /* acquire */,
                false /* weak */, true /* exchange */);
   }
   // tmp2 holds value fetched.
@@ -579,9 +579,9 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
   // compares result with expected.
   if (is_narrow) {
     __ cmpxchg32(addr, tmp2, new_val, tmp1, false /* sign */, false /* retold */,
-                 acquire /* barrier */, false /* weak */, false /* exchange */);
+                 acquire /* acquire */, false /* weak */, false /* exchange */);
   } else {
-    __ cmpxchg(addr, tmp2, new_val, tmp1, false /* retold */, acquire /* barrier */,
+    __ cmpxchg(addr, tmp2, new_val, tmp1, false /* retold */, acquire /* acquire */,
                false /* weak */, false /* exchange */);
   }
   // tmp1 set iff success, tmp2 holds value fetched.

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.hpp
@@ -81,7 +81,7 @@ public:
                         Address dst, Register val, Register tmp1, Register tmp2, Register tmp3);
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);
-  void cmpxchg_oop(MacroAssembler* masm, Register mem, Register expected, Register new_val,
+  void cmpxchg_oop(MacroAssembler* masm, Address mem, Register expected, Register new_val,
                    bool acquire, bool is_cae, Register result);
 };
 

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoah_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoah_loongarch_64.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2018, Red Hat, Inc. All rights reserved.
-// Copyright (c) 2022, Loongson Technology. All rights reserved.
+// Copyright (c) 2023, Loongson Technology. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -31,20 +31,20 @@ source_hpp %{
 encode %{
   enc_class loongarch_enc_cmpxchg_oop_shenandoah(memory mem, mRegP oldval, mRegP newval, mRegI res) %{
     MacroAssembler _masm(&cbuf);
-    guarantee($mem$$index == -1 && $mem$$disp == 0, "impossible encoding");
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
 
   enc_class loongarch_enc_cmpxchg_acq_oop_shenandoah(memory mem, mRegP oldval, mRegP newval, mRegI res) %{
     MacroAssembler _masm(&cbuf);
-    guarantee($mem$$index == -1 && $mem$$disp == 0, "impossible encoding");
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
 %}
 
-instruct compareAndSwapP_shenandoah(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
+instruct compareAndSwapP_shenandoah(mRegI res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahCompareAndSwapP mem (Binary oldval newval)));
 
   format %{
@@ -56,7 +56,7 @@ instruct compareAndSwapP_shenandoah(mRegI res, indirect mem, mRegP oldval, mRegP
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
+instruct compareAndSwapN_shenandoah(mRegI res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahCompareAndSwapN mem (Binary oldval newval)));
 
   format %{
@@ -64,14 +64,15 @@ instruct compareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN
   %}
 
   ins_encode %{
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndSwapPAcq_shenandoah(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
+instruct compareAndSwapPAcq_shenandoah(mRegI res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahCompareAndSwapP mem (Binary oldval newval)));
 
   format %{
@@ -83,7 +84,7 @@ instruct compareAndSwapPAcq_shenandoah(mRegI res, indirect mem, mRegP oldval, mR
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
+instruct compareAndSwapNAcq_shenandoah(mRegI res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahCompareAndSwapN mem (Binary oldval newval)));
 
  format %{
@@ -91,14 +92,15 @@ instruct compareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval, mR
  %}
 
   ins_encode %{
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndExchangeN_shenandoah(mRegN res, indirect mem, mRegN oldval, mRegN newval) %{
+instruct compareAndExchangeN_shenandoah(mRegN res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahCompareAndExchangeN mem (Binary oldval newval)));
 
   format %{
@@ -106,14 +108,15 @@ instruct compareAndExchangeN_shenandoah(mRegN res, indirect mem, mRegN oldval, m
   %}
 
   ins_encode %{
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ true, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndExchangeP_shenandoah(mRegP res, indirect mem, mRegP oldval, mRegP newval) %{
+instruct compareAndExchangeP_shenandoah(mRegP res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahCompareAndExchangeP mem (Binary oldval newval)));
 
   format %{
@@ -121,14 +124,15 @@ instruct compareAndExchangeP_shenandoah(mRegP res, indirect mem, mRegP oldval, m
   %}
 
   ins_encode %{
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ true, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndExchangeNAcq_shenandoah(mRegN res, indirect mem, mRegN oldval, mRegN newval) %{
+instruct compareAndExchangeNAcq_shenandoah(mRegN res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahCompareAndExchangeN mem (Binary oldval newval)));
 
   format %{
@@ -136,14 +140,15 @@ instruct compareAndExchangeNAcq_shenandoah(mRegN res, indirect mem, mRegN oldval
   %}
 
   ins_encode %{
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ true, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndExchangePAcq_shenandoah(mRegP res, indirect mem, mRegP oldval, mRegP newval) %{
+instruct compareAndExchangePAcq_shenandoah(mRegP res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahCompareAndExchangeP mem (Binary oldval newval)));
 
   format %{
@@ -151,14 +156,15 @@ instruct compareAndExchangePAcq_shenandoah(mRegP res, indirect mem, mRegP oldval
   %}
 
   ins_encode %{
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ true, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct weakCompareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
+instruct weakCompareAndSwapN_shenandoah(mRegI res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahWeakCompareAndSwapN mem (Binary oldval newval)));
 
   format %{
@@ -166,14 +172,15 @@ instruct weakCompareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, m
   %}
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct weakCompareAndSwapP_shenandoah(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
+instruct weakCompareAndSwapP_shenandoah(mRegI res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahWeakCompareAndSwapP mem (Binary oldval newval)));
 
   format %{
@@ -182,14 +189,15 @@ instruct weakCompareAndSwapP_shenandoah(mRegI res, indirect mem, mRegP oldval, m
 
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct weakCompareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
+instruct weakCompareAndSwapNAcq_shenandoah(mRegI res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahWeakCompareAndSwapN mem (Binary oldval newval)));
 
   format %{
@@ -198,14 +206,15 @@ instruct weakCompareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval
 
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
 %}
 
-instruct weakCompareAndSwapPAcq_shenandoah(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
+instruct weakCompareAndSwapPAcq_shenandoah(mRegI res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahWeakCompareAndSwapP mem (Binary oldval newval)));
 
   format %{
@@ -214,7 +223,8 @@ instruct weakCompareAndSwapPAcq_shenandoah(mRegI res, indirect mem, mRegP oldval
 
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, $oldval$$Register, $newval$$Register,
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
 

--- a/src/hotspot/cpu/loongarch/gc/x/xBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/x/xBarrierSetAssembler_loongarch.cpp
@@ -453,11 +453,9 @@ void XBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, X
   // Stub exit
   __ b(*stub->continuation());
 }
-
-#undef __
-
 #endif // COMPILER2
 
+#undef __
 #define __ masm->
 
 void XBarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register tmp1, Register tmp2, Label& error) {

--- a/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
@@ -71,7 +71,7 @@ static void z_compare_and_swap(MacroAssembler& _masm, const MachNode* node,
   Address addr(mem);
   __ z_color(oldval_tmp, oldval, tmp);
   z_store_barrier(_masm, node, addr, newval, newval_tmp, tmp, true /* is_atomic */);
-  __ cmpxchg(addr, oldval_tmp, newval_tmp, res, false /* retold */, acquire /* barrier */,
+  __ cmpxchg(addr, oldval_tmp, newval_tmp, res, false /* retold */, acquire /* acquire */,
              false /* weak */, false /* exchange */);
 }
 
@@ -81,7 +81,7 @@ static void z_compare_and_exchange(MacroAssembler& _masm, const MachNode* node,
   Address addr(mem);
   __ z_color(oldval_tmp, oldval, tmp);
   z_store_barrier(_masm, node, addr, newval, newval_tmp, tmp, true /* is_atomic */);
-  __ cmpxchg(addr, oldval_tmp, newval_tmp, res, false /* retold */, acquire /* barrier */,
+  __ cmpxchg(addr, oldval_tmp, newval_tmp, res, false /* retold */, acquire /* acquire */,
              false /* weak */, true /* exchange */);
   __ z_uncolor(res);
 }

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -841,7 +841,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
 
       assert(lock_offset == 0, "displached header must be first word in BasicObjectLock");
 
-      cmpxchg(Address(scr_reg, 0), tmp_reg, lock_reg, AT, true, false, count);
+      cmpxchg(Address(scr_reg, 0), tmp_reg, lock_reg, AT, true, true /* acquire */, count);
 
       // Test if the oopMark is an obvious stack pointer, i.e.,
       //  1) (mark & 3) == 0, and
@@ -940,7 +940,7 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
       beqz(hdr_reg, count);
 
       // Atomic swap back the old header
-      cmpxchg(Address(scr_reg, 0), tmp_reg, hdr_reg, AT, false, false, count);
+      cmpxchg(Address(scr_reg, 0), tmp_reg, hdr_reg, AT, false, true /* acquire */, count);
     }
     // Call the runtime routine for slow case.
     st_d(scr_reg, Address(lock_reg, BasicObjectLock::obj_offset())); // restore obj

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -11723,6 +11723,7 @@ instruct partialSubtypeCheckVsZero_short( mRegP sub, mRegP super, mRegP tmp1, mR
 
 instruct compareAndSwapI(mRegI res, mRegP mem_ptr, mRegI oldval, mRegI newval) %{
   match(Set res (CompareAndSwapI mem_ptr (Binary oldval newval)));
+  effect(TEMP_DEF res);
   ins_cost(3 * MEMORY_REF_COST);
   format %{ "CMPXCHG $newval, [$mem_ptr], $oldval @ compareAndSwapI" %}
   ins_encode %{
@@ -11731,12 +11732,7 @@ instruct compareAndSwapI(mRegI res, mRegP mem_ptr, mRegI oldval, mRegI newval) %
     Register res    = $res$$Register;
     Address  addr($mem_ptr$$Register, 0);
 
-    if (res != addr.base() && res != oldval && res != newval) {
-      __ cmpxchg32(addr, oldval, newval, res, true, false, true);
-    } else {
-      __ cmpxchg32(addr, oldval, newval, AT, true, false, true);
-      __ move(res, AT);
-    }
+    __ cmpxchg32(addr, oldval, newval, res, true, false, true);
   %}
   ins_pipe( long_memory_op );
 %}
@@ -11744,6 +11740,7 @@ instruct compareAndSwapI(mRegI res, mRegP mem_ptr, mRegI oldval, mRegI newval) %
 instruct compareAndSwapL(mRegI res, mRegP mem_ptr, mRegL oldval, mRegL newval) %{
   predicate(VM_Version::supports_cx8());
   match(Set res (CompareAndSwapL mem_ptr (Binary oldval newval)));
+  effect(TEMP_DEF res);
   ins_cost(3 * MEMORY_REF_COST);
   format %{ "CMPXCHG $newval, [$mem_ptr], $oldval @ compareAndSwapL" %}
   ins_encode %{
@@ -11752,18 +11749,14 @@ instruct compareAndSwapL(mRegI res, mRegP mem_ptr, mRegL oldval, mRegL newval) %
     Register res    = $res$$Register;
     Address  addr($mem_ptr$$Register, 0);
 
-    if (res != addr.base() && res != oldval && res != newval) {
-      __ cmpxchg(addr, oldval, newval, res, false, true);
-    } else {
-      __ cmpxchg(addr, oldval, newval, AT, false, true);
-      __ move(res, AT);
-    }
+    __ cmpxchg(addr, oldval, newval, res, false, true);
   %}
   ins_pipe( long_memory_op );
 %}
 
 instruct compareAndSwapP(mRegI res, mRegP mem_ptr, mRegP oldval, mRegP newval) %{
   match(Set res (CompareAndSwapP mem_ptr (Binary oldval newval)));
+  effect(TEMP_DEF res);
   predicate(n->as_LoadStore()->barrier_data() == 0);
   ins_cost(3 * MEMORY_REF_COST);
   format %{ "CMPXCHG $newval, [$mem_ptr], $oldval @ compareAndSwapP" %}
@@ -11773,18 +11766,14 @@ instruct compareAndSwapP(mRegI res, mRegP mem_ptr, mRegP oldval, mRegP newval) %
     Register res    = $res$$Register;
     Address  addr($mem_ptr$$Register, 0);
 
-    if (res != addr.base() && res != oldval && res != newval) {
-      __ cmpxchg(addr, oldval, newval, res, false, true);
-    } else {
-      __ cmpxchg(addr, oldval, newval, AT, false, true);
-      __ move(res, AT);
-    }
+    __ cmpxchg(addr, oldval, newval, res, false, true);
   %}
   ins_pipe( long_memory_op );
 %}
 
 instruct compareAndSwapN(mRegI res, mRegP mem_ptr, mRegN oldval, mRegN newval) %{
   match(Set res (CompareAndSwapN mem_ptr (Binary oldval newval)));
+  effect(TEMP_DEF res);
   ins_cost(3 * MEMORY_REF_COST);
   format %{ "CMPXCHG $newval, [$mem_ptr], $oldval @ compareAndSwapN" %}
   ins_encode %{
@@ -11793,12 +11782,7 @@ instruct compareAndSwapN(mRegI res, mRegP mem_ptr, mRegN oldval, mRegN newval) %
     Register res    = $res$$Register;
     Address  addr($mem_ptr$$Register, 0);
 
-    if (res != addr.base() && res != oldval && res != newval) {
-      __ cmpxchg32(addr, oldval, newval, res, false, false, true);
-    } else {
-      __ cmpxchg32(addr, oldval, newval, AT, false, false, true);
-      __ move(res, AT);
-    }
+    __ cmpxchg32(addr, oldval, newval, res, false, false, true);
   %}
   ins_pipe( long_memory_op );
 %}
@@ -11942,6 +11926,7 @@ instruct compareAndExchangeI(mRegI res, indirect mem, mRegI oldval, mRegI newval
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
+
     __ cmpxchg32(addr, oldval, newval, res, true /* sign */, false /* retold */, true /* barrier */, false /* weak */, true /* exchange */);
   %}
   ins_pipe( pipe_slow );
@@ -11960,6 +11945,7 @@ instruct compareAndExchangeL(mRegL res, indirect mem, mRegL oldval, mRegL newval
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
+
     __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, false /* weak */, true /* exchange */);
   %}
   ins_pipe( pipe_slow );
@@ -11978,6 +11964,7 @@ instruct compareAndExchangeP(mRegP res, indirect mem, mRegP oldval, mRegP newval
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
+
     __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, false /* weak */, true /* exchange */);
   %}
   ins_pipe( pipe_slow );
@@ -12004,6 +11991,7 @@ instruct compareAndExchangeN(mRegN res, indirect mem, mRegN oldval, mRegN newval
 instruct weakCompareAndSwapI(mRegI res, indirect mem, mRegI oldval, mRegI newval) %{
 
   match(Set res (WeakCompareAndSwapI mem (Binary oldval newval)));
+  effect(TEMP_DEF res);
   ins_cost(2 * MEMORY_REF_COST);
   format %{
     "cmpxchg32 $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapI"
@@ -12013,12 +12001,7 @@ instruct weakCompareAndSwapI(mRegI res, indirect mem, mRegI oldval, mRegI newval
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
-    if (res != addr.base() && res != oldval && res != newval) {
-      __ cmpxchg32(addr, oldval, newval, res, true /* sign */, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
-    } else {
-      __ cmpxchg32(addr, oldval, newval, AT, true /* sign */, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
-      __ move(res, AT);
-    }
+    __ cmpxchg32(addr, oldval, newval, res, true /* sign */, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -12026,6 +12009,7 @@ instruct weakCompareAndSwapI(mRegI res, indirect mem, mRegI oldval, mRegI newval
 instruct weakCompareAndSwapL(mRegI res, indirect mem, mRegL oldval, mRegL newval) %{
 
   match(Set res (WeakCompareAndSwapL mem (Binary oldval newval)));
+  effect(TEMP_DEF res);
   ins_cost(2 * MEMORY_REF_COST);
   format %{
     "cmpxchg $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @WeakCompareAndSwapL"
@@ -12035,12 +12019,8 @@ instruct weakCompareAndSwapL(mRegI res, indirect mem, mRegL oldval, mRegL newval
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
-    if (res != addr.base() && res != oldval && res != newval) {
-      __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
-    } else {
-      __ cmpxchg(addr, oldval, newval, AT, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
-      __ move(res, AT);
-    }
+
+    __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -12048,6 +12028,7 @@ instruct weakCompareAndSwapL(mRegI res, indirect mem, mRegL oldval, mRegL newval
 instruct weakCompareAndSwapP(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
   predicate((((CompareAndSwapNode*)n)->order() != MemNode::acquire && ((CompareAndSwapNode*)n)->order() != MemNode::seqcst) && n->as_LoadStore()->barrier_data() == 0);
   match(Set res (WeakCompareAndSwapP mem (Binary oldval newval)));
+  effect(TEMP_DEF res);
   ins_cost(MEMORY_REF_COST);
   format %{
     "cmpxchg $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapP"
@@ -12057,12 +12038,8 @@ instruct weakCompareAndSwapP(mRegI res, indirect mem, mRegP oldval, mRegP newval
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
-    if (res != addr.base() && res != oldval && res != newval) {
-      __ cmpxchg(addr, oldval, newval, res, false /* retold */, false /* barrier */, true /* weak */, false /* exchange */);
-    } else {
-      __ cmpxchg(addr, oldval, newval, AT, false /* retold */, false /* barrier */, true /* weak */, false /* exchange */);
-      __ move(res, AT);
-    }
+
+  __ cmpxchg(addr, oldval, newval, res, false /* retold */, false /* barrier */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -12070,6 +12047,7 @@ instruct weakCompareAndSwapP(mRegI res, indirect mem, mRegP oldval, mRegP newval
 instruct weakCompareAndSwapP_acq(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
   predicate(n->as_LoadStore()->barrier_data() == 0);
   match(Set res (WeakCompareAndSwapP mem (Binary oldval newval)));
+  effect(TEMP_DEF res);
   ins_cost(2 * MEMORY_REF_COST);
   format %{
     "cmpxchg $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapP"
@@ -12079,12 +12057,8 @@ instruct weakCompareAndSwapP_acq(mRegI res, indirect mem, mRegP oldval, mRegP ne
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
-    if (res != addr.base() && res != oldval && res != newval) {
-      __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
-    } else {
-      __ cmpxchg(addr, oldval, newval, AT, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
-      __ move(res, AT);
-    }
+
+    __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -12092,6 +12066,7 @@ instruct weakCompareAndSwapP_acq(mRegI res, indirect mem, mRegP oldval, mRegP ne
 instruct weakCompareAndSwapN(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
 
   match(Set res (WeakCompareAndSwapN mem (Binary oldval newval)));
+  effect(TEMP_DEF res);
   ins_cost(2 * MEMORY_REF_COST);
   format %{
     "cmpxchg32 $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapN"
@@ -12101,12 +12076,8 @@ instruct weakCompareAndSwapN(mRegI res, indirect mem, mRegN oldval, mRegN newval
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
-    if (res != addr.base() && res != oldval && res != newval) {
-      __ cmpxchg32(addr, oldval, newval, res, false /* sign */, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
-    } else {
-      __ cmpxchg32(addr, oldval, newval, AT, false /* sign */, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
-      __ move(res, AT);
-    }
+
+    __ cmpxchg32(addr, oldval, newval, res, false /* sign */, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -11732,7 +11732,7 @@ instruct compareAndSwapI(mRegI res, mRegP mem_ptr, mRegI oldval, mRegI newval) %
     Register res    = $res$$Register;
     Address  addr($mem_ptr$$Register, 0);
 
-    __ cmpxchg32(addr, oldval, newval, res, true, false, true);
+    __ cmpxchg32(addr, oldval, newval, res, true, false, true /* acquire */);
   %}
   ins_pipe( long_memory_op );
 %}
@@ -11749,7 +11749,7 @@ instruct compareAndSwapL(mRegI res, mRegP mem_ptr, mRegL oldval, mRegL newval) %
     Register res    = $res$$Register;
     Address  addr($mem_ptr$$Register, 0);
 
-    __ cmpxchg(addr, oldval, newval, res, false, true);
+    __ cmpxchg(addr, oldval, newval, res, false, true /* acquire */);
   %}
   ins_pipe( long_memory_op );
 %}
@@ -11766,7 +11766,7 @@ instruct compareAndSwapP(mRegI res, mRegP mem_ptr, mRegP oldval, mRegP newval) %
     Register res    = $res$$Register;
     Address  addr($mem_ptr$$Register, 0);
 
-    __ cmpxchg(addr, oldval, newval, res, false, true);
+    __ cmpxchg(addr, oldval, newval, res, false, true /* acquire */);
   %}
   ins_pipe( long_memory_op );
 %}
@@ -11782,7 +11782,7 @@ instruct compareAndSwapN(mRegI res, mRegP mem_ptr, mRegN oldval, mRegN newval) %
     Register res    = $res$$Register;
     Address  addr($mem_ptr$$Register, 0);
 
-    __ cmpxchg32(addr, oldval, newval, res, false, false, true);
+    __ cmpxchg32(addr, oldval, newval, res, false, false, true /* acquire */);
   %}
   ins_pipe( long_memory_op );
 %}
@@ -11919,7 +11919,7 @@ instruct compareAndExchangeI(mRegI res, indirect mem, mRegI oldval, mRegI newval
   ins_cost(2 * MEMORY_REF_COST);
   effect(TEMP_DEF res);
   format %{
-    "cmpxchg32 $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @compareAndExchangeI"
+    "CMPXCHG $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @compareAndExchangeI"
   %}
   ins_encode %{
     Register newval = $newval$$Register;
@@ -11938,7 +11938,7 @@ instruct compareAndExchangeL(mRegL res, indirect mem, mRegL oldval, mRegL newval
   ins_cost(2 * MEMORY_REF_COST);
   effect(TEMP_DEF res);
   format %{
-    "cmpxchg $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @compareAndExchangeL"
+    "CMPXCHG $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @compareAndExchangeL"
   %}
   ins_encode %{
     Register newval = $newval$$Register;
@@ -11957,7 +11957,7 @@ instruct compareAndExchangeP(mRegP res, indirect mem, mRegP oldval, mRegP newval
   ins_cost(2 * MEMORY_REF_COST);
   effect(TEMP_DEF res);
   format %{
-    "cmpxchg $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @compareAndExchangeP"
+    "CMPXCHG $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @compareAndExchangeP"
   %}
   ins_encode %{
     Register newval = $newval$$Register;
@@ -11976,14 +11976,14 @@ instruct compareAndExchangeN(mRegN res, indirect mem, mRegN oldval, mRegN newval
   ins_cost(2 * MEMORY_REF_COST);
   effect(TEMP_DEF res);
   format %{
-    "cmpxchg32 $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @compareAndExchangeN"
+    "CMPXCHG $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @compareAndExchangeN"
   %}
   ins_encode %{
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
-    __ cmpxchg32(addr, oldval, newval, res, false /* sign */, false /* retold */, true /* barrier */, false /* weak */, true /* exchange */);
+    __ cmpxchg32(addr, oldval, newval, res, false /* sign */, false /* retold */, true /* acquire */, false /* weak */, true /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -11994,14 +11994,15 @@ instruct weakCompareAndSwapI(mRegI res, indirect mem, mRegI oldval, mRegI newval
   effect(TEMP_DEF res);
   ins_cost(2 * MEMORY_REF_COST);
   format %{
-    "cmpxchg32 $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapI"
+    "CMPXCHG $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapI"
   %}
   ins_encode %{
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
-    __ cmpxchg32(addr, oldval, newval, res, true /* sign */, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
+
+    __ cmpxchg32(addr, oldval, newval, res, true /* sign */, false /* retold */, true /* acquire */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -12012,7 +12013,7 @@ instruct weakCompareAndSwapL(mRegI res, indirect mem, mRegL oldval, mRegL newval
   effect(TEMP_DEF res);
   ins_cost(2 * MEMORY_REF_COST);
   format %{
-    "cmpxchg $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @WeakCompareAndSwapL"
+    "CMPXCHG $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @WeakCompareAndSwapL"
   %}
   ins_encode %{
     Register newval = $newval$$Register;
@@ -12020,7 +12021,7 @@ instruct weakCompareAndSwapL(mRegI res, indirect mem, mRegL oldval, mRegL newval
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
 
-    __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
+    __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* acquire */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -12031,7 +12032,7 @@ instruct weakCompareAndSwapP(mRegI res, indirect mem, mRegP oldval, mRegP newval
   effect(TEMP_DEF res);
   ins_cost(MEMORY_REF_COST);
   format %{
-    "cmpxchg $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapP"
+    "CMPXCHG $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapP"
   %}
   ins_encode %{
     Register newval = $newval$$Register;
@@ -12039,7 +12040,7 @@ instruct weakCompareAndSwapP(mRegI res, indirect mem, mRegP oldval, mRegP newval
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
 
-  __ cmpxchg(addr, oldval, newval, res, false /* retold */, false /* barrier */, true /* weak */, false /* exchange */);
+  __ cmpxchg(addr, oldval, newval, res, false /* retold */, false /* acquire */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -12050,7 +12051,7 @@ instruct weakCompareAndSwapP_acq(mRegI res, indirect mem, mRegP oldval, mRegP ne
   effect(TEMP_DEF res);
   ins_cost(2 * MEMORY_REF_COST);
   format %{
-    "cmpxchg $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapP"
+    "CMPXCHG $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapP"
   %}
   ins_encode %{
     Register newval = $newval$$Register;
@@ -12058,7 +12059,7 @@ instruct weakCompareAndSwapP_acq(mRegI res, indirect mem, mRegP oldval, mRegP ne
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
 
-    __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
+    __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* acquire */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -12069,7 +12070,7 @@ instruct weakCompareAndSwapN(mRegI res, indirect mem, mRegN oldval, mRegN newval
   effect(TEMP_DEF res);
   ins_cost(2 * MEMORY_REF_COST);
   format %{
-    "cmpxchg32 $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapN"
+    "CMPXCHG $res = $mem, $oldval, $newval\t# if $mem == $oldval then $mem <-- $newval @weakCompareAndSwapN"
   %}
   ins_encode %{
     Register newval = $newval$$Register;
@@ -12077,7 +12078,7 @@ instruct weakCompareAndSwapN(mRegI res, indirect mem, mRegN oldval, mRegN newval
     Register res    = $res$$Register;
     Address addr(as_Register($mem$$base));
 
-    __ cmpxchg32(addr, oldval, newval, res, false /* sign */, false /* retold */, true /* barrier */, true /* weak */, false /* exchange */);
+    __ cmpxchg32(addr, oldval, newval, res, false /* sign */, false /* retold */, true /* acquire */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1013,12 +1013,23 @@ bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType bt) {
         return false;
       }
       break;
-    case Op_VectorCastB2X:
-    case Op_VectorLoadMask:
-    case Op_VectorStoreMask:
     case Op_VectorLoadShuffle:
-    case Op_VectorRearrange:
-      if (vlen < 16)
+      if (vlen < 4 || !UseLASX)
+        return false;
+      break;
+    case Op_VectorCastB2X:
+    case Op_VectorCastS2X:
+    case Op_VectorCastI2X:
+    case Op_VectorCastL2X:
+    case Op_VectorCastF2X:
+    case Op_VectorCastD2X:
+    case Op_VectorLoadMask:
+    case Op_VectorMaskCast:
+      if (!UseLASX)
+        return false;
+      break;
+    case Op_VectorTest:
+      if (vlen * type2aelembytes(bt) < 16)
         return false;
       break;
     default:
@@ -1075,18 +1086,23 @@ bool Matcher::is_short_branch_offset(int rule, int br_size, int offset) {
 }
 
 MachOper* Matcher::pd_specialize_generic_vector_operand(MachOper* generic_opnd, uint ideal_reg, bool is_temp) {
-  ShouldNotReachHere(); // generic vector operands not supported
+  assert(Matcher::is_generic_vector(generic_opnd), "not generic");
+  switch (ideal_reg) {
+    case Op_VecS: return new vecSOper();
+    case Op_VecD: return new vecDOper();
+    case Op_VecX: return new vecXOper();
+    case Op_VecY: return new vecYOper();
+  }
+  ShouldNotReachHere();
   return nullptr;
 }
 
 bool Matcher::is_reg2reg_move(MachNode* m) {
-  ShouldNotReachHere(); // generic vector operands not supported
   return false;
 }
 
 bool Matcher::is_generic_vector(MachOper* opnd)  {
-  ShouldNotReachHere();  // generic vector operands not supported
-  return false;
+  return opnd->opcode() == VREG;
 }
 
 bool Matcher::vector_needs_partial_operations(Node* node, const TypeVect* vt) {
@@ -1111,8 +1127,9 @@ int Matcher::superword_max_vector_size(const BasicType bt) {
 
 // Vector ideal reg
 uint Matcher::vector_ideal_reg(int size) {
-  assert(MaxVectorSize == 16 || MaxVectorSize == 32, "");
   switch(size) {
+    case  4: return Op_VecS;
+    case  8: return Op_VecD;
     case 16: return Op_VecX;
     case 32: return Op_VecY;
   }
@@ -1151,8 +1168,9 @@ int Matcher::min_vector_size(const BasicType bt) {
   int max_size = max_vector_size(bt);
   int size     = 0;
 
-  if (UseLSX) size = 16;
+  if (UseLSX) size = 4;
   size = size / type2aelembytes(bt);
+  if (size < 2) size = 2;
   return MIN2(size,max_size);
 }
 
@@ -1312,6 +1330,12 @@ static int vec_mov_helper(CodeBuffer *cbuf, bool do_size, int src_lo, int dst_lo
     MacroAssembler _masm(cbuf);
     int offset = __ offset();
     switch (ireg) {
+      case Op_VecS:
+        __ fmov_s(as_FloatRegister(Matcher::_regEncode[dst_lo]), as_FloatRegister(Matcher::_regEncode[src_lo]));
+        break;
+      case Op_VecD:
+        __ fmov_d(as_FloatRegister(Matcher::_regEncode[dst_lo]), as_FloatRegister(Matcher::_regEncode[src_lo]));
+        break;
       case Op_VecX:
         __ vori_b(as_FloatRegister(Matcher::_regEncode[dst_lo]), as_FloatRegister(Matcher::_regEncode[src_lo]), 0);
         break;
@@ -1324,6 +1348,12 @@ static int vec_mov_helper(CodeBuffer *cbuf, bool do_size, int src_lo, int dst_lo
 #ifndef PRODUCT
   } else if (!do_size) {
     switch (ireg) {
+      case Op_VecS:
+        st->print("fmov.s    %s, %s\t# spill", Matcher::regName[dst_lo], Matcher::regName[src_lo]);
+        break;
+      case Op_VecD:
+        st->print("fmov.d    %s, %s\t# spill", Matcher::regName[dst_lo], Matcher::regName[src_lo]);
+        break;
       case Op_VecX:
         st->print("vori.b    %s, %s, 0\t# spill", Matcher::regName[dst_lo], Matcher::regName[src_lo]);
         break;
@@ -1347,6 +1377,12 @@ static int vec_spill_helper(CodeBuffer *cbuf, bool do_size, bool is_load,
     int offset = __ offset();
     if (is_load) {
       switch (ireg) {
+        case Op_VecS:
+          __ fld_s(as_FloatRegister(Matcher::_regEncode[reg]), SP, stack_offset);
+          break;
+        case Op_VecD:
+          __ fld_d(as_FloatRegister(Matcher::_regEncode[reg]), SP, stack_offset);
+          break;
         case Op_VecX:
           __ vld(as_FloatRegister(Matcher::_regEncode[reg]), SP, stack_offset);
           break;
@@ -1358,6 +1394,12 @@ static int vec_spill_helper(CodeBuffer *cbuf, bool do_size, bool is_load,
       }
     } else { // store
       switch (ireg) {
+        case Op_VecS:
+          __ fst_s(as_FloatRegister(Matcher::_regEncode[reg]), SP, stack_offset);
+          break;
+        case Op_VecD:
+          __ fst_d(as_FloatRegister(Matcher::_regEncode[reg]), SP, stack_offset);
+          break;
         case Op_VecX:
           __ vst(as_FloatRegister(Matcher::_regEncode[reg]), SP, stack_offset);
           break;
@@ -1372,6 +1414,12 @@ static int vec_spill_helper(CodeBuffer *cbuf, bool do_size, bool is_load,
   } else if (!do_size) {
     if (is_load) {
       switch (ireg) {
+        case Op_VecS:
+          st->print("fld.s    %s, [SP + %d]\t# spill", Matcher::regName[reg], stack_offset);
+          break;
+        case Op_VecD:
+          st->print("fld.d    %s, [SP + %d]\t# spill", Matcher::regName[reg], stack_offset);
+          break;
         case Op_VecX:
           st->print("vld    %s, [SP + %d]\t# spill", Matcher::regName[reg], stack_offset);
           break;
@@ -1383,6 +1431,12 @@ static int vec_spill_helper(CodeBuffer *cbuf, bool do_size, bool is_load,
       }
     } else { // store
       switch (ireg) {
+        case Op_VecS:
+          st->print("fst.s    %s, [SP + %d]\t# spill", Matcher::regName[reg], stack_offset);
+          break;
+        case Op_VecD:
+          st->print("fst.d    %s, [SP + %d]\t# spill", Matcher::regName[reg], stack_offset);
+          break;
         case Op_VecX:
           st->print("vst    %s, [SP + %d]\t# spill", Matcher::regName[reg], stack_offset);
           break;
@@ -1405,6 +1459,14 @@ static int vec_stack_to_stack_helper(CodeBuffer *cbuf, int src_offset,
   if (cbuf) {
     MacroAssembler _masm(cbuf);
     switch (ireg) {
+      case Op_VecS:
+        __ fld_s(F23, SP, src_offset);
+        __ fst_s(F23, SP, dst_offset);
+        break;
+      case Op_VecD:
+        __ fld_d(F23, SP, src_offset);
+        __ fst_d(F23, SP, dst_offset);
+        break;
       case Op_VecX:
         __ vld(F23, SP, src_offset);
         __ vst(F23, SP, dst_offset);
@@ -1419,6 +1481,16 @@ static int vec_stack_to_stack_helper(CodeBuffer *cbuf, int src_offset,
 #ifndef PRODUCT
   } else {
     switch (ireg) {
+      case Op_VecS:
+        st->print("fld.s f23, %d(sp)\n\t"
+                  "fst.s f23, %d(sp)\t# 32-bit mem-mem spill",
+                  src_offset, dst_offset);
+        break;
+      case Op_VecD:
+        st->print("fld.d f23, %d(sp)\n\t"
+                  "fst.d f23, %d(sp)\t# 64-bit mem-mem spill",
+                  src_offset, dst_offset);
+        break;
       case Op_VecX:
         st->print("vld f23, %d(sp)\n\t"
                   "vst f23, %d(sp)\t# 128-bit mem-mem spill",
@@ -2542,6 +2614,33 @@ ins_attrib ins_alignment(4);    // Required alignment attribute (must be a power
 
 // Vectors
 
+operand vReg() %{
+  constraint(ALLOC_IN_RC(dynamic));
+  match(VecS);
+  match(VecD);
+  match(VecX);
+  match(VecY);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vecS() %{
+  constraint(ALLOC_IN_RC(flt_reg));
+  match(VecS);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vecD() %{
+  constraint(ALLOC_IN_RC(dbl_reg));
+  match(VecD);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
 operand vecX() %{
   constraint(ALLOC_IN_RC(vectorx_reg));
   match(VecX);
@@ -2700,6 +2799,24 @@ operand immI_1() %{
 
 operand immI_2() %{
   predicate(n->get_int() == 2);
+  match(ConI);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+operand immI_4() %{
+  predicate(n->get_int() == 4);
+  match(ConI);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+operand immI_8() %{
+  predicate(n->get_int() == 8);
   match(ConI);
 
   op_cost(0);
@@ -11124,15 +11241,7 @@ instruct castDD(regD dst) %{
   ins_pipe( empty );
 %}
 
-instruct castVVX(vecX dst) %{
-  match(Set dst (CastVV dst));
-  size(0);
-  format %{ "# castVV of $dst" %}
-  ins_encode(/*empty*/);
-  ins_pipe( empty );
-%}
-
-instruct castVVY(vecY dst) %{
+instruct castVV(vReg dst) %{
   match(Set dst (CastVV dst));
   size(0);
   format %{ "# castVV of $dst" %}
@@ -12719,1684 +12828,786 @@ instruct popCountL_mem(mRegI dst, memory mem) %{
 
 // --------------------------------- Load -------------------------------------
 
-instruct loadV16(vecX dst, memory mem) %{
-  predicate(n->as_LoadVector()->memory_size() == 16);
+instruct loadV(vReg dst, memory mem) %{
   match(Set dst (LoadVector mem));
-  format %{ "vload    $dst, $mem\t# @loadV16" %}
+  format %{ "(x)vload    $dst, $mem\t# @loadV" %}
   ins_encode %{
-    __ loadstore_enc($dst$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::LOAD_VECTORX);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct loadV32(vecY dst, memory mem) %{
-  predicate(n->as_LoadVector()->memory_size() == 32);
-  match(Set dst (LoadVector mem));
-  format %{ "xvload    $dst, $mem\t# @loadV32" %}
-  ins_encode %{
-    __ loadstore_enc($dst$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::LOAD_VECTORY);
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4: __ loadstore_enc($dst$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::LOAD_FLOAT);   break;
+      case  8: __ loadstore_enc($dst$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::LOAD_DOUBLE);  break;
+      case 16: __ loadstore_enc($dst$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::LOAD_VECTORX); break;
+      case 32: __ loadstore_enc($dst$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::LOAD_VECTORY); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- Store ------------------------------------
 
-instruct storeV16(memory mem, vecX src) %{
-  predicate(n->as_StoreVector()->memory_size() == 16);
+instruct storeV(memory mem, vReg src) %{
   match(Set mem (StoreVector mem src));
-  format %{ "vstore    $src, $mem\t# @storeV16" %}
+  format %{ "(x)vstore    $src, $mem\t# @storeV" %}
   ins_encode %{
-    __ loadstore_enc($src$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::STORE_VECTORX);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct storeV32(memory mem, vecY src) %{
-  predicate(n->as_StoreVector()->memory_size() == 32);
-  match(Set mem (StoreVector mem src));
-  format %{ "xvstore    $src, $mem\t# @storeV32" %}
-  ins_encode %{
-    __ loadstore_enc($src$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::STORE_VECTORY);
+    switch (Matcher::vector_length_in_bytes(this, $src)) {
+      case  4: __ loadstore_enc($src$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::STORE_FLOAT);   break;
+      case  8: __ loadstore_enc($src$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::STORE_DOUBLE);  break;
+      case 16: __ loadstore_enc($src$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::STORE_VECTORX); break;
+      case 32: __ loadstore_enc($src$$FloatRegister, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::STORE_VECTORY); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ------------------------------- Replicate ----------------------------------
 
-instruct repl16B(vecX dst, mRegI src) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct replV(vReg dst, mRegI src) %{
   match(Set dst (ReplicateB src));
-  format %{ "vreplgr2vr.b    $dst, $src\t# @repl16B" %}
-  ins_encode %{
-    __ vreplgr2vr_b($dst$$FloatRegister, $src$$Register);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl16B_imm(vecX dst, immI_M128_255 imm) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (ReplicateB imm));
-  format %{ "vldi    $dst, $imm\t# @repl16B_imm" %}
-  ins_encode %{
-    __ vldi($dst$$FloatRegister, ($imm$$constant & 0xff));
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl8S(vecX dst, mRegI src) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (ReplicateS src));
-  format %{ "vreplgr2vr.h    $dst, $src\t# @repl8S" %}
-  ins_encode %{
-    __ vreplgr2vr_h($dst$$FloatRegister, $src$$Register);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl8S_imm(vecX dst, immI10 imm) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (ReplicateS imm));
-  format %{ "vldi    $dst, $imm\t# @repl8S_imm" %}
-  ins_encode %{
-    __ vldi($dst$$FloatRegister, (0b001 << 10 ) | ($imm$$constant & 0x3ff));
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl4I(vecX dst, mRegI src) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (ReplicateI src));
-  format %{ "vreplgr2vr.w    $dst, $src\t# @repl4I" %}
+  format %{ "(x)vreplgr2vr    $dst, $src\t# @replV" %}
   ins_encode %{
-    __ vreplgr2vr_w($dst$$FloatRegister, $src$$Register);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ xvreplgr2vr_b($dst$$FloatRegister, $src$$Register); break;
+        case T_SHORT: __ xvreplgr2vr_h($dst$$FloatRegister, $src$$Register); break;
+        case T_INT  : __ xvreplgr2vr_w($dst$$FloatRegister, $src$$Register); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ vreplgr2vr_b($dst$$FloatRegister, $src$$Register); break;
+        case T_SHORT: __ vreplgr2vr_h($dst$$FloatRegister, $src$$Register); break;
+        case T_INT  : __ vreplgr2vr_w($dst$$FloatRegister, $src$$Register); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct repl4I_imm(vecX dst, immI10 imm) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (ReplicateI imm));
-  format %{ "vldi    $dst, $imm\t# @repl4I_imm" %}
-  ins_encode %{
-    __ vldi($dst$$FloatRegister, (0b010 << 10 ) | ($imm$$constant & 0x3ff));
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl2L(vecX dst, mRegL src) %{
-  predicate(Matcher::vector_length(n) == 2);
+instruct replVL(vReg dst, mRegL src) %{
   match(Set dst (ReplicateL src));
-  format %{ "vreplgr2vr.d    $dst, $src\t# @repl2L" %}
+  format %{ "(x)vreplgr2vr.d    $dst, $src\t# @replVL" %}
   ins_encode %{
-    __ vreplgr2vr_d($dst$$FloatRegister, $src$$Register);
+    switch (Matcher::vector_length(this)) {
+      case 2: __  vreplgr2vr_d($dst$$FloatRegister, $src$$Register); break;
+      case 4: __ xvreplgr2vr_d($dst$$FloatRegister, $src$$Register); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct repl2L_imm(vecX dst, immL10 imm) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (ReplicateL imm));
-  format %{ "vldi    $dst, $imm\t# @repl2L_imm" %}
-  ins_encode %{
-    __ vldi($dst$$FloatRegister, (0b011 << 10 ) | ($imm$$constant & 0x3ff));
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl4F(vecX dst, regF src) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct replVF(vReg dst, regF src) %{
   match(Set dst (ReplicateF src));
-  format %{ "vreplvei.w    $dst, $src, 0\t# @repl4F" %}
+  format %{ "(x)vreplve0.w    $dst, $src\t# @replVF" %}
   ins_encode %{
     __ vreplvei_w($dst$$FloatRegister, $src$$FloatRegister, 0);
+    switch (Matcher::vector_length(this)) {
+      case 2:
+      case 4: __  vreplvei_w($dst$$FloatRegister, $src$$FloatRegister, 0); break;
+      case 8: __ xvreplve0_w($dst$$FloatRegister, $src$$FloatRegister);    break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct repl2D(vecX dst, regD src) %{
-  predicate(Matcher::vector_length(n) == 2);
+instruct replVD(vReg dst, regD src) %{
   match(Set dst (ReplicateD src));
-  format %{ "vreplvei.d    $dst, $src, 0\t# @repl2D" %}
+  format %{ "(x)vreplve0.d    $dst, $src\t# @replVD" %}
   ins_encode %{
-    __ vreplvei_d($dst$$FloatRegister, $src$$FloatRegister, 0);
+    switch (Matcher::vector_length(this)) {
+      case 2: __  vreplvei_d($dst$$FloatRegister, $src$$FloatRegister, 0); break;
+      case 4: __ xvreplve0_d($dst$$FloatRegister, $src$$FloatRegister);    break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct repl32B(vecY dst, mRegI src) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (ReplicateB src));
-  format %{ "xvreplgr2vr.b    $dst, $src\t# @repl32B" %}
-  ins_encode %{
-    __ xvreplgr2vr_b($dst$$FloatRegister, $src$$Register);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl32B_imm(vecY dst, immI_M128_255 imm) %{
-  predicate(Matcher::vector_length(n) == 32);
+instruct replVB_imm(vReg dst, immI_M128_255 imm) %{
   match(Set dst (ReplicateB imm));
-  format %{ "xvldi    $dst, $imm\t# @repl32B_imm" %}
+  format %{ "(x)vldi    $dst, $imm\t# @replVB_imm" %}
   ins_encode %{
-    __ xvldi($dst$$FloatRegister, ($imm$$constant & 0xff));
+    switch (Matcher::vector_length(this)) {
+      case  4:
+      case  8:
+      case 16: __  vldi($dst$$FloatRegister, ($imm$$constant & 0xff)); break;
+      case 32: __ xvldi($dst$$FloatRegister, ($imm$$constant & 0xff)); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct repl16S(vecY dst, mRegI src) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (ReplicateS src));
-  format %{ "xvreplgr2vr.h    $dst, $src\t# @repl16S" %}
-  ins_encode %{
-    __ xvreplgr2vr_h($dst$$FloatRegister, $src$$Register);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl16S_imm(vecY dst, immI10 imm) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct replV_imm(vReg dst, immI10 imm) %{
   match(Set dst (ReplicateS imm));
-  format %{ "xvldi    $dst, $imm\t# @repl16S_imm" %}
-  ins_encode %{
-    __ xvldi($dst$$FloatRegister, (0b001 << 10 ) | ($imm$$constant & 0x3ff));
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl8I(vecY dst, mRegI src) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (ReplicateI src));
-  format %{ "xvreplgr2vr.w    $dst, $src\t# @repl8I" %}
-  ins_encode %{
-    __ xvreplgr2vr_w($dst$$FloatRegister, $src$$Register);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl8I_imm(vecY dst, immI10 imm) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (ReplicateI imm));
-  format %{ "xvldi    $dst, $imm\t# @repl8I_imm" %}
+  format %{ "(x)vldi    $dst, $imm\t# @replV_imm" %}
   ins_encode %{
-    __ xvldi($dst$$FloatRegister, (0b010 << 10 ) | ($imm$$constant & 0x3ff));
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_SHORT: __ xvldi($dst$$FloatRegister, (0b001 << 10 ) | ($imm$$constant & 0x3ff)); break;
+        case T_INT  : __ xvldi($dst$$FloatRegister, (0b010 << 10 ) | ($imm$$constant & 0x3ff)); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_SHORT: __ vldi($dst$$FloatRegister, (0b001 << 10 ) | ($imm$$constant & 0x3ff)); break;
+        case T_INT  : __ vldi($dst$$FloatRegister, (0b010 << 10 ) | ($imm$$constant & 0x3ff)); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct repl4L(vecY dst, mRegL src) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (ReplicateL src));
-  format %{ "xvreplgr2vr.d    $dst, $src\t# @repl4L" %}
-  ins_encode %{
-    __ xvreplgr2vr_d($dst$$FloatRegister, $src$$Register);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl4L_imm(vecY dst, immL10 imm) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct replVL_imm(vReg dst, immL10 imm) %{
   match(Set dst (ReplicateL imm));
-  format %{ "xvldi    $dst, $imm\t# @repl4L_imm" %}
+  format %{ "(x)vldi    $dst, $imm\t# @replVL_imm" %}
   ins_encode %{
-    __ xvldi($dst$$FloatRegister, (0b011 << 10 ) | ($imm$$constant & 0x3ff));
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl8F(vecY dst, regF src) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (ReplicateF src));
-  format %{ "xvreplve0.w    $dst, $src\t# @repl8F" %}
-  ins_encode %{
-    __ xvreplve0_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct repl4D(vecY dst, regD src) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (ReplicateD src));
-  format %{ "xvreplve0.d    $dst, $src\t# @repl4D" %}
-  ins_encode %{
-    __ xvreplve0_d($dst$$FloatRegister, $src$$FloatRegister);
+    switch (Matcher::vector_length(this)) {
+      case 2: __  vldi($dst$$FloatRegister, (0b011 << 10 ) | ($imm$$constant & 0x3ff)); break;
+      case 4: __ xvldi($dst$$FloatRegister, (0b011 << 10 ) | ($imm$$constant & 0x3ff)); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- ADD --------------------------------------
 
-instruct add16B(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct addV(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AddVB src1 src2));
-  format %{ "vadd.b    $dst, $src1, $src2\t# @add16B" %}
-  ins_encode %{
-    __ vadd_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add16B_imm(vecX dst, vecX src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (AddVB src (ReplicateB imm)));
-  format %{ "vaddi.bu    $dst, $src, $imm\t# @add16B_imm" %}
-  ins_encode %{
-    __ vaddi_bu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add8S(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (AddVS src1 src2));
-  format %{ "vadd.h    $dst, $src1, $src2\t# @add8S" %}
-  ins_encode %{
-    __ vadd_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add8S_imm(vecX dst, vecX src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (AddVS src (ReplicateS imm)));
-  format %{ "vaddi.hu    $dst, $src, $imm\t# @add8S_imm" %}
-  ins_encode %{
-    __ vaddi_hu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add4I(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (AddVI src1 src2));
-  format %{ "vadd.w    $dst, $src1, src2\t# @add4I" %}
-  ins_encode %{
-    __ vadd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add4I_imm(vecX dst, vecX src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (AddVI src (ReplicateI imm)));
-  format %{ "vaddi.wu    $dst, $src, $imm\t# @add4I_imm" %}
-  ins_encode %{
-    __ vaddi_wu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add2L(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (AddVL src1 src2));
-  format %{ "vadd.d    $dst, $src1, $src2\t# @add2L" %}
-  ins_encode %{
-    __ vadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add2L_imm(vecX dst, vecX src, immLU5 imm) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (AddVL src (ReplicateL imm)));
-  format %{ "vaddi.du    $dst, $src, $imm\t# @add2L_imm" %}
-  ins_encode %{
-    __ vaddi_du($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add4F(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (AddVF src1 src2));
-  format %{ "vfadd.s    $dst, $src1, $src2\t# @add4F" %}
-  ins_encode %{
-    __ vfadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add2D(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (AddVD src1 src2));
-  format %{ "vfadd.d    $dst, $src1, $src2\t# @add2D" %}
+  format %{ "(x)vadd    $dst, $src1, $src2\t# @addV" %}
   ins_encode %{
-    __ vfadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ xvadd_b ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT : __ xvadd_h ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT   : __ xvadd_w ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG  : __ xvadd_d ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_FLOAT : __ xvfadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_DOUBLE: __ xvfadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ vadd_b ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT : __ vadd_h ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT   : __ vadd_w ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG  : __ vadd_d ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_FLOAT : __ vfadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_DOUBLE: __ vfadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct add32B(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (AddVB src1 src2));
-  format %{ "xvadd.b    $dst, $src1, $src2\t# @add32B" %}
-  ins_encode %{
-    __ xvadd_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add32B_imm(vecY dst, vecY src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 32);
+instruct addV_imm(vReg dst, vReg src, immIU5 imm) %{
   match(Set dst (AddVB src (ReplicateB imm)));
-  format %{ "xvaddi.bu    $dst, $src, $imm\t# @add32B_imm" %}
-  ins_encode %{
-    __ xvaddi_bu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add16S(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (AddVS src1 src2));
-  format %{ "xvadd.h    $dst, $src1, $src2\t# @add16S" %}
-  ins_encode %{
-    __ xvadd_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add16S_imm(vecY dst, vecY src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 16);
   match(Set dst (AddVS src (ReplicateS imm)));
-  format %{ "xvaddi.hu    $dst, $src, $imm\t# @add16S_imm" %}
-  ins_encode %{
-    __ xvaddi_hu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add8I(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (AddVI src1 src2));
-  format %{ "xvadd.wu    $dst, $src1, $src2\t# @add8I" %}
-  ins_encode %{
-    __ xvadd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add8I_imm(vecY dst, vecY src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (AddVI src (ReplicateI imm)));
-  format %{ "xvaddi.wu    $dst, $src, $imm\t# @add8I_imm" %}
+  format %{ "(x)vaddi    $dst, $src, $imm\t# @addV_imm" %}
   ins_encode %{
-    __ xvaddi_wu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ xvaddi_bu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        case T_SHORT: __ xvaddi_hu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        case T_INT  : __ xvaddi_wu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ vaddi_bu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        case T_SHORT: __ vaddi_hu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        case T_INT  : __ vaddi_wu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct add4L(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (AddVL src1 src2));
-  format %{ "xvadd.d    $dst, $src1, $src2\t# @add4L" %}
-  ins_encode %{
-    __ xvadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add4L_imm(vecY dst, vecY src, immLU5 imm) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct addVL_imm(vReg dst, vReg src, immLU5 imm) %{
   match(Set dst (AddVL src (ReplicateL imm)));
-  format %{ "xvaddi.du    $dst, $src, $imm\t# @add4L_imm" %}
+  format %{ "(x)vaddi.du    $dst, $src, $imm\t# @addVL_imm" %}
   ins_encode %{
-    __ xvaddi_du($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add8F(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (AddVF src1 src2));
-  format %{ "xvfadd.s    $dst, $src1, $src2\t# @add8F" %}
-  ins_encode %{
-    __ xvfadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct add4D(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (AddVD src1 src2));
-  format %{ "xvfadd.d    $dst, $src1, $src2\t# @add4D" %}
-  ins_encode %{
-    __ xvfadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    switch (Matcher::vector_length(this)) {
+      case 2: __  vaddi_du($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      case 4: __ xvaddi_du($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- SUB --------------------------------------
 
-instruct sub16B(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct subV(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (SubVB src1 src2));
-  format %{ "vsub.b    $dst, $src1, $src2\t# @sub16B" %}
-  ins_encode %{
-    __ vsub_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub16B_imm(vecX dst, vecX src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (SubVB src (ReplicateB imm)));
-  format %{ "vsubi.bu    $dst, $src, $imm\t# @sub16B_imm" %}
-  ins_encode %{
-    __ vsubi_bu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub8S(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (SubVS src1 src2));
-  format %{ "vsub.h    $dst, $src1, $src2\t# @sub8S" %}
-  ins_encode %{
-    __ vsub_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub8S_imm(vecX dst, vecX src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (SubVS src (ReplicateS imm)));
-  format %{ "vsubi.hu    $dst, $src, $imm\t# @sub8S_imm" %}
-  ins_encode %{
-    __ vsubi_hu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub4I(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (SubVI src1 src2));
-  format %{ "vsub.w    $dst, $src1, src2\t# @sub4I" %}
-  ins_encode %{
-    __ vsub_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub4I_imm(vecX dst, vecX src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (SubVI src (ReplicateI imm)));
-  format %{ "vsubi.wu    $dst, $src, $imm\t# @sub4I_imm" %}
-  ins_encode %{
-    __ vsubi_wu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub2L(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (SubVL src1 src2));
-  format %{ "vsub.d    $dst, $src1, $src2\t# @sub2L" %}
-  ins_encode %{
-    __ vsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub2L_imm(vecX dst, vecX src, immLU5 imm) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (SubVL src (ReplicateL imm)));
-  format %{ "vsubi.du    $dst, $src, $imm\t# @sub2L_imm" %}
-  ins_encode %{
-    __ vsubi_du($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub4F(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (SubVF src1 src2));
-  format %{ "vfsub.s    $dst, $src1, $src2\t# @sub4F" %}
-  ins_encode %{
-    __ vfsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub2D(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (SubVD src1 src2));
-  format %{ "vfsub.d    $dst, $src1, $src2\t# @sub2D" %}
+  format %{ "(x)vsub    $dst, $src1, $src2\t# @subV" %}
   ins_encode %{
-    __ vfsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ xvsub_b ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT : __ xvsub_h ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT   : __ xvsub_w ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG  : __ xvsub_d ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_FLOAT : __ xvfsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_DOUBLE: __ xvfsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ vsub_b ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT : __ vsub_h ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT   : __ vsub_w ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG  : __ vsub_d ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_FLOAT : __ vfsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_DOUBLE: __ vfsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct sub32B(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (SubVB src1 src2));
-  format %{ "xvsub.b    $dst, $src1, $src2\t# @sub32B" %}
-  ins_encode %{
-    __ xvsub_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub32B_imm(vecY dst, vecY src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 32);
+instruct subV_imm(vReg dst, vReg src, immIU5 imm) %{
   match(Set dst (SubVB src (ReplicateB imm)));
-  format %{ "xvsubi.bu    $dst, $src, $imm\t# @sub32B_imm" %}
+  match(Set dst (SubVS src (ReplicateB imm)));
+  match(Set dst (SubVI src (ReplicateB imm)));
+  format %{ "(x)vsubi    $dst, $src, $imm\t# @subV_imm" %}
   ins_encode %{
-    __ xvsubi_bu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ xvsubi_bu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        case T_SHORT: __ xvsubi_hu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        case T_INT  : __ xvsubi_wu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ vsubi_bu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        case T_SHORT: __ vsubi_hu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        case T_INT  : __ vsubi_wu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct sub16S(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (SubVS src1 src2));
-  format %{ "xvsub.h    $dst, $src1, $src2\t# @sub16S" %}
-  ins_encode %{
-    __ xvsub_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub16S_imm(vecY dst, vecY src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (SubVS src (ReplicateS imm)));
-  format %{ "xvsubi.hu    $dst, $src, $imm\t# @sub16S_imm" %}
-  ins_encode %{
-    __ xvsubi_hu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub8I(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (SubVI src1 src2));
-  format %{ "xvsub.w    $dst, $src1, $src2\t# @sub8I" %}
-  ins_encode %{
-    __ xvsub_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub8I_imm(vecY dst, vecY src, immIU5 imm) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (SubVI src (ReplicateI imm)));
-  format %{ "xvsubi.wu    $dst, $src, $imm\t# @sub8I_imm" %}
-  ins_encode %{
-    __ xvsubi_wu($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub4L(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (SubVL src1 src2));
-  format %{ "xvsub.d    $dst, $src1, $src2\t# @sub4L" %}
-  ins_encode %{
-    __ xvsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub4L_imm(vecY dst, vecY src, immLU5 imm) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct subVL_imm(vReg dst, vReg src, immLU5 imm) %{
   match(Set dst (SubVL src (ReplicateL imm)));
-  format %{ "xvsubi.du    $dst, $src, $imm\t# @sub4L_imm" %}
+  format %{ "(x)vsubi.du    $dst, $src, $imm\t# @subVL_imm" %}
   ins_encode %{
-    __ xvsubi_du($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub8F(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (SubVF src1 src2));
-  format %{ "xvfsub.s    $dst, $src1, $src2\t# @sub8F" %}
-  ins_encode %{
-    __ xvfsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sub4D(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (SubVD src1 src2));
-  format %{ "xvfsub.d    $dst,$src1,$src2\t# @sub4D" %}
-  ins_encode %{
-    __ xvfsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    switch (Matcher::vector_length(this)) {
+      case 2: __  vsubi_du($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      case 4: __ xvsubi_du($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- MUL --------------------------------------
-instruct mul16B(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 16);
+
+instruct mulV(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (MulVB src1 src2));
-  format %{ "vmul.b    $dst, $src1, $src2\t# @mul16B" %}
-  ins_encode %{
-    __ vmul_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul8S(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (MulVS src1 src2));
-  format %{ "vmul.h    $dst, $src1, $src2\t# @mul8S" %}
-  ins_encode %{
-    __ vmul_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul4I(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (MulVI src1 src2));
-  format %{ "vmul.w    $dst, $src1, $src2\t# @mul4I" %}
-  ins_encode %{
-    __ vmul_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul2L(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (MulVL src1 src2));
-  format %{ "vmul.d    $dst, $src1, $src2\t# @mul2L" %}
-  ins_encode %{
-    __ vmul_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul4F(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (MulVF src1 src2));
-  format %{ "vfmul.s    $dst, $src1, $src2\t# @mul4F" %}
-  ins_encode %{
-    __ vfmul_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul2D(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (MulVD src1 src2));
-  format %{ "vfmul.d    $dst, $src1, $src2\t# @mul2D" %}
+  format %{ "(x)vmul    $dst, $src1, $src2\t# @mulV" %}
   ins_encode %{
-    __ vfmul_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul32B(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (MulVB src1 src2));
-  format %{ "xvmul.b    $dst, $src1, $src2\t# @mul32B" %}
-  ins_encode %{
-    __ xvmul_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul16S(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (MulVS src1 src2));
-  format %{ "xvmul.h    $dst, $src1, $src2\t# @mul16S" %}
-  ins_encode %{
-    __ xvmul_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul8I(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (MulVI src1 src2));
-  format %{ "xvmul.w    $dst, $src1, $src2\t# @mul8I" %}
-  ins_encode %{
-    __ xvmul_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul4L(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (MulVL src1 src2));
-  format %{ "xvmul.d    $dst, $src1, $src2\t# @mul4L" %}
-  ins_encode %{
-    __ xvmul_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul8F(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (MulVF src1 src2));
-  format %{ "xvfmul.s    $dst, $src1, $src2\t# @mul8F" %}
-  ins_encode %{
-    __ xvfmul_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct mul4D(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (MulVD src1 src2));
-  format %{ "xvfmul.d    $dst, $src1, $src2\t# @mul4D" %}
-  ins_encode %{
-    __ xvfmul_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ xvmul_b ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT : __ xvmul_h ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT   : __ xvmul_w ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG  : __ xvmul_d ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_FLOAT : __ xvfmul_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_DOUBLE: __ xvfmul_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ vmul_b ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT : __ vmul_h ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT   : __ vmul_w ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG  : __ vmul_d ($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_FLOAT : __ vfmul_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_DOUBLE: __ vfmul_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- DIV --------------------------------------
-instruct div4F(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
+
+instruct divV(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (DivVF src1 src2));
-  format %{ "vfdiv.s    $dst, $src1, $src2\t# @div4F" %}
-  ins_encode %{
-    __ vfdiv_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct div2D(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (DivVD src1 src2));
-  format %{ "vfdiv.d    $dst, $src1, $src2\t# @div2D" %}
+  format %{ "(x)vfdiv    $dst, $src1, $src2\t# @divV" %}
   ins_encode %{
-    __ vfdiv_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct div8F(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (DivVF src1 src2));
-  format %{ "xvfdiv.s    $dst, $src1, $src2\t# @div8F" %}
-  ins_encode %{
-    __ xvfdiv_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct div4D(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (DivVD src1 src2));
-  format %{ "xvfdiv.d    $dst, $src1, $src2\t# @div4D" %}
-  ins_encode %{
-    __ xvfdiv_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ xvfdiv_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_DOUBLE: __ xvfdiv_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ vfdiv_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_DOUBLE: __ vfdiv_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- ABS --------------------------------------
 
-instruct abs16B(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct absV(vReg dst, vReg src) %{
   match(Set dst (AbsVB src));
-  format %{ "vabs    $dst, $src\t# @abs16B" %}
-  ins_encode %{
-    __ vxor_v(fscratch, fscratch, fscratch);
-    __ vabsd_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs8S(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (AbsVS src));
-  format %{ "vabs    $dst, $src\t# @abs8S" %}
-  ins_encode %{
-    __ vxor_v(fscratch, fscratch, fscratch);
-    __ vabsd_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs4I(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (AbsVI src));
-  format %{ "vabs    $dst, $src\t# @abs4I" %}
-  ins_encode %{
-    __ vxor_v(fscratch, fscratch, fscratch);
-    __ vabsd_w($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs2L(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (AbsVL src));
-  format %{ "vabs    $dst, $src\t# @abs2L" %}
-  ins_encode %{
-    __ vxor_v(fscratch, fscratch, fscratch);
-    __ vabsd_d($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs4F(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (AbsVF src));
-  format %{ "vbitclri.w    $dst, $src\t# @abs4F" %}
-  ins_encode %{
-    __ vbitclri_w($dst$$FloatRegister, $src$$FloatRegister, 0x1f);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs2D(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (AbsVD src));
-  format %{ "vbitclri.d    $dst, $src\t# @abs2D" %}
+  format %{ "(x)vabs    $dst, $src\t# @absV" %}
   ins_encode %{
-    __ vbitclri_d($dst$$FloatRegister, $src$$FloatRegister, 0x3f);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs32B(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (AbsVB src));
-  format %{ "xvabs    $dst, $src\t# @abs32B" %}
-  ins_encode %{
-    __ xvxor_v(fscratch, fscratch, fscratch);
-    __ xvabsd_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs16S(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (AbsVS src));
-  format %{ "xvabs    $dst, $src\t# @abs16S" %}
-  ins_encode %{
-    __ xvxor_v(fscratch, fscratch, fscratch);
-    __ xvabsd_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs8I(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (AbsVI src));
-  format %{ "xvabs    $dst, $src\t# @abs8I" %}
-  ins_encode %{
-    __ xvxor_v(fscratch, fscratch, fscratch);
-    __ xvabsd_w($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs4L(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (AbsVL src));
-  format %{ "xvabs    $dst, $src\t# @abs4L" %}
-  ins_encode %{
-    __ xvxor_v(fscratch, fscratch, fscratch);
-    __ xvabsd_d($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs8F(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (AbsVF src));
-  format %{ "xvbitclri.w    $dst, $src\t# @abs8F" %}
-  ins_encode %{
-    __ xvbitclri_w($dst$$FloatRegister, $src$$FloatRegister, 0x1f);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct abs4D(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (AbsVD src));
-  format %{ "xvbitclri.d    $dst, $src\t# @abs4D" %}
-  ins_encode %{
-    __ xvbitclri_d($dst$$FloatRegister, $src$$FloatRegister, 0x3f);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      if (!is_floating_point_type(Matcher::vector_element_basic_type(this)))
+        __ xvxor_v(fscratch, fscratch, fscratch);
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ xvabsd_b($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_SHORT : __ xvabsd_h($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_INT   : __ xvabsd_w($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_LONG  : __ xvabsd_d($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_FLOAT : __ xvbitclri_w($dst$$FloatRegister, $src$$FloatRegister, 0x1f);  break;
+        case T_DOUBLE: __ xvbitclri_d($dst$$FloatRegister, $src$$FloatRegister, 0x3f);  break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      if (!is_floating_point_type(Matcher::vector_element_basic_type(this)))
+        __ vxor_v(fscratch, fscratch, fscratch);
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ vabsd_b($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_SHORT : __ vabsd_h($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_INT   : __ vabsd_w($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_LONG  : __ vabsd_d($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_FLOAT : __ vbitclri_w($dst$$FloatRegister, $src$$FloatRegister, 0x1f);  break;
+        case T_DOUBLE: __ vbitclri_d($dst$$FloatRegister, $src$$FloatRegister, 0x3f);  break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- ABS DIFF ---------------------------------
 
-instruct absd4I(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct absdV(vReg dst, vReg src1, vReg src2) %{
+  match(Set dst (AbsVB (SubVI src1 src2)));
+  match(Set dst (AbsVS (SubVI src1 src2)));
   match(Set dst (AbsVI (SubVI src1 src2)));
-  format %{ "vabsd.w    $dst, $src1, $src2\t# @absd4I" %}
+  match(Set dst (AbsVL (SubVI src1 src2)));
+  format %{ "(x)vabsd    $dst, $src1, $src2\t# @absdV" %}
   ins_encode %{
-    __ vabsd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct absd2L(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (AbsVL (SubVL src1 src2)));
-  format %{ "vabsd.d    $dst, $src1, $src2\t# @absd2L" %}
-  ins_encode %{
-    __ vabsd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct absd8I(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (AbsVI (SubVI src1 src2)));
-  format %{ "xvabsd.w    $dst, $src1, $src2\t# @absd8I" %}
-  ins_encode %{
-    __ xvabsd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct absd4L(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (AbsVL (SubVL src1 src2)));
-  format %{ "xvabsd.d    $dst, $src1, $src2\t# @absd4L" %}
-  ins_encode %{
-    __ xvabsd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ xvabsd_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ xvabsd_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ xvabsd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ xvabsd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ vabsd_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ vabsd_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ vabsd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ vabsd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- MAX --------------------------------------
 
-instruct max16B(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_BYTE);
+instruct maxV(vReg dst, vReg src1, vReg src2) %{
+  predicate(!(is_floating_point_type(Matcher::vector_element_basic_type(n))));
   match(Set dst (MaxV src1 src2));
-  format %{ "vmax.b    $dst, $src1, $src2\t# @max16B" %}
+  format %{ "(x)vmax    $dst, $src1, $src2\t# @maxV" %}
   ins_encode %{
-    __ vmax_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ xvmax_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ xvmax_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ xvmax_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ xvmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ vmax_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ vmax_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ vmax_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ vmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct max8S(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_SHORT);
-  match(Set dst (MaxV src1 src2));
-  format %{ "vmax.h    $dst, $src1, $src2\t# @max8S" %}
-  ins_encode %{
-    __ vmax_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct max4I(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_INT);
-  match(Set dst (MaxV src1 src2));
-  format %{ "vmax.w    $dst, $src1, $src2\t# @max4I" %}
-  ins_encode %{
-    __ vmax_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct max2L(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_LONG);
-  match(Set dst (MaxV src1 src2));
-  format %{ "vmax.d    $dst, $src1, $src2\t# @max2L" %}
-  ins_encode %{
-    __ vmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct max4F(vecX dst, vecX src1, vecX src2, vecX tmp) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
+instruct maxVF(vReg dst, vReg src1, vReg src2, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (MaxV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vfmax    $dst, $src1, $src2\t# TEMP($tmp) @max4F" %}
+  format %{ "(x)vfmax    $dst, $src1, $src2\t# TEMP($tmp) @maxVF" %}
   ins_encode %{
-    __ vfmax_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ vfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ vfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      __ xvfmax_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ xvfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ xvfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    } else {
+      __ vfmax_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ vfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ vfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct max2D(vecX dst, vecX src1, vecX src2, vecX tmp) %{
-  predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
+instruct maxVD(vReg dst, vReg src1, vReg src2, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MaxV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vfmax    $dst, $src1, $src2\t# TEMP($tmp) @max2D" %}
+  format %{ "(x)vfmax    $dst, $src1, $src2\t# TEMP($tmp) @maxVD" %}
   ins_encode %{
-    __ vfmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ vfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ vfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct max32B(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 32 && Matcher::vector_element_basic_type(n) == T_BYTE);
-  match(Set dst (MaxV src1 src2));
-  format %{ "xvmax.b    $dst, $src1, $src2\t# @max32B" %}
-  ins_encode %{
-    __ xvmax_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct max16S(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_SHORT);
-  match(Set dst (MaxV src1 src2));
-  format %{ "xvmax.h    $dst, $src1, $src2\t# @max16S" %}
-  ins_encode %{
-    __ xvmax_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct max8I(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_INT);
-  match(Set dst (MaxV src1 src2));
-  format %{ "xvmax.w    $dst, $src1, $src2\t# @max8I" %}
-  ins_encode %{
-    __ xvmax_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct max4L(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_LONG);
-  match(Set dst (MaxV src1 src2));
-  format %{ "xvmax.d    $dst, $src1, $src2\t# @max4L" %}
-  ins_encode %{
-    __ xvmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct max8F(vecY dst, vecY src1, vecY src2, vecY tmp) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_FLOAT);
-  match(Set dst (MaxV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "xvfmax    $dst, $src1, $src2\t# TEMP($tmp) @max8F" %}
-  ins_encode %{
-    __ xvfmax_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ xvfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ xvfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct max4D(vecY dst, vecY src1, vecY src2, vecY tmp) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (MaxV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "xvfmax    $dst, $src1, $src2\t# TEMP($tmp) @max4D" %}
-  ins_encode %{
-    __ xvfmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ xvfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ xvfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      __ xvfmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ xvfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ xvfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    } else {
+      __ vfmax_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ vfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ vfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- MIN --------------------------------------
 
-instruct min16B(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_BYTE);
+instruct minV(vReg dst, vReg src1, vReg src2) %{
+  predicate(!(is_floating_point_type(Matcher::vector_element_basic_type(n))));
   match(Set dst (MinV src1 src2));
-  format %{ "vmin.b    $dst, $src1, $src2\t# @min16B" %}
+  format %{ "(x)vmin    $dst, $src1, $src2\t# @minV" %}
   ins_encode %{
-    __ vmin_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ xvmin_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ xvmin_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ xvmin_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ xvmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ vmin_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ vmin_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ vmin_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ vmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct min8S(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_SHORT);
-  match(Set dst (MinV src1 src2));
-  format %{ "vmin.h    $dst, $src1, $src2\t# @min8S" %}
-  ins_encode %{
-    __ vmin_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct min4I(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_INT);
-  match(Set dst (MinV src1 src2));
-  format %{ "vmin.w    $dst, $src1, $src2\t# @min4I" %}
-  ins_encode %{
-    __ vmin_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct min2L(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_LONG);
-  match(Set dst (MinV src1 src2));
-  format %{ "vmin.d    $dst, $src1, $src2\t# @min2L" %}
-  ins_encode %{
-    __ vmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct min4F(vecX dst, vecX src1, vecX src2, vecX tmp) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
+instruct minVF(vReg dst, vReg src1, vReg src2, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (MinV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vfmin    $dst, $src1, $src2\t# TEMP($tmp) @min4F" %}
+  format %{ "(x)vfmin    $dst, $src1, $src2\t# TEMP($tmp) @minVF" %}
   ins_encode %{
-    __ vfmin_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ vfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ vfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      __ xvfmin_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ xvfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ xvfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    } else {
+      __ vfmin_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ vfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ vfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct min2D(vecX dst, vecX src1, vecX src2, vecX tmp) %{
-  predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
+instruct minVD(vReg dst, vReg src1, vReg src2, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MinV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "vfmin    $dst, $src1, $src2\t# TEMP($tmp) @min2D" %}
+  format %{ "(x)vfmin    $dst, $src1, $src2\t# TEMP($tmp) @minVD" %}
   ins_encode %{
-    __ vfmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ vfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ vfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct min32B(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 32 && Matcher::vector_element_basic_type(n) == T_BYTE);
-  match(Set dst (MinV src1 src2));
-  format %{ "xvmin.b    $dst, $src1, $src2\t# @min32B" %}
-  ins_encode %{
-    __ xvmin_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct min16S(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_SHORT);
-  match(Set dst (MinV src1 src2));
-  format %{ "xvmin.h    $dst, $src1, $src2\t# @min16S" %}
-  ins_encode %{
-    __ xvmin_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct min8I(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_INT);
-  match(Set dst (MinV src1 src2));
-  format %{ "xvmin.w    $dst, $src1, $src2\t# @min8I" %}
-  ins_encode %{
-    __ xvmin_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct min4L(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_LONG);
-  match(Set dst (MinV src1 src2));
-  format %{ "xvmin.d    $dst, $src1, $src2\t# @min4L" %}
-  ins_encode %{
-    __ xvmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct min8F(vecY dst, vecY src1, vecY src2, vecY tmp) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_FLOAT);
-  match(Set dst (MinV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "xvfmin    $dst, $src1, $src2\t# TEMP($tmp) @min8F" %}
-  ins_encode %{
-    __ xvfmin_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ xvfdiv_s($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ xvfcmp_cun_s(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct min4D(vecY dst, vecY src1, vecY src2, vecY tmp) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (MinV src1 src2));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "xvfmin    $dst, $src1, $src2\t# TEMP($tmp) @min4D" %}
-  ins_encode %{
-    __ xvfmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ xvfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ xvfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
-    __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      __ xvfmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ xvxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ xvfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ xvfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ xvbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    } else {
+      __ vfmin_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ vxor_v($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ vfdiv_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ vfcmp_cun_d(fscratch, $src1$$FloatRegister, $src2$$FloatRegister);
+      __ vbitsel_v($dst$$FloatRegister, $dst$$FloatRegister, $tmp$$FloatRegister, fscratch);
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- NEG --------------------------------------
 
-instruct neg16B(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct negV(vReg dst, vReg src) %{
   match(Set dst (NegVI src));
-  format %{ "vneg.b    $dst, $src\t# @neg16S" %}
-  ins_encode %{
-    __ vneg_b($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg8S(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (NegVI src));
-  format %{ "vneg.h    $dst, $src\t# @neg8B" %}
-  ins_encode %{
-    __ vneg_h($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg4I(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (NegVI src));
-  format %{ "vneg.w    $dst, $src\t# @neg4I" %}
-  ins_encode %{
-    __ vneg_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg2L(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (NegVL src));
-  format %{ "vneg.d    $dst, $src\t# @neg2L" %}
-  ins_encode %{
-    __ vneg_d($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg4F(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (NegVF src));
-  format %{ "vbitrevi.w    $dst, $src\t# @neg4F" %}
-  ins_encode %{
-    __ vbitrevi_w($dst$$FloatRegister, $src$$FloatRegister, 0x1f);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg2D(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (NegVD src));
-  format %{ "vbitrevi.d    $dst, $src\t# @neg2D" %}
+  format %{ "(x)vneg    $dst, $src\t# @negV" %}
   ins_encode %{
-    __ vbitrevi_d($dst$$FloatRegister, $src$$FloatRegister, 0x3f);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg32B(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (NegVI src));
-  format %{ "xvneg.b    $dst, $src\t# @neg32B" %}
-  ins_encode %{
-    __ xvneg_b($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg16S(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (NegVI src));
-  format %{ "xvneg.h    $dst, $src\t# @neg16S" %}
-  ins_encode %{
-    __ xvneg_h($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg8I(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (NegVI src));
-  format %{ "xvneg.w    $dst, $src\t# @neg8I" %}
-  ins_encode %{
-    __ xvneg_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg4L(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (NegVL src));
-  format %{ "xvneg.w    $dst, $src\t# @neg4L" %}
-  ins_encode %{
-    __ xvneg_d($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg8F(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (NegVF src));
-  format %{ "xvbitrevi.w    $dst, $src\t# @neg8F" %}
-  ins_encode %{
-    __ xvbitrevi_w($dst$$FloatRegister, $src$$FloatRegister, 0x1f);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct neg4D(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (NegVD src));
-  format %{ "xvbitrevi.d    $dst, $src\t# @neg4D" %}
-  ins_encode %{
-    __ xvbitrevi_d($dst$$FloatRegister, $src$$FloatRegister, 0x3f);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ xvneg_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_SHORT : __ xvneg_h($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_INT   : __ xvneg_w($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_LONG  : __ xvneg_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_FLOAT : __ xvbitrevi_w($dst$$FloatRegister, $src$$FloatRegister, 0x1f); break;
+        case T_DOUBLE: __ xvbitrevi_d($dst$$FloatRegister, $src$$FloatRegister, 0x3f); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ vneg_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_SHORT : __ vneg_h($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_INT   : __ vneg_w($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_LONG  : __ vneg_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_FLOAT : __ vbitrevi_w($dst$$FloatRegister, $src$$FloatRegister, 0x1f); break;
+        case T_DOUBLE: __ vbitrevi_d($dst$$FloatRegister, $src$$FloatRegister, 0x3f); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- SQRT -------------------------------------
 
-instruct sqrt4F(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct sqrtVF(vReg dst, vReg src) %{
   match(Set dst (SqrtVF src));
-  format %{ "vfsqrt.s    $dst, $src\t# @sqrt4F" %}
-  ins_encode %{
-    __ vfsqrt_s($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sqrt2D(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (SqrtVD src));
-  format %{ "vfsqrt.d    $dst, $src\t# @sqrt2D" %}
+  format %{ "(x)vfsqrt.s    $dst, $src\t# @sqrtVF" %}
   ins_encode %{
-    __ vfsqrt_d($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sqrt8F(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (SqrtVF src));
-  format %{ "xvfsqrt.s    $dst, $src\t# @sqrt8F" %}
-  ins_encode %{
-    __ xvfsqrt_s($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sqrt4D(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (SqrtVD src));
-  format %{ "xvfsqrt.d    $dst, $src\t# @sqrt4D" %}
-  ins_encode %{
-    __ xvfsqrt_d($dst$$FloatRegister, $src$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ xvfsqrt_s($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_DOUBLE: __ xvfsqrt_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ vfsqrt_s($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_DOUBLE: __ vfsqrt_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- MADD -------------------------------------
 
-instruct madd16B(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct maddV(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AddVB dst (MulVB src1 src2)));
-  format %{ "vmadd.b    $dst, $src1, $src2\t# @madd16B" %}
-  ins_encode %{
-    __ vmadd_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct madd8S(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (AddVS dst (MulVS src1 src2)));
-  format %{ "vmadd.h    $dst, $src1, $src2\t# @madd8S" %}
-  ins_encode %{
-    __ vmadd_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct madd4I(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (AddVI dst (MulVI src1 src2)));
-  format %{ "vmadd    $dst, $src1, $src2\t# @madd4I" %}
-  ins_encode %{
-    __ vmadd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct madd2L(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (AddVL dst (MulVL src1 src2)));
-  format %{ "vmadd.d    $dst, $src1, $src2\t# @madd2L" %}
+  format %{ "(x)vmadd    $dst, $src1, $src2\t# @maddV" %}
   ins_encode %{
-    __ vmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ xvmadd_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ xvmadd_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ xvmadd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ xvmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ vmadd_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ vmadd_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ vmadd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ vmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // src1 * src2 + src3
-instruct madd4F(vecX dst, vecX src1, vecX src2, vecX src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 4);
+instruct fmaddV(vReg dst, vReg src1, vReg src2, vReg src3) %{
   match(Set dst (FmaVF src3 (Binary src1 src2)));
-  format %{ "vfmadd.s    $dst, $src1, $src2, $src3\t# @madd4F" %}
-  ins_encode %{
-    __ vfmadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// src1 * src2 + src3
-instruct madd2D(vecX dst, vecX src1, vecX src2, vecX src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 2);
   match(Set dst (FmaVD src3 (Binary src1 src2)));
-  format %{ "vfmadd.d    $dst, $src1, $src2, $src3\t# @madd2D" %}
+  format %{ "(x)vfmadd    $dst, $src1, $src2, $src3\t# @fmaddV" %}
   ins_encode %{
-    __ vfmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct madd32B(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (AddVB dst (MulVB src1 src2)));
-  format %{ "xvmadd.b    $dst, $src1, $src2\t# @madd32B" %}
-  ins_encode %{
-    __ xvmadd_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct madd16S(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (AddVS dst (MulVS src1 src2)));
-  format %{ "xvmadd.h    $dst, $src1, $src2\t# @madd16S" %}
-  ins_encode %{
-    __ xvmadd_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct madd8I(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (AddVI dst (MulVI src1 src2)));
-  format %{ "xvmadd.w    $dst, $src1, $src2\t# @madd8I" %}
-  ins_encode %{
-    __ xvmadd_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct madd4L(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (AddVL dst (MulVL src1 src2)));
-  format %{ "xvmadd.d    $dst, $src1, $src2\t# @madd4L" %}
-  ins_encode %{
-    __ xvmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// src1 * src2 + src3
-instruct madd8F(vecY dst, vecY src1, vecY src2, vecY src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 8);
-  match(Set dst (FmaVF src3 (Binary src1 src2)));
-  format %{ "xvfmadd.s    $dst, $src1, $src2, $src3\t# @madd8F" %}
-  ins_encode %{
-    __ xvfmadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// src1 * src2 + src3
-instruct madd4D(vecY dst, vecY src1, vecY src2, vecY src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 4);
-  match(Set dst (FmaVD src3 (Binary src1 src2)));
-  format %{ "xvfmadd.d    $dst, $src1, $src2, $src3\t# @madd4D" %}
-  ins_encode %{
-    __ xvfmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ xvfmadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        case T_DOUBLE: __ xvfmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ vfmadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        case T_DOUBLE: __ vfmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- MSUB -------------------------------------
 
-instruct msub16B(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct msubV(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (SubVB dst (MulVB src1 src2)));
-  format %{ "vmsub.b    $dst, $src1, $src2\t# @msub16B" %}
-  ins_encode %{
-    __ vmsub_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct msub8S(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (SubVS dst (MulVS src1 src2)));
-  format %{ "vmsub.h    $dst, $src1, $src2\t# @msub8S" %}
-  ins_encode %{
-    __ vmsub_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct msub4I(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (SubVI dst (MulVI src1 src2)));
-  format %{ "vmsub.w    $dst, $src1, $src2\t# @msub4I" %}
-  ins_encode %{
-    __ vmsub_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct msub2L(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (SubVL dst (MulVL src1 src2)));
-  format %{ "vmsub.d    $dst, $src1, $src2\t# @msub2L" %}
+  format %{ "(x)vmsub    $dst, $src1, $src2\t# @msubV" %}
   ins_encode %{
-    __ vmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ xvmsub_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ xvmsub_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ xvmsub_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ xvmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ vmsub_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_SHORT: __ vmsub_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_INT  : __ vmsub_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        case T_LONG : __ vmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // src1 * src2 - src3
-instruct msub4F(vecX dst, vecX src1, vecX src2, vecX src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 4);
+instruct fmsubV(vReg dst, vReg src1, vReg src2, vReg src3) %{
   match(Set dst (FmaVF (NegVF src3) (Binary src1 src2)));
-  format %{ "vfmsub.s    $dst, $src1, $src2, $src3\t# @msub4F" %}
+  format %{ "(x)vfmsub    $dst, $src1, $src2, $src3\t# @fmsubV" %}
   ins_encode %{
-    __ vfmsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// src1 * src2 - src3
-instruct msub2D(vecX dst, vecX src1, vecX src2, vecX src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 2);
-  match(Set dst (FmaVD (NegVD src3) (Binary src1 src2)));
-  format %{ "vfmsub.d    $dst, $src1, $src2, $src3\t# @msub2D" %}
-  ins_encode %{
-    __ vfmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct msub32B(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (SubVB dst (MulVB src1 src2)));
-  format %{ "xvmsub.b    $dst, $src1, $src2\t# @msub32B" %}
-  ins_encode %{
-    __ xvmsub_b($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct msub16S(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (SubVS dst (MulVS src1 src2)));
-  format %{ "xvmsub.h    $dst, $src1, $src2\t# @msub16S" %}
-  ins_encode %{
-    __ xvmsub_h($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct msub8I(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (SubVI dst (MulVI src1 src2)));
-  format %{ "xvmsub.w    $dst, $src1, $src2\t# @msub8I" %}
-  ins_encode %{
-    __ xvmsub_w($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct msub4L(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (SubVL dst (MulVL src1 src2)));
-  format %{ "xvmsub.d    $dst, $src1, $src2\t# @msub4L" %}
-  ins_encode %{
-    __ xvmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// src1 * src2 - src3
-instruct msub8F(vecY dst, vecY src1, vecY src2, vecY src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 8);
-  match(Set dst (FmaVF (NegVF src3) (Binary src1 src2)));
-  format %{ "xvfmsub.s    $dst, $src1, $src2, $src3\t# @msub8F" %}
-  ins_encode %{
-    __ xvfmsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// src1 * src2 - src3
-instruct msub4D(vecY dst, vecY src1, vecY src2, vecY src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 4);
-  match(Set dst (FmaVD (NegVD src3) (Binary src1 src2)));
-  format %{ "xvfmsub.d    $dst, $src1, $src2, $src3\t# @msub4D" %}
-  ins_encode %{
-    __ xvfmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ xvfmsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        case T_DOUBLE: __ xvfmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ vfmsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        case T_DOUBLE: __ vfmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14404,49 +13615,28 @@ instruct msub4D(vecY dst, vecY src1, vecY src2, vecY src3) %{
 // --------------------------------- FNMADD -----------------------------------
 
 // -src1 * src2 - src3
-instruct nmadd4F(vecX dst, vecX src1, vecX src2, vecX src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 4);
+instruct fnmaddV(vReg dst, vReg src1, vReg src2, vReg src3) %{
   match(Set dst (FmaVF (NegVF src3) (Binary (NegVF src1) src2)));
   match(Set dst (FmaVF (NegVF src3) (Binary src1 (NegVF src2))));
-  format %{ "vfnmadd.s    $dst, $src1, $src2, $src3\t# @nmadd4F" %}
-  ins_encode %{
-    __ vfnmadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// -src1 * src2 - src3
-instruct nmadd2D(vecX dst, vecX src1, vecX src2, vecX src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 2);
   match(Set dst (FmaVD (NegVD src3) (Binary (NegVD src1) src2)));
   match(Set dst (FmaVD (NegVD src3) (Binary src1 (NegVD src2))));
-  format %{ "vfnmadd.d    $dst, $src1, $src2, $src3\t# @nmadd2D" %}
+  format %{ "(x)vfnmadd    $dst, $src1, $src2, $src3\t# @fnmaddV" %}
   ins_encode %{
-    __ vfnmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// -src1 * src2 - src3
-instruct nmadd8F(vecY dst, vecY src1, vecY src2, vecY src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 8);
-  match(Set dst (FmaVF (NegVF src3) (Binary (NegVF src1) src2)));
-  match(Set dst (FmaVF (NegVF src3) (Binary src1 (NegVF src2))));
-  format %{ "xvfnmadd.s    $dst, $src1, $src2, $src3\t# @nmadd8F" %}
-  ins_encode %{
-    __ xvfnmadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// -src1 * src2 - src3
-instruct nmadd4D(vecY dst, vecY src1, vecY src2, vecY src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 4);
-  match(Set dst (FmaVD (NegVD src3) (Binary (NegVD src1) src2)));
-  match(Set dst (FmaVD (NegVD src3) (Binary src1 (NegVD src2))));
-  format %{ "xvfnmadd.d    $dst, $src1, $src2, $src3\t# @nmadd4D" %}
-  ins_encode %{
-    __ xvfnmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ xvfnmadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        case T_DOUBLE: __ xvfnmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ vfnmadd_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        case T_DOUBLE: __ vfnmadd_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14454,56 +13644,35 @@ instruct nmadd4D(vecY dst, vecY src1, vecY src2, vecY src3) %{
 // --------------------------------- FNMSUB -----------------------------------
 
 // -src1 * src2 + src3
-instruct nmsub4F(vecX dst, vecX src1, vecX src2, vecX src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 4);
+instruct fnmsubV(vReg dst, vReg src1, vReg src2, vReg src3) %{
   match(Set dst (FmaVF src3 (Binary (NegVF src1) src2)));
   match(Set dst (FmaVF src3 (Binary src1 (NegVF src2))));
-  format %{ "vfnmsub.s    $dst, $src1, $src2, $src3\t# @nmsub4F" %}
-  ins_encode %{
-    __ vfnmsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// -src1 * src2 + src3
-instruct nmsub2D(vecX dst, vecX src1, vecX src2, vecX src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 2);
   match(Set dst (FmaVD src3 (Binary (NegVD src1) src2)));
   match(Set dst (FmaVD src3 (Binary src1 (NegVD src2))));
-  format %{ "vfnmsub.d    $dst, $src1, $src2, $src3\t# @nmsub2D" %}
+  format %{ "(x)vfnmsub    $dst, $src1, $src2, $src3\t# @fnmsubV" %}
   ins_encode %{
-    __ vfnmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// -src1 * src2 + src3
-instruct nmsub8F(vecY dst, vecY src1, vecY src2, vecY src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 8);
-  match(Set dst (FmaVF src3 (Binary (NegVF src1) src2)));
-  match(Set dst (FmaVF src3 (Binary src1 (NegVF src2))));
-  format %{ "xvfnmsub.s    $dst, $src1, $src2, $src3\t# @nmsub8F" %}
-  ins_encode %{
-    __ xvfnmsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// -src1 * src2 + src3
-instruct nmsub4D(vecY dst, vecY src1, vecY src2, vecY src3) %{
-  predicate(UseFMA && Matcher::vector_length(n) == 4);
-  match(Set dst (FmaVD src3 (Binary (NegVD src1) src2)));
-  match(Set dst (FmaVD src3 (Binary src1 (NegVD src2))));
-  format %{ "xvfnmsub.d    $dst, $src1, $src2, $src3\t# @nmsub4D" %}
-  ins_encode %{
-    __ xvfnmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ xvfnmsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        case T_DOUBLE: __ xvfnmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch(Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT : __ vfnmsub_s($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        case T_DOUBLE: __ vfnmsub_d($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $src3$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------- Vector Multiply-Add Shorts into Integer --------------------
 
-instruct muladd8Sto4I(vecX dst, vecX src1, vecX src2) %{
+instruct muladd8Sto4I(vReg dst, vReg src1, vReg src2) %{
   predicate(Matcher::vector_length(n->in(1)) == 8 && Matcher::vector_element_basic_type(n->in(1)) == T_SHORT);
   match(Set dst (MulAddVS2VI src1 src2));
   format %{ "muladdvs2vi    $dst, $src1, $src2\t# @muladd8Sto4I" %}
@@ -14516,7 +13685,7 @@ instruct muladd8Sto4I(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct muladd16Sto8I(vecY dst, vecY src1, vecY src2) %{
+instruct muladd16Sto8I(vReg dst, vReg src1, vReg src2) %{
   predicate(Matcher::vector_length(n->in(1)) == 16 && Matcher::vector_element_basic_type(n->in(1)) == T_SHORT);
   match(Set dst (MulAddVS2VI src1 src2));
   format %{ "muladdvs2vi    $dst, $src1, $src2\t# @muladd16Sto8I" %}
@@ -14531,1721 +13700,683 @@ instruct muladd16Sto8I(vecY dst, vecY src1, vecY src2) %{
 
 // ------------------------------ Shift ---------------------------------------
 
-instruct shiftcntX(vecX dst, mRegI cnt) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
+instruct shiftcntV(vReg dst, mRegI cnt) %{
   match(Set dst (LShiftCntV cnt));
   match(Set dst (RShiftCntV cnt));
-  format %{ "vreplgr2vr.b    $dst, $cnt\t# @shiftcntX" %}
+  format %{ "(x)vreplgr2vr.b    $dst, $cnt\t# @shiftcntV" %}
   ins_encode %{
-    __ vreplgr2vr_b($dst$$FloatRegister, $cnt$$Register);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct shiftcntY(vecY dst, mRegI cnt) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (LShiftCntV cnt));
-  match(Set dst (RShiftCntV cnt));
-  format %{ "xvreplgr2vr.b    $dst, $cnt\t# @shiftcntY" %}
-  ins_encode %{
-    __ xvreplgr2vr_b($dst$$FloatRegister, $cnt$$Register);
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4:
+      case  8:
+      case 16: __  vreplgr2vr_b($dst$$FloatRegister, $cnt$$Register); break;
+      case 32: __ xvreplgr2vr_b($dst$$FloatRegister, $cnt$$Register); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ------------------------------ LeftShift -----------------------------------
 
-instruct sll16B(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct sllV(vReg dst, vReg src, vReg shift) %{
   match(Set dst (LShiftVB src shift));
-  format %{ "vsll    $dst, $src, $shift\t# @sll16B" %}
-  ins_encode %{
-    __ vsll_b(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
-    __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll16B_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (LShiftVB src (LShiftCntV shift)));
-  format %{ "vslli.b    $dst, $src, $shift\t# @sll16B_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 8) {
-      __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    } else {
-      __ vslli_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll8S(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (LShiftVS src shift));
-  format %{ "vsll    $dst, $src, $shift\t# @sll8S" %}
+  match(Set dst (LShiftVI src shift));
+  match(Set dst (LShiftVL src shift));
+  format %{ "(x)vsll    $dst, $src, $shift\t# @sllV" %}
   ins_encode %{
-    __ vsll_h(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
-    __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll8S_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (LShiftVS src (LShiftCntV shift)));
-  format %{ "vslli.h    $dst, $src, $shift\t# @sll8S_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 16) {
-      __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ xvsll_b(fscratch,            $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_CHAR   :
+        case T_SHORT  : __ xvsll_h(fscratch,            $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_INT    : __ xvsll_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_LONG   : __ xvsll_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister,  8);
+                        __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch); break;
+        case T_CHAR   :
+        case T_SHORT  : __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 16);
+                        __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch); break;
+        default:
+          break; // do nothing
+      }
     } else {
-      __ vslli_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ vsll_b(fscratch,            $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_CHAR   :
+        case T_SHORT  : __ vsll_h(fscratch,            $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_INT    : __ vsll_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_LONG   : __ vsll_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister,  8);
+                        __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch); break;
+        case T_CHAR   :
+        case T_SHORT  : __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 16);
+                        __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch); break;
+        default:
+          break; // do nothing
+      }
     }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct sll4I(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (LShiftVI src shift));
-  format %{ "vsll.w    $dst, $src, $shift\t# @sll4I" %}
-  ins_encode %{
-    __ vsll_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll4I_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (LShiftVI src (LShiftCntV shift)));
-  format %{ "vslli.w    $dst, $src, $shift\t# @sll4I_imm" %}
-  ins_encode %{
-    __ vslli_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll2L(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (LShiftVL src shift));
-  format %{ "vsll.d    $dst, $src, $shift\t# @sll2L" %}
-  ins_encode %{
-    __ vsll_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll2L_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (LShiftVL src (LShiftCntV shift)));
-  format %{ "vslli.d    $dst, $src, $shift\t# @sll2L_imm" %}
-  ins_encode %{
-    __ vslli_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll32B(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (LShiftVB src shift));
-  format %{ "xvsll    $dst, $src, $shift\t# @sll32B" %}
-  ins_encode %{
-    __ xvsll_b(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
-    __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll32B_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 32);
+instruct sllV_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVB src (LShiftCntV shift)));
-  format %{ "xvslli.b    $dst, $src, $shift\t# @sll32B_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 8) {
-      __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    } else {
-      __ xvslli_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll16S(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (LShiftVS src shift));
-  format %{ "xvsll    $dst, $src, $shift\t# @sll16S" %}
-  ins_encode %{
-    __ xvsll_h(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
-    __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll16S_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 16);
   match(Set dst (LShiftVS src (LShiftCntV shift)));
-  format %{ "xvslli.h    $dst, $src, $shift\t# @sll16S_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 16) {
-      __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    } else {
-      __ xvslli_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll8I(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (LShiftVI src shift));
-  format %{ "xvsll.w    $dst, $src, $shift\t# @sll8I" %}
-  ins_encode %{
-    __ xvsll_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll8I_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (LShiftVI src (LShiftCntV shift)));
-  format %{ "xvslli.w    $dst, $src, $shift\t# @sll8I_imm" %}
-  ins_encode %{
-    __ xvslli_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll4L(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (LShiftVL src shift));
-  format %{ "xvsll.d    $dst, $src, $shift\t# @sll4L" %}
-  ins_encode %{
-    __ xvsll_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sll4L_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (LShiftVL src (LShiftCntV shift)));
-  format %{ "xvslli.d    $dst, $src, $shift\t# @sll4L_imm" %}
+  format %{ "(x)vslli    $dst, $src, $shift\t# @sllV_imm" %}
   ins_encode %{
-    __ xvslli_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : $shift$$constant >= 8 ?
+                        __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister) :
+                        __ xvslli_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_CHAR   :
+        case T_SHORT  : $shift$$constant >= 16 ?
+                        __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister) :
+                        __ xvslli_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_INT    : __ xvslli_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_LONG   : __ xvslli_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : $shift$$constant >= 8 ?
+                        __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister) :
+                        __ vslli_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_CHAR   :
+        case T_SHORT  : $shift$$constant >= 16 ?
+                        __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister) :
+                        __ vslli_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_INT    : __ vslli_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_LONG   : __ vslli_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ----------------------- LogicalRightShift ----------------------------------
 
-instruct srl16B(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct srlV(vReg dst, vReg src, vReg shift) %{
   match(Set dst (URShiftVB src shift));
-  format %{ "vsrl    $dst, $src, $shift\t# @srl16B" %}
-  ins_encode %{
-    __ vsrl_b(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
-    __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl16B_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (URShiftVB src (RShiftCntV shift)));
-  format %{ "vsrli.b    $dst, $src, $shift\t# @srl16B_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 8) {
-      __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    } else {
-      __ vsrli_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl8S(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (URShiftVS src shift));
-  format %{ "vsrl    $dst, $src, $shift\t# @srl8S" %}
+  match(Set dst (URShiftVI src shift));
+  match(Set dst (URShiftVL src shift));
+  format %{ "(x)vsrl    $dst, $src, $shift\t# @srlV" %}
   ins_encode %{
-    __ vsrl_h(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
-    __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl8S_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (URShiftVS src (RShiftCntV shift)));
-  format %{ "vsrli.h    $dst, $src, $shift\t# @srl8S_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 16) {
-      __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ xvsrl_b(fscratch,            $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_CHAR   :
+        case T_SHORT  : __ xvsrl_h(fscratch,            $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_INT    : __ xvsrl_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_LONG   : __ xvsrl_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister,  8);
+                        __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch); break;
+        case T_CHAR   :
+        case T_SHORT  : __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 16);
+                        __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch); break;
+        default:
+          break; // do nothing
+      }
     } else {
-      __ vsrli_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ vsrl_b(fscratch,            $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_CHAR   :
+        case T_SHORT  : __ vsrl_h(fscratch,            $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_INT    : __ vsrl_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_LONG   : __ vsrl_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister,  8);
+                        __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch); break;
+        case T_CHAR   :
+        case T_SHORT  : __ vslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 16);
+                        __ vand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch); break;
+        default:
+          break; // do nothing
+      }
     }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct srl4I(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (URShiftVI src shift));
-  format %{ "vsrl.w    $dst, $src, $shift\t# @srl4I" %}
-  ins_encode %{
-    __ vsrl_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl4I_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (URShiftVI src (RShiftCntV shift)));
-  format %{ "vsrli.w    $dst, $src, $shift\t# @srl4I_imm" %}
-  ins_encode %{
-    __ vsrli_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl2L(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (URShiftVL src shift));
-  format %{ "vsrl.d    $dst, $src, $shift\t# @srl2L" %}
-  ins_encode %{
-    __ vsrl_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl2L_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (URShiftVL src (RShiftCntV shift)));
-  format %{ "vsrli.d    $dst, $src, $shift\t# @srl2L_imm" %}
-  ins_encode %{
-    __ vsrli_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl32B(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (URShiftVB src shift));
-  format %{ "xvsrl    $dst, $src, $shift\t# @srl32B" %}
-  ins_encode %{
-    __ xvsrl_b(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
-    __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x8);
-    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl32B_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 32);
+instruct srlV_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVB src (RShiftCntV shift)));
-  format %{ "xvsrli.b    $dst, $src, $shift\t# @srl32B_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 8) {
-      __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    } else {
-      __ xvsrli_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl16S(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (URShiftVS src shift));
-  format %{ "xvsrl    $dst, $src, $shift\t# @srl16S" %}
-  ins_encode %{
-    __ xvsrl_h(fscratch, $src$$FloatRegister, $shift$$FloatRegister);
-    __ xvslti_bu($dst$$FloatRegister, $shift$$FloatRegister, 0x10);
-    __ xvand_v($dst$$FloatRegister, $dst$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl16S_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 16);
   match(Set dst (URShiftVS src (RShiftCntV shift)));
-  format %{ "xvsrli.h    $dst, $src, $shift\t# @srl16S_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 16) {
-      __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-    } else {
-      __ xvsrli_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl8I(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (URShiftVI src shift));
-  format %{ "xvsrl.w    $dst, $src, $shift\t# @srl8I" %}
-  ins_encode %{
-    __ xvsrl_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl8I_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (URShiftVI src (RShiftCntV shift)));
-  format %{ "xvsrli.w    $dst, $src, $shift\t# @srl8I_imm" %}
-  ins_encode %{
-    __ xvsrli_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl4L(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (URShiftVL src shift));
-  format %{ "xvsrl.d    $dst, $src, $shift\t# @srl4L" %}
-  ins_encode %{
-    __ xvsrl_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct srl4L_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (URShiftVL src (RShiftCntV shift)));
-  format %{ "xvsrli.d    $dst, $src, $shift\t# @srl4L_imm" %}
+  format %{ "(x)vsrli    $dst, $src, $shift\t# @srlV_imm" %}
   ins_encode %{
-    __ xvsrli_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : $shift$$constant >= 8 ?
+                        __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister) :
+                        __ xvsrli_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_CHAR   :
+        case T_SHORT  : $shift$$constant >= 16 ?
+                        __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister) :
+                        __ xvsrli_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_INT    : __ xvsrli_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_LONG   : __ xvsrli_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : $shift$$constant >= 8 ?
+                        __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister) :
+                        __ vsrli_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_CHAR   :
+        case T_SHORT  : $shift$$constant >= 16 ?
+                        __ vxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister) :
+                        __ vsrli_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_INT    : __ vsrli_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_LONG   : __ vsrli_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ------------------------- ArithmeticRightShift -----------------------------
 
-instruct sra16B(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct sraV(vReg dst, vReg src, vReg shift) %{
   match(Set dst (RShiftVB src shift));
-  format %{ "vsra    $dst, $src, $shift\t# @sra16B" %}
-  ins_encode %{
-    __ vslti_bu(fscratch, $shift$$FloatRegister, 0x8);
-    __ vorn_v(fscratch, $shift$$FloatRegister, fscratch);
-    __ vsra_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra16B_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (RShiftVB src (RShiftCntV shift)));
-  format %{ "vsrai.b    $dst, $src, $shift\t# @sra16B_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 8) {
-      __ vsrai_b($dst$$FloatRegister, $src$$FloatRegister, 7);
-    } else {
-      __ vsrai_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra8S(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (RShiftVS src shift));
-  format %{ "vsra    $dst, $src, $shift\t# @sra8S" %}
+  match(Set dst (RShiftVI src shift));
+  match(Set dst (RShiftVL src shift));
+  format %{ "(x)vsra    $dst, $src, $shift\t# @sraV" %}
   ins_encode %{
-    __ vslti_bu(fscratch, $shift$$FloatRegister, 0x10);
-    __ vorn_v(fscratch, $shift$$FloatRegister, fscratch);
-    __ vsra_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra8S_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (RShiftVS src (RShiftCntV shift)));
-  format %{ "vsrai.h    $dst, $src, $shift\t# @sra8S_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 16) {
-      __ vsrai_h($dst$$FloatRegister, $src$$FloatRegister, 15);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ xvslti_bu(fscratch, $shift$$FloatRegister,  8);
+                        __ xvorn_v(fscratch, $shift$$FloatRegister, fscratch); break;
+        case T_CHAR   :
+        case T_SHORT  : __ xvslti_bu(fscratch, $shift$$FloatRegister, 16);
+                        __ xvorn_v(fscratch, $shift$$FloatRegister, fscratch); break;
+        default:
+          break; // do nothing
+      }
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ xvsra_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);              break;
+        case T_CHAR   :
+        case T_SHORT  : __ xvsra_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);              break;
+        case T_INT    : __ xvsra_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_LONG   : __ xvsra_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
     } else {
-      __ vsrai_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ vslti_bu(fscratch, $shift$$FloatRegister,  8);
+                        __ vorn_v(fscratch, $shift$$FloatRegister, fscratch); break;
+        case T_CHAR   :
+        case T_SHORT  : __ vslti_bu(fscratch, $shift$$FloatRegister, 16);
+                        __ vorn_v(fscratch, $shift$$FloatRegister, fscratch); break;
+        default:
+          break; // do nothing
+      }
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : __ vsra_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);              break;
+        case T_CHAR   :
+        case T_SHORT  : __ vsra_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);              break;
+        case T_INT    : __ vsra_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_LONG   : __ vsra_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
     }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct sra4I(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (RShiftVI src shift));
-  format %{ "vsra.w    $dst, $src, $shift\t# @sra4I" %}
-  ins_encode %{
-    __ vsra_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra4I_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (RShiftVI src (RShiftCntV shift)));
-  format %{ "vsrai.w    $dst, $src, $shift\t# @sra4I_imm" %}
-  ins_encode %{
-    __ vsrai_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra2L(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (RShiftVL src shift));
-  format %{ "vsra.d    $dst, $src, $shift\t# @sra2L" %}
-  ins_encode %{
-    __ vsra_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra2L_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (RShiftVL src (RShiftCntV shift)));
-  format %{ "vsrai.d    $dst, $src, $shift\t# @sra2L_imm" %}
-  ins_encode %{
-    __ vsrai_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra32B(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (RShiftVB src shift));
-  format %{ "xvsra    $dst, $src, $shift\t# @sra32B" %}
-  ins_encode %{
-    __ xvslti_bu(fscratch, $shift$$FloatRegister, 0x8);
-    __ xvorn_v(fscratch, $shift$$FloatRegister, fscratch);
-    __ xvsra_b($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra32B_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 32);
+instruct sraV_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVB src (RShiftCntV shift)));
-  format %{ "xvsrai.b    $dst, $src, $shift\t# @sra32B_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 8) {
-      __ xvsrai_b($dst$$FloatRegister, $src$$FloatRegister, 7);
-    } else {
-      __ xvsrai_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra16S(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (RShiftVS src shift));
-  format %{ "xvsra    $dst, $src, $shift\t# @sra16S" %}
-  ins_encode %{
-    __ xvslti_bu(fscratch, $shift$$FloatRegister, 0x10);
-    __ xvorn_v(fscratch, $shift$$FloatRegister, fscratch);
-    __ xvsra_h($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra16S_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 16);
   match(Set dst (RShiftVS src (RShiftCntV shift)));
-  format %{ "xvsrai.h    $dst, $src, $shift\t# @sra16S_imm" %}
-  ins_encode %{
-    if ($shift$$constant >= 16) {
-      __ xvsrai_h($dst$$FloatRegister, $src$$FloatRegister, 15);
-    } else {
-      __ xvsrai_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra8I(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (RShiftVI src shift));
-  format %{ "xvsra.w    $dst, $src, $shift\t# @sra8I" %}
-  ins_encode %{
-    __ xvsra_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra8I_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (RShiftVI src (RShiftCntV shift)));
-  format %{ "xvsrai.w    $dst, $src, $shift\t# @sra8I_imm" %}
-  ins_encode %{
-    __ xvsrai_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra4L(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (RShiftVL src shift));
-  format %{ "xvsra.d    $dst, $src, $shift\t# @sra4L" %}
-  ins_encode %{
-    __ xvsra_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct sra4L_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (RShiftVL src (RShiftCntV shift)));
-  format %{ "xvsrai.d    $dst, $src, $shift\t# @sra4L_imm" %}
+  format %{ "(x)vsrai    $dst, $src, $shift\t# @sraV_imm" %}
   ins_encode %{
-    __ xvsrai_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : $shift$$constant >= 8 ?
+                        __ xvsrai_b($dst$$FloatRegister, $src$$FloatRegister,  7) :
+                        __ xvsrai_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_CHAR   :
+        case T_SHORT  : $shift$$constant >= 16 ?
+                        __ xvsrai_h($dst$$FloatRegister, $src$$FloatRegister, 15) :
+                        __ xvsrai_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_INT    : __ xvsrai_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_LONG   : __ xvsrai_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BOOLEAN:
+        case T_BYTE   : $shift$$constant >= 8 ?
+                        __ vsrai_b($dst$$FloatRegister, $src$$FloatRegister,  7) :
+                        __ vsrai_b($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_CHAR   :
+        case T_SHORT  : $shift$$constant >= 16 ?
+                        __ vsrai_h($dst$$FloatRegister, $src$$FloatRegister, 15) :
+                        __ vsrai_h($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_INT    : __ vsrai_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_LONG   : __ vsrai_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ----------------------------- RotateRightV ---------------------------------
 
-instruct rotr4I(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct rotrV(vReg dst, vReg src, vReg shift) %{
   match(Set dst (RotateRightV src shift));
-  format %{ "vrotr.w    $dst, $src, $shift\t# @rotr4I" %}
+  format %{ "(x)vrotr    $dst, $src, $shift\t# @rotrV" %}
   ins_encode %{
-    __ vrotr_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ xvrotr_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_LONG: __ xvrotr_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ vrotr_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        case T_LONG: __ vrotr_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct rotr4I_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct rotrV_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (RotateRightV src shift));
-  format %{ "vrotri.w    $dst, $src, $shift\t# @rotr4I_imm" %}
+  format %{ "(x)vrotri    $dst, $src, $shift\t# @rotrV_imm" %}
   ins_encode %{
-    __ vrotri_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotr2L(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (RotateRightV src shift));
-  format %{ "vrotr.d    $dst, $src, $shift\t# @rotr2L" %}
-  ins_encode %{
-    __ vrotr_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotr2L_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (RotateRightV src shift));
-  format %{ "vrotri.d    $dst, $src, $shift\t# @rotr2L_imm" %}
-  ins_encode %{
-    __ vrotri_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotr8I(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (RotateRightV src shift));
-  format %{ "xvrotr.w    $dst, $src, $shift\t# @rotr8I" %}
-  ins_encode %{
-    __ xvrotr_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotr8I_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (RotateRightV src shift));
-  format %{ "xvrotri.w    $dst, $src, $shift\t# @rotr8I_imm" %}
-  ins_encode %{
-    __ xvrotri_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotr4L(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (RotateRightV src shift));
-  format %{ "xvrotr.d    $dst, $src, $shift\t# @rotr4L" %}
-  ins_encode %{
-    __ xvrotr_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotr4L_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (RotateRightV src  shift));
-  format %{ "xvrotri.d    $dst, $src, $shift\t# @rotr4L_imm" %}
-  ins_encode %{
-    __ xvrotri_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ xvrotri_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_LONG: __ xvrotri_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ vrotri_w($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        case T_LONG: __ vrotri_d($dst$$FloatRegister, $src$$FloatRegister, $shift$$constant); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ------------------------------ RotateLeftV ---------------------------------
 
-instruct rotl4I(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct rotlV(vReg dst, vReg src, vReg shift) %{
   match(Set dst (RotateLeftV src shift));
-  format %{ "vrotl    $dst, $src, $shift\t# @rotl4I" %}
+  format %{ "(x)vrotl    $dst, $src, $shift\t# @rotlV" %}
   ins_encode %{
-    __ vneg_w(fscratch, $shift$$FloatRegister);
-    __ vrotr_w($dst$$FloatRegister, $src$$FloatRegister, fscratch);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ xvneg_w(fscratch, $shift$$FloatRegister); break;
+        case T_LONG: __ xvneg_d(fscratch, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ xvrotr_w($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_LONG: __ xvrotr_d($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ vneg_w(fscratch, $shift$$FloatRegister); break;
+        case T_LONG: __ vneg_d(fscratch, $shift$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ vrotr_w($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        case T_LONG: __ vrotr_d($dst$$FloatRegister, $src$$FloatRegister, fscratch); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct rotl4I_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
+instruct rotlV_imm(vReg dst, vReg src, immI shift) %{
   match(Set dst (RotateLeftV src shift));
-  format %{ "vrotli    $dst, $src, $shift\t# @rotl4I_imm" %}
+  format %{ "(x)vrotli    $dst, $src, $shift\t# @rotlV_imm" %}
   ins_encode %{
-    __ vrotri_w($dst$$FloatRegister, $src$$FloatRegister, (-$shift$$constant) & 0x1f);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotl2L(vecX dst, vecX src, vecX shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (RotateLeftV src shift));
-  format %{ "vrotl    $dst, $src, $shift\t# @rotl2L" %}
-  ins_encode %{
-    __ vneg_d(fscratch, $shift$$FloatRegister);
-    __ vrotr_d($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotl2L_imm(vecX dst, vecX src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 2);
-  match(Set dst (RotateLeftV src shift));
-  format %{ "vrotli    $dst, $src, $shift\t# @rotl2L_imm" %}
-  ins_encode %{
-    __ vrotri_d($dst$$FloatRegister, $src$$FloatRegister, (-$shift$$constant) & 0x3f);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotl8I(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (RotateLeftV src shift));
-  format %{ "xvrotl    $dst, $src, $shift\t# @rotl8I" %}
-  ins_encode %{
-    __ xvneg_w(fscratch, $shift$$FloatRegister);
-    __ xvrotr_w($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotl8I_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 8);
-  match(Set dst (RotateLeftV src shift));
-  format %{ "xvrotli    $dst, $src, $shift\t# @rotr8I_imm" %}
-  ins_encode %{
-    __ xvrotri_w($dst$$FloatRegister, $src$$FloatRegister, (-$shift$$constant) & 0x1f);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotl4L(vecY dst, vecY src, vecY shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (RotateLeftV src shift));
-  format %{ "xvrotl    $dst, $src, $shift\t# @rotl4L" %}
-  ins_encode %{
-    __ xvneg_d(fscratch, $shift$$FloatRegister);
-    __ xvrotr_d($dst$$FloatRegister, $src$$FloatRegister, fscratch);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rotl4L_imm(vecY dst, vecY src, immI shift) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (RotateLeftV src  shift));
-  format %{ "xvrotli    $dst, $src, $shift\t# @rotl4L_imm" %}
-  ins_encode %{
-    __ xvrotri_d($dst$$FloatRegister, $src$$FloatRegister, (-$shift$$constant) & 0x3f);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ xvrotri_w($dst$$FloatRegister, $src$$FloatRegister, (-$shift$$constant) & 0x1f); break;
+        case T_LONG: __ xvrotri_d($dst$$FloatRegister, $src$$FloatRegister, (-$shift$$constant) & 0x3f); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_INT : __ vrotri_w($dst$$FloatRegister, $src$$FloatRegister, (-$shift$$constant) & 0x1f); break;
+        case T_LONG: __ vrotri_d($dst$$FloatRegister, $src$$FloatRegister, (-$shift$$constant) & 0x3f); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- AND --------------------------------------
 
-instruct andV16(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
+instruct andV(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AndV src1 src2));
-  format %{ "vand.v    $dst, $src1, $src2\t# @andV16" %}
+  format %{ "(x)vand.v    $dst, $src1, $src2\t# @andV" %}
   ins_encode %{
-    __ vand_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4:
+      case  8:
+      case 16: __  vand_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      case 32: __ xvand_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct and16B_imm(vecX dst, vecX src, immIU8 imm) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct andVB_imm(vReg dst, vReg src, immIU8 imm) %{
   match(Set dst (AndV src (ReplicateB imm)));
-  format %{ "vandi.b    $dst, $src, $imm\t# @and16B_imm" %}
+  format %{ "(x)vandi.b    $dst, $src, $imm\t# @andVB_imm" %}
   ins_encode %{
-    __ vandi_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct andV32(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (AndV src1 src2));
-  format %{ "xvand.v    $dst, $src1, $src2\t# @andV32" %}
-  ins_encode %{
-    __ xvand_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct and32B_imm(vecY dst, vecY src, immIU8 imm) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (AndV src (ReplicateB imm)));
-  format %{ "xvandi.b    $dst, $src, $imm\t# @and32B_imm" %}
-  ins_encode %{
-    __ xvandi_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
+    switch (Matcher::vector_length(this)) {
+      case  4:
+      case  8:
+      case 16: __  vandi_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      case 32: __ xvandi_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- OR ---------------------------------------
 
-instruct orV16(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
+instruct orV(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (OrV src1 src2));
-  format %{ "vor.v    $dst, $src1, $src2\t# @orV16" %}
+  format %{ "(x)vor.v    $dst, $src1, $src2\t# @orV" %}
   ins_encode %{
-    __ vor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4:
+      case  8:
+      case 16: __  vor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      case 32: __ xvor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct or16B_imm(vecX dst, vecX src, immIU8 imm) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct orVB_imm(vReg dst, vReg src, immIU8 imm) %{
   match(Set dst (OrV src (ReplicateB imm)));
-  format %{ "vori.b    $dst, $src, $imm\t# @or16B_imm" %}
+  format %{ "(x)vori.b    $dst, $src, $imm\t# @orVB_imm" %}
   ins_encode %{
-    __ vori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct orV32(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (OrV src1 src2));
-  format %{ "xvor.v    $dst, $src1, $src2\t# @orV32" %}
-  ins_encode %{
-    __ xvor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct or32B_imm(vecY dst, vecY src, immIU8 imm) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (OrV src (ReplicateB imm)));
-  format %{ "xvori.b    $dst, $src, $imm\t# @or32B_imm" %}
-  ins_encode %{
-    __ xvori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
+    switch (Matcher::vector_length(this)) {
+      case  4:
+      case  8:
+      case 16: __  vori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      case 32: __ xvori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- XOR --------------------------------------
 
-instruct xorV16(vecX dst, vecX src1, vecX src2) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
+instruct xorV(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (XorV src1 src2));
-  format %{ "vxor.v    $dst, $src1, $src2\t# @xorV16" %}
+  format %{ "(x)vxor.v    $dst, $src1, $src2\t# @xorV" %}
   ins_encode %{
-    __ vxor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4:
+      case  8:
+      case 16: __  vxor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      case 32: __ xvxor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct xor16B_imm(vecX dst, vecX src, immIU8 imm) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct xor16B_imm(vReg dst, vReg src, immIU8 imm) %{
   match(Set dst (XorV src (ReplicateB imm)));
-  format %{ "vxori.b    $dst, $src, $imm\t# @xor16B_imm" %}
+  format %{ "(x)vxori.b    $dst, $src, $imm\t# @xor16B_imm" %}
   ins_encode %{
-    __ vxori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct xorV32(vecY dst, vecY src1, vecY src2) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (XorV src1 src2));
-  format %{ "xvxor.v    $dst, $src1, $src2\t# @xorV32" %}
-  ins_encode %{
-    __ xvxor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct xor32B_imm(vecX dst, vecX src, immIU8 imm) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (XorV src (ReplicateB imm)));
-  format %{ "xvxori.b    $dst, $src, $imm\t# @xor32B_imm" %}
-  ins_encode %{
-    __ xvxori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
+    switch (Matcher::vector_length(this)) {
+      case  4:
+      case  8:
+      case 16: __  vxori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      case 32: __ xvxori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- NOR --------------------------------------
 
-instruct norV16(vecX dst, vecX src1, vecX src2, immI_M1 m1) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
+instruct norV(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
   match(Set dst (XorV (OrV src1 src2) (ReplicateB m1)));
   match(Set dst (XorV (OrV src1 src2) (ReplicateS m1)));
   match(Set dst (XorV (OrV src1 src2) (ReplicateI m1)));
-  format %{ "vnor.v    $dst, $src1, $src2\t# @norV16" %}
+  format %{ "(x)vnor.v    $dst, $src1, $src2\t# @norV" %}
   ins_encode %{
-    __ vnor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4:
+      case  8:
+      case 16: __  vnor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      case 32: __ xvnor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct nor16B_imm(vecX dst, vecX src, immIU8 imm, immI_M1 m1) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct norVB_imm(vReg dst, vReg src, immIU8 imm, immI_M1 m1) %{
   match(Set dst (XorV (OrV src (ReplicateB imm)) (ReplicateB m1)));
-  format %{ "vnori.b    $dst, $src, $imm\t# @nor16B_imm" %}
+  format %{ "(x)vnori.b    $dst, $src, $imm\t# @norVB_imm" %}
   ins_encode %{
-    __ vnori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct norV32(vecY dst, vecY src1, vecY src2, immI_M1 m1) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (XorV (OrV src1 src2) (ReplicateB m1)));
-  match(Set dst (XorV (OrV src1 src2) (ReplicateS m1)));
-  match(Set dst (XorV (OrV src1 src2) (ReplicateI m1)));
-  format %{ "xvnor.v    $dst, $src1, $src2\t# @norV32" %}
-  ins_encode %{
-    __ xvnor_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct nor32B_imm(vecY dst, vecY src, immIU8 imm, immI_M1 m1) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (XorV (OrV src (ReplicateB imm)) (ReplicateB m1)));
-  format %{ "xvnori.b    $dst, $src, $imm\t# @nor32B_imm" %}
-  ins_encode %{
-    __ xvnori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant);
+    switch (Matcher::vector_length(this)) {
+      case  4:
+      case  8:
+      case 16: __  vnori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      case 32: __ xvnori_b($dst$$FloatRegister, $src$$FloatRegister, $imm$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- ANDN -------------------------------------
 
-instruct andnV16(vecX dst, vecX src1, vecX src2, immI_M1 m1) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
+instruct andnV(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
   match(Set dst (AndV src2 (XorV src1 (ReplicateB m1))));
   match(Set dst (AndV src2 (XorV src1 (ReplicateS m1))));
   match(Set dst (AndV src2 (XorV src1 (ReplicateI m1))));
-  format %{ "vandn.v    $dst, $src1, $src2\t# @andnV16" %}
+  format %{ "(x)vandn.v    $dst, $src1, $src2\t# @andnV" %}
   ins_encode %{
-    __ vandn_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct andnV32(vecY dst, vecY src1, vecY src2, immI_M1 m1) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (AndV src2 (XorV src1 (ReplicateB m1))));
-  match(Set dst (AndV src2 (XorV src1 (ReplicateS m1))));
-  match(Set dst (AndV src2 (XorV src1 (ReplicateI m1))));
-  format %{ "xvandn.v    $dst, $src1, $src2\t# @andnV32" %}
-  ins_encode %{
-    __ xvandn_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4:
+      case  8:
+      case 16: __  vandn_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      case 32: __ xvandn_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------------- ORN --------------------------------------
 
-instruct ornV16(vecX dst, vecX src1, vecX src2, immI_M1 m1) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
+instruct ornV(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
   match(Set dst (OrV src1 (XorV src2 (ReplicateB m1))));
   match(Set dst (OrV src1 (XorV src2 (ReplicateS m1))));
   match(Set dst (OrV src1 (XorV src2 (ReplicateI m1))));
-  format %{ "vorn.v    $dst, $src1, $src2\t# @ornV16" %}
+  format %{ "(x)vorn.v    $dst, $src1, $src2\t# @ornV" %}
   ins_encode %{
-    __ vorn_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct ornV32(vecY dst, vecY src1, vecY src2, immI_M1 m1) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (OrV src1 (XorV src2 (ReplicateB m1))));
-  match(Set dst (OrV src1 (XorV src2 (ReplicateS m1))));
-  match(Set dst (OrV src1 (XorV src2 (ReplicateI m1))));
-  format %{ "xvorn.v    $dst, $src1, $src2\t# @ornV32" %}
-  ins_encode %{
-    __ xvorn_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4:
+      case  8:
+      case 16: __  vorn_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      case 32: __ xvorn_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ----------------------------- Reduction Add --------------------------------
 
-instruct reduce_add16B(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
+instruct reduceV(mRegI dst, mRegI src, vReg vsrc, vReg tmp1, vReg tmp2) %{
   match(Set dst (AddReductionVI src vsrc));
+  match(Set dst (MulReductionVI src vsrc));
+  match(Set dst (MaxReductionV  src vsrc));
+  match(Set dst (MinReductionV  src vsrc));
+  match(Set dst (AndReductionV  src vsrc));
+  match(Set dst (OrReductionV   src vsrc));
+  match(Set dst (XorReductionV  src vsrc));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_add16B" %}
+  format %{ "(x)vreduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduceV" %}
   ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 16);
+    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister,
+              Matcher::vector_element_basic_type(this, $vsrc), this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $vsrc));
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct reduce_add8S(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (AddReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_add8S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add4I(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (AddReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_add4I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add2L(mRegL dst, mRegL src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 2 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
+instruct reduceVL(mRegL dst, mRegL src, vReg vsrc, vReg tmp1, vReg tmp2) %{
   match(Set dst (AddReductionVL src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_add2L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp$$FloatRegister, FNOREG, T_LONG, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add4F(regF dst, regF src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
-  match(Set dst (AddReductionVF src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_add4F" %}
-  ins_encode %{
-    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister, T_FLOAT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add2D(regD dst, regD src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 2 && Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
-  match(Set dst (AddReductionVD src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_add2D" %}
-  ins_encode %{
-    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister, T_DOUBLE, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add32B(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 32 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (AddReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_add32B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add16S(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (AddReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_add16S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add8I(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (AddReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_add8I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add4L(mRegL dst, mRegL src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (AddReductionVL src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_add4L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_LONG, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add8F(regF dst, regF src, vecY vsrc, vecY tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
-  match(Set dst (AddReductionVF src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_add8F" %}
-  ins_encode %{
-    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister, T_FLOAT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_add4D(regD dst, regD src, vecY vsrc, vecY tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
-  match(Set dst (AddReductionVD src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_add4D" %}
-  ins_encode %{
-    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister, T_DOUBLE, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// ----------------------------- Reduction Mul --------------------------------
-
-instruct reduce_mul16B(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (MulReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_mul16B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_mul8S(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (MulReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_mul8S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_mul4I(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (MulReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_mul4I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_mul2L(mRegL dst, mRegL src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 2 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MulReductionVL src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_mul2L" %}
+  match(Set dst (MaxReductionV  src vsrc));
+  match(Set dst (MinReductionV  src vsrc));
+  match(Set dst (AndReductionV  src vsrc));
+  match(Set dst (OrReductionV   src vsrc));
+  match(Set dst (XorReductionV  src vsrc));
+  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  format %{ "(x)vreduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduceVL" %}
   ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp$$FloatRegister, FNOREG, T_LONG, this->ideal_Opcode(), 16);
+    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister,
+              T_LONG, this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $vsrc));
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct reduce_mul4F(regF dst, regF src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
+instruct reduceVF(regF dst, regF src, vReg vsrc, vReg tmp) %{
+  match(Set dst (AddReductionVF src vsrc));
   match(Set dst (MulReductionVF src vsrc));
   effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_mul4F" %}
+  format %{ "(x)vreduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduceVF" %}
   ins_encode %{
-    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister, T_FLOAT, this->ideal_Opcode(), 16);
+    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister,
+              T_FLOAT, this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $vsrc));
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct reduce_mul2D(regD dst, regD src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 2 && Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
+instruct reduceVD(regD dst, regD src, vReg vsrc, vReg tmp) %{
+  match(Set dst (AddReductionVD src vsrc));
   match(Set dst (MulReductionVD src vsrc));
   effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_mul2D" %}
+  format %{ "(x)vreduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduceVD" %}
   ins_encode %{
-    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister, T_DOUBLE, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_mul32B(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 32 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (MulReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_mul32B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_mul16S(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (MulReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_mul16S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_mul8I(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (MulReductionVI src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_mul8I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_mul4L(mRegL dst, mRegL src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (MulReductionVL src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_mul4L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_LONG, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_mul8F(regF dst, regF src, vecY vsrc, vecY tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
-  match(Set dst (MulReductionVF src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_mul8F" %}
-  ins_encode %{
-    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister, T_FLOAT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_mul4D(regD dst, regD src, vecY vsrc, vecY tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
-  match(Set dst (MulReductionVD src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_mul4D" %}
-  ins_encode %{
-    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister, T_DOUBLE, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// ----------------------------- Reduction Max --------------------------------
-
-instruct reduce_max16B(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (MaxReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_max16B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_max8S(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (MaxReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_max8S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_max4I(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (MaxReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_max4I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_max2L(mRegL dst, mRegL src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 2 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (MaxReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_max2L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp$$FloatRegister, FNOREG, T_LONG, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_max32B(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 32 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (MaxReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_max32B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_max16S(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (MaxReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_max16S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_max8I(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (MaxReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_max8I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_max4L(mRegL dst, mRegL src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (MaxReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_max4L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_LONG, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// ----------------------------- Reduction Min --------------------------------
-
-instruct reduce_min16B(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (MinReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_min16B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_min8S(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (MinReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_min8S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_min4I(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (MinReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_min4I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_min2L(mRegL dst, mRegL src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 2 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (MinReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_min2L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp$$FloatRegister, FNOREG, T_LONG, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_min32B(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 32 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (MinReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_min32B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_min16S(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (MinReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_min16S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_min8I(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (MinReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_min8I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_min4L(mRegL dst, mRegL src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (MinReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_min4L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_LONG, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// ----------------------------- Reduction And --------------------------------
-
-instruct reduce_and16B(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (AndReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_and16B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_and8S(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (AndReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_and8S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_and4I(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (AndReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_and4I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_and2L(mRegL dst, mRegL src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 2 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (AndReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_and2L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp$$FloatRegister, FNOREG, T_LONG, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_and32B(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 32 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (AndReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_and32B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_and16S(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (AndReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_and16S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_and8I(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (AndReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_and8I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_and4L(mRegL dst, mRegL src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (AndReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_and4L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_LONG, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// ----------------------------- Reduction Or ---------------------------------
-
-instruct reduce_or16B(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (OrReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_or16B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_or8S(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (OrReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_or8S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_or4I(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (OrReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_or4I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_or2L(mRegL dst, mRegL src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 2 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (OrReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_or2L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp$$FloatRegister, FNOREG, T_LONG, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_or32B(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 32 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (OrReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_or32B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_or16S(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (OrReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_or16S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_or8I(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (OrReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_or8I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_or4L(mRegL dst, mRegL src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (OrReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_or4L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_LONG, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// ----------------------------- Reduction Xor --------------------------------
-
-instruct reduce_xor16B(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (XorReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_xor16B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_xor8S(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (XorReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_xor8S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_xor4I(mRegI dst, mRegI src, vecX vsrc, vecX tmp1, vecX tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (XorReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_xor4I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_xor2L(mRegL dst, mRegL src, vecX vsrc, vecX tmp) %{
-  predicate(Matcher::vector_length(n->in(2)) == 2 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (XorReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp) @reduce_xor2L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp$$FloatRegister, FNOREG, T_LONG, this->ideal_Opcode(), 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_xor32B(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 32 && Matcher::vector_element_basic_type(n->in(2)) == T_BYTE);
-  match(Set dst (XorReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_xor32B" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_BYTE, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_xor16S(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 16 && Matcher::vector_element_basic_type(n->in(2)) == T_SHORT);
-  match(Set dst (XorReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_xor16S" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_SHORT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_xor8I(mRegI dst, mRegI src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 8 && Matcher::vector_element_basic_type(n->in(2)) == T_INT);
-  match(Set dst (XorReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_xor8I" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_INT, this->ideal_Opcode(), 32);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduce_xor4L(mRegL dst, mRegL src, vecY vsrc, vecY tmp1, vecY tmp2) %{
-  predicate(Matcher::vector_length(n->in(2)) == 4 && Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
-  match(Set dst (XorReductionV src vsrc));
-  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  format %{ "reduce    $dst, $src, $vsrc\t# TEMP($tmp1, $tmp2) @reduce_xor4L" %}
-  ins_encode %{
-    __ reduce($dst$$Register, $src$$Register, $vsrc$$FloatRegister, $tmp1$$FloatRegister, $tmp2$$FloatRegister, T_LONG, this->ideal_Opcode(), 32);
+    __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister,
+              T_DOUBLE, this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $vsrc));
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ------------------------------ RoundDoubleModeV ----------------------------
 
-instruct round2D(vecX dst, vecX src, immI rmode) %{
-  predicate(Matcher::vector_length(n) == 2);
+instruct roundVD(vReg dst, vReg src, immI rmode) %{
   match(Set dst (RoundDoubleModeV src rmode));
-  format %{ "vfrint    $dst, $src, $rmode\t# @round2D" %}
+  format %{ "(x)vfrint    $dst, $src, $rmode\t# @roundVD" %}
   ins_encode %{
-    switch ($rmode$$constant) {
-      case RoundDoubleModeNode::rmode_rint:  __ vfrintrne_d($dst$$FloatRegister, $src$$FloatRegister); break;
-      case RoundDoubleModeNode::rmode_floor: __ vfrintrm_d($dst$$FloatRegister, $src$$FloatRegister);  break;
-      case RoundDoubleModeNode::rmode_ceil:  __ vfrintrp_d($dst$$FloatRegister, $src$$FloatRegister);  break;
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct round4D(vecY dst, vecY src, immI rmode) %{
-  predicate(Matcher::vector_length(n) == 4);
-  match(Set dst (RoundDoubleModeV src rmode));
-  format %{ "xvfrint    $dst, $src, $rmode\t# @round4D" %}
-  ins_encode %{
-    switch ($rmode$$constant) {
-      case RoundDoubleModeNode::rmode_rint:  __ xvfrintrne_d($dst$$FloatRegister, $src$$FloatRegister); break;
-      case RoundDoubleModeNode::rmode_floor: __ xvfrintrm_d($dst$$FloatRegister, $src$$FloatRegister);  break;
-      case RoundDoubleModeNode::rmode_ceil:  __ xvfrintrp_d($dst$$FloatRegister, $src$$FloatRegister);  break;
+    if (Matcher::vector_length(this) == 4) {
+      switch ($rmode$$constant) {
+        case RoundDoubleModeNode::rmode_rint:  __ xvfrintrne_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        case RoundDoubleModeNode::rmode_floor: __ xvfrintrm_d($dst$$FloatRegister, $src$$FloatRegister);  break;
+        case RoundDoubleModeNode::rmode_ceil:  __ xvfrintrp_d($dst$$FloatRegister, $src$$FloatRegister);  break;
+      }
+    } else if (Matcher::vector_length(this) == 2) {
+      switch ($rmode$$constant) {
+        case RoundDoubleModeNode::rmode_rint:  __ vfrintrne_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        case RoundDoubleModeNode::rmode_floor: __ vfrintrm_d($dst$$FloatRegister, $src$$FloatRegister);  break;
+        case RoundDoubleModeNode::rmode_ceil:  __ vfrintrp_d($dst$$FloatRegister, $src$$FloatRegister);  break;
+      }
+    } else {
+      ShouldNotReachHere();
     }
   %}
   ins_pipe( pipe_slow );
@@ -16253,258 +14384,216 @@ instruct round4D(vecY dst, vecY src, immI rmode) %{
 
 // ---------------------------- Vector Cast B2X -------------------------------
 
-instruct cvt16Bto16S(vecY dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_SHORT);
+instruct cvtVB(vReg dst, vReg src) %{
   match(Set dst (VectorCastB2X src));
-  format %{ "vext2xv.h.b    $dst, $src\t# @cvt16Bto16S" %}
+  format %{ "(x)vconvert    $dst, $src\t# @cvtVB" %}
   ins_encode %{
-    __ vext2xv_h_b($dst$$FloatRegister, $src$$FloatRegister);
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_SHORT : __ vext2xv_h_b($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_INT   : __ vext2xv_w_b($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_LONG  : __ vext2xv_d_b($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_FLOAT : __ vext2xv_w_b($dst$$FloatRegister, $src$$FloatRegister);
+                     Matcher::vector_length_in_bytes(this) > 16 ?
+                     __ xvffint_s_w($dst$$FloatRegister, $dst$$FloatRegister) :
+                     __  vffint_s_w($dst$$FloatRegister, $dst$$FloatRegister); break;
+      case T_DOUBLE: __ vext2xv_d_b($dst$$FloatRegister, $src$$FloatRegister);
+                     assert(Matcher::vector_length_in_bytes(this) > 16, "only support 4Bto4D");
+                     __ xvffint_d_l($dst$$FloatRegister, $dst$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------- Vector Cast S2X --------------------------------
 
-instruct cvt16Sto16B(vecX dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_BYTE);
+instruct cvtVS(vReg dst, vReg src) %{
   match(Set dst (VectorCastS2X src));
-  effect(TEMP_DEF dst);
-  format %{ "vconvert    $dst, $src\t# @cvt16Sto16B" %}
+  format %{ "(x)vconvert    $dst, $src\t# @cvtVS" %}
   ins_encode %{
-    __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0x01);
-    __ vsrlni_b_h($dst$$FloatRegister, $src$$FloatRegister, 0);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt8Sto8I(vecY dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_INT);
-  match(Set dst (VectorCastS2X src));
-  format %{ "vext2xv.w.h    $dst, $src\t# @cvt8Sto8I" %}
-  ins_encode %{
-    __ vext2xv_w_h($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt8Sto8F(vecY dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_FLOAT);
-  match(Set dst (VectorCastS2X src));
-  format %{ "vconvert    $dst, $src\t# @cvt8Sto8F" %}
-  ins_encode %{
-    __ vext2xv_w_h($dst$$FloatRegister, $src$$FloatRegister);
-    __ xvffint_s_w($dst$$FloatRegister, $dst$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this, $src) > 16 && Matcher::vector_element_basic_type(this) == T_BYTE) {
+      __ xvpermi_q(fscratch, $src$$FloatRegister, 0x00);
+      __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0x11);
+    }
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_BYTE  : Matcher::vector_length_in_bytes(this, $src) > 16 ?
+                     __ vsrlni_b_h($dst$$FloatRegister, fscratch, 0) :
+                     __ vsrlni_b_h($dst$$FloatRegister, $src$$FloatRegister, 0); break;
+      case T_INT   : __ vext2xv_w_h($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_LONG  : __ vext2xv_d_h($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_FLOAT : __ vext2xv_w_h($dst$$FloatRegister, $src$$FloatRegister);
+                     Matcher::vector_length_in_bytes(this) > 16 ?
+                     __ xvffint_s_w($dst$$FloatRegister, $dst$$FloatRegister) :
+                     __  vffint_s_w($dst$$FloatRegister, $dst$$FloatRegister); break;
+      case T_DOUBLE: __ vext2xv_d_h($dst$$FloatRegister, $src$$FloatRegister);
+                     Matcher::vector_length_in_bytes(this) > 16 ?
+                     __ xvffint_d_l($dst$$FloatRegister, $dst$$FloatRegister) :
+                     __  vffint_d_l($dst$$FloatRegister, $dst$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // --------------------------- Vector Cast I2X --------------------------------
 
-instruct cvt8Ito8S(vecX dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_SHORT);
+instruct cvtVI(vReg dst, vReg src) %{
   match(Set dst (VectorCastI2X src));
-  effect(TEMP_DEF dst);
-  format %{ "vconvert    $dst, $src\t# @cvt8Ito8S" %}
+  format %{ "(x)vconvert    $dst, $src\t# @cvtVI" %}
   ins_encode %{
-    __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0x01);
-    __ vsrlni_h_w($dst$$FloatRegister, $src$$FloatRegister, 0);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Ito4F(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
-  match(Set dst (VectorCastI2X src));
-  format %{ "vffint.s.w    $dst, $src\t# @cvt4Ito4F" %}
-  ins_encode %{
-    __ vffint_s_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Ito4L(vecY dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_LONG);
-  match(Set dst (VectorCastI2X src));
-  format %{ "vext2xv.d.w    $dst, $src\t# @cvt4Ito4L" %}
-  ins_encode %{
-    __ vext2xv_d_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt8Ito8F(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_FLOAT);
-  match(Set dst (VectorCastI2X src));
-  format %{ "xvffint.s.w    $dst, $src\t# @cvt8Ito8F" %}
-  ins_encode %{
-    __ xvffint_s_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Ito4D(vecY dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (VectorCastI2X src));
-  format %{ "vconvert    $dst, $src\t# @cvt4Ito4D" %}
-  ins_encode %{
-    __ vext2xv_d_w($dst$$FloatRegister, $src$$FloatRegister);
-    __ xvffint_d_l($dst$$FloatRegister, $dst$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this, $src) > 16 && type2aelembytes(Matcher::vector_element_basic_type(this)) < 4) {
+      __ xvpermi_q(fscratch, $src$$FloatRegister, 0x00);
+      __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0x11);
+    }
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_BYTE  : if (Matcher::vector_length_in_bytes(this, $src) > 16) {
+                       __ vsrlni_h_w($dst$$FloatRegister, fscratch, 0);
+                       __ vsrlni_b_h($dst$$FloatRegister, $dst$$FloatRegister, 0);
+                     } else {
+                       __ vsrlni_h_w($dst$$FloatRegister, $src$$FloatRegister, 0);
+                       __ vsrlni_b_h($dst$$FloatRegister, $dst$$FloatRegister, 0);
+                     }
+                     break;
+      case T_SHORT : Matcher::vector_length_in_bytes(this, $src) > 16 ?
+                     __ vsrlni_h_w($dst$$FloatRegister, fscratch, 0) :
+                     __ vsrlni_h_w($dst$$FloatRegister, $src$$FloatRegister, 0); break;
+      case T_LONG  : __ vext2xv_d_w($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_FLOAT : Matcher::vector_length_in_bytes(this) > 16 ?
+                     __ xvffint_s_w($dst$$FloatRegister, $src$$FloatRegister) :
+                     __  vffint_s_w($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_DOUBLE: __ vext2xv_d_w($dst$$FloatRegister, $src$$FloatRegister);
+                     Matcher::vector_length_in_bytes(this) > 16 ?
+                     __ xvffint_d_l($dst$$FloatRegister, $dst$$FloatRegister) :
+                     __  vffint_d_l($dst$$FloatRegister, $dst$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ----------------------------- Vector Cast L2X ------------------------------
 
-instruct cvt4Lto4I(vecX dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_INT);
+instruct cvtVL(vReg dst, vReg src) %{
   match(Set dst (VectorCastL2X src));
-  effect(TEMP_DEF dst);
-  format %{ "vconvert    $dst, $src\t# @cvt4Lto4I" %}
+  format %{ "(x)vconvert    $dst, $src\t# @cvtVL" %}
   ins_encode %{
-    __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0x01);
-    __ vsrlni_w_d($dst$$FloatRegister, $src$$FloatRegister, 0);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Lto4F(vecX dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
-  match(Set dst (VectorCastL2X src));
-  format %{ "vconvert    $dst, $src\t# @cvt4Lto4F" %}
-  ins_encode %{
-    __ xvpermi_q(fscratch, $src$$FloatRegister, 0x01);
-    __ xvffint_s_l($dst$$FloatRegister, fscratch, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt2Lto2D(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (VectorCastL2X src));
-  format %{ "vffint.d.l    $dst, $src\t# @cvt2Lto2D" %}
-  ins_encode %{
-    __ vffint_d_l($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Lto4D(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (VectorCastL2X src));
-  format %{ "xvffint.d.l    $dst, $src\t# @cvt4Lto4D" %}
-  ins_encode %{
-    __ xvffint_d_l($dst$$FloatRegister, $src$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this, $src) > 16 && type2aelembytes(Matcher::vector_element_basic_type(this)) < 8) {
+      __ xvpermi_q(fscratch, $src$$FloatRegister, 0x00);
+      __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0x11);
+    }
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_BYTE  : assert(Matcher::vector_length_in_bytes(this, $src) > 16, "only support 4Lto4B");
+                     __ vsrlni_w_d($dst$$FloatRegister, fscratch, 0);
+                     __ vsrlni_h_w($dst$$FloatRegister, $dst$$FloatRegister, 0);
+                     __ vsrlni_b_h($dst$$FloatRegister, $dst$$FloatRegister, 0); break;
+      case T_SHORT : if (Matcher::vector_length_in_bytes(this, $src) > 16) {
+                       __ vsrlni_w_d($dst$$FloatRegister, fscratch, 0);
+                       __ vsrlni_h_w($dst$$FloatRegister, $dst$$FloatRegister, 0);
+                     } else {
+                       __ vsrlni_w_d($dst$$FloatRegister, $src$$FloatRegister, 0);
+                       __ vsrlni_h_w($dst$$FloatRegister, $dst$$FloatRegister, 0);
+                     }
+                     break;
+      case T_INT   : Matcher::vector_length_in_bytes(this, $src) > 16 ?
+                     __ vsrlni_w_d($dst$$FloatRegister, fscratch, 0) :
+                     __ vsrlni_w_d($dst$$FloatRegister, $src$$FloatRegister, 0); break;
+      case T_FLOAT : Matcher::vector_length_in_bytes(this, $src) > 16 ?
+                     __ vffint_s_l($dst$$FloatRegister, $dst$$FloatRegister, fscratch) :
+                     __ vffint_s_l($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister); break;
+      case T_DOUBLE: Matcher::vector_length_in_bytes(this) > 16 ?
+                     __ xvffint_d_l($dst$$FloatRegister, $src$$FloatRegister) :
+                     __  vffint_d_l($dst$$FloatRegister, $src$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ----------------------------- Vector Cast F2X ------------------------------
 
-instruct cvt8Fto8S(vecX dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_SHORT);
+instruct cvtVF(vReg dst, vReg src) %{
   match(Set dst (VectorCastF2X src));
-  effect(TEMP_DEF dst);
-  format %{ "vconvert    $dst, $src\t# @cvt8Fto8S" %}
+  format %{ "(x)vconvert    $dst, $src\t# @cvtVF" %}
   ins_encode %{
-    __ xvftintrz_w_s(fscratch, $src$$FloatRegister);
-    __ xvpermi_q($dst$$FloatRegister, fscratch, 0x01);
-    __ vsrlni_h_w($dst$$FloatRegister, fscratch, 0);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Fto4I(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_INT);
-  match(Set dst (VectorCastF2X src));
-  format %{ "vftintrz.w.s    $dst, $src\t# @cvt2Fto2I" %}
-  ins_encode %{
-    __ vftintrz_w_s($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt8Fto8I(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_INT);
-  match(Set dst (VectorCastF2X src));
-  format %{ "xvftintrz.w.s    $dst, $src\t# @cvt4Fto4I" %}
-  ins_encode %{
-    __ xvftintrz_w_s($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Fto4L(vecY dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_LONG);
-  match(Set dst (VectorCastF2X src));
-  format %{ "vconvert    $dst, $src\t# @cvt4Fto4L" %}
-  ins_encode %{
-    __ xvpermi_d($dst$$FloatRegister, $src$$FloatRegister, 0b01010000);
-    __ xvftintrzl_l_s($dst$$FloatRegister, $dst$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Fto4D(vecY dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (VectorCastF2X src));
-  format %{ "vconvert    $dst, $src\t# @cvt4Fto4D" %}
-  ins_encode %{
-    __ xvpermi_d($dst$$FloatRegister, $src$$FloatRegister, 0b01010000);
-    __ xvfcvtl_d_s($dst$$FloatRegister, $dst$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this, $src) > 16 && type2aelembytes(Matcher::vector_element_basic_type(this)) < 4) {
+      __ xvftintrz_w_s(fscratch, $src$$FloatRegister);
+      __ xvpermi_q($dst$$FloatRegister, fscratch, 0x11);
+    } else if (Matcher::vector_length_in_bytes(this) > 16 && type2aelembytes(Matcher::vector_element_basic_type(this)) > 4) {
+      __ xvpermi_d($dst$$FloatRegister, $src$$FloatRegister, 0b01010000);
+    } else if (Matcher::vector_length_in_bytes(this, $src) <= 16 && type2aelembytes(Matcher::vector_element_basic_type(this)) < 4) {
+      __ vftintrz_w_s($dst$$FloatRegister, $src$$FloatRegister);
+    }
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_BYTE  : if (Matcher::vector_length_in_bytes(this, $src) > 16) {
+                       __ vsrlni_h_w($dst$$FloatRegister, fscratch, 0);
+                       __ vsrlni_b_h($dst$$FloatRegister, $dst$$FloatRegister, 0);
+                     } else {
+                       __ vsrlni_h_w($dst$$FloatRegister, $dst$$FloatRegister, 0);
+                       __ vsrlni_b_h($dst$$FloatRegister, $dst$$FloatRegister, 0);
+                     }
+                     break;
+      case T_SHORT : Matcher::vector_length_in_bytes(this, $src) > 16 ?
+                     __ vsrlni_h_w($dst$$FloatRegister, fscratch, 0) :
+                     __ vsrlni_h_w($dst$$FloatRegister, $dst$$FloatRegister, 0); break;
+      case T_INT   : Matcher::vector_length_in_bytes(this, $src) > 16 ?
+                     __ xvftintrz_w_s($dst$$FloatRegister, $src$$FloatRegister) :
+                     __  vftintrz_w_s($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_LONG  : Matcher::vector_length_in_bytes(this) > 16 ?
+                     __ xvftintrzl_l_s($dst$$FloatRegister, $dst$$FloatRegister) :
+                     __  vftintrzl_l_s($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_DOUBLE: Matcher::vector_length_in_bytes(this) > 16 ?
+                     __ xvfcvtl_d_s($dst$$FloatRegister, $dst$$FloatRegister) :
+                     __  vfcvtl_d_s($dst$$FloatRegister, $src$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ---------------------------- Vector Cast D2X -------------------------------
 
-instruct cvt4Dto4I(vecX dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_INT);
+instruct cvtVD(vReg dst, vReg src) %{
   match(Set dst (VectorCastD2X src));
-  format %{ "vconvert    $dst, $src\t# @cvt4Dto4I" %}
+  format %{ "(x)vconvert    $dst, $src\t# @cvtVD" %}
   ins_encode %{
-    __ xvftintrz_w_d($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister);
-    __ xvpermi_d($dst$$FloatRegister, $dst$$FloatRegister, 0b11011000);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Dto4F(vecX dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
-  match(Set dst (VectorCastD2X src));
-  format %{ "vconvert    $dst, $src\t# @cvt4Dto4F" %}
-  ins_encode %{
-    __ xvfcvt_s_d($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister);
-    __ xvpermi_d($dst$$FloatRegister, $dst$$FloatRegister, 0b11011000);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt2Dto2L(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_LONG);
-  match(Set dst (VectorCastD2X src));
-  format %{ "vftintrz.l.d    $dst, $src\t# @cvt2Dto2L" %}
-  ins_encode %{
-    __ vftintrz_l_d($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cvt4Dto4L(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_LONG);
-  match(Set dst (VectorCastD2X src));
-  format %{ "xvftintrz.l.d    $dst, $src\t# @cvt4Dto4L" %}
-  ins_encode %{
-    __ xvftintrz_l_d($dst$$FloatRegister, $src$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this, $src) > 16 && type2aelembytes(Matcher::vector_element_basic_type(this)) < 8) {
+      __ xvpermi_q(fscratch, $src$$FloatRegister, 0x11);
+      if (Matcher::vector_element_basic_type(this) != T_FLOAT)
+        __ vftintrz_w_d($dst$$FloatRegister, fscratch, $src$$FloatRegister);
+    } else if (Matcher::vector_length_in_bytes(this, $src) <= 16 && type2aelembytes(Matcher::vector_element_basic_type(this)) < 8) {
+      if (Matcher::vector_element_basic_type(this) != T_FLOAT)
+        __ vftintrz_w_d($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister);
+    }
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_BYTE : assert(Matcher::vector_length_in_bytes(this, $src) > 16, "only support 4Dto4B");
+                    __ vsrlni_h_w($dst$$FloatRegister, $dst$$FloatRegister, 0);
+                    __ vsrlni_b_h($dst$$FloatRegister, $dst$$FloatRegister, 0); break;
+      case T_SHORT: __ vsrlni_h_w($dst$$FloatRegister, $dst$$FloatRegister, 0); break;
+      case T_INT  : break;
+      case T_LONG : Matcher::vector_length_in_bytes(this) > 16 ?
+                    __ xvftintrz_l_d($dst$$FloatRegister, $src$$FloatRegister) :
+                    __  vftintrz_l_d($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_FLOAT: Matcher::vector_length_in_bytes(this, $src) > 16 ?
+                    __ vfcvt_s_d($dst$$FloatRegister, fscratch, $src$$FloatRegister) :
+                    __ vfcvt_s_d($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ---------------------------- Vector Cast HF2F -------------------------------
 
-instruct cvt8HFto8F(vecY dst, vecX src) %{
+instruct cvt8HFto8F(vReg dst, vReg src) %{
   predicate(Matcher::vector_length(n) == 8);
   match(Set dst (VectorCastHF2F src));
-  format %{ "vconvert    $dst, $src\t# @cvt8HFto8F" %}
+  format %{ "(x)vconvert    $dst, $src\t# @cvt8HFto8F" %}
   ins_encode %{
     __ xvpermi_d($dst$$FloatRegister, $src$$FloatRegister, 0b01010000);
     __ xvfcvtl_s_h($dst$$FloatRegister, $dst$$FloatRegister);
@@ -16514,10 +14603,10 @@ instruct cvt8HFto8F(vecY dst, vecX src) %{
 
 // ---------------------------- Vector Cast F2HF -------------------------------
 
-instruct cvt8Fto8HF(vecX dst, vecY src) %{
+instruct cvt8Fto8HF(vReg dst, vReg src) %{
   predicate(Matcher::vector_length(n) == 8);
   match(Set dst (VectorCastF2HF src));
-  format %{ "vconvert    $dst, $src\t# @cvt8Fto8HF" %}
+  format %{ "(x)vconvert    $dst, $src\t# @cvt8Fto8HF" %}
   ins_encode %{
     __ xvfcvt_h_s($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister);
     __ xvpermi_d($dst$$FloatRegister, $dst$$FloatRegister, 0b11011000);
@@ -16527,129 +14616,114 @@ instruct cvt8Fto8HF(vecX dst, vecY src) %{
 
 // ------------------------------ VectorReinterpret ---------------------------
 
-instruct reinterpretX(vecX dst)
-%{
-  predicate(Matcher::vector_length_in_bytes(n) == 16 && Matcher::vector_length_in_bytes(n->in(1)) == 16);
-  match(Set dst (VectorReinterpret dst));
-  format %{ "vreinterpret    $dst\t# @reinterpretX" %}
-  ins_encode %{
-    // empty
-  %}
-  ins_pipe( empty );
-%}
-
-instruct reinterpretY(vecY dst)
-%{
-  predicate(Matcher::vector_length_in_bytes(n) == 32 && Matcher::vector_length_in_bytes(n->in(1)) == 32);
-  match(Set dst (VectorReinterpret dst));
-  format %{ "xvreinterpret    $dst\t# @reinterpretY" %}
-  ins_encode %{
-    // empty
-  %}
-  ins_pipe( empty );
-%}
-
-instruct reinterpretX2Y(vecY dst, vecX src)
-%{
-  predicate(Matcher::vector_length_in_bytes(n) == 32 && Matcher::vector_length_in_bytes(n->in(1)) == 16);
+instruct reinterpretV(vReg dst, vReg src) %{
   match(Set dst (VectorReinterpret src));
-  format %{ "vreinterpret    $dst, $src\t# @reinterpretX2Y" %}
+  format %{ "(x)vreinterpret    $dst, $src\t# @reinterpretV" %}
   ins_encode %{
-    // The higher 128-bits of the "dst" register must be cleared to zero.
-    if ($dst$$FloatRegister ==  $src$$FloatRegister) {
-      __ xvinsgr2vr_d($dst$$FloatRegister, R0, 2);
-      __ xvinsgr2vr_d($dst$$FloatRegister, R0, 3);
-    } else {
-      __ xvxor_v($dst$$FloatRegister, $dst$$FloatRegister, $dst$$FloatRegister);
-      __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0b00110000);
+    uint length_in_bytes_src = Matcher::vector_length_in_bytes(this, $src);
+    uint length_in_bytes_dst = Matcher::vector_length_in_bytes(this);
+    if ($dst$$FloatRegister != $src$$FloatRegister) {
+      if (length_in_bytes_dst > 16)
+        __ xvori_b($dst$$FloatRegister, $src$$FloatRegister, 0);
+      else
+        __ vori_b($dst$$FloatRegister, $src$$FloatRegister, 0);
+    }
+    if (length_in_bytes_dst > length_in_bytes_src) {
+      if (length_in_bytes_dst == 32) {
+        switch (length_in_bytes_src) {
+          case  4: __ xvinsgr2vr_w($dst$$FloatRegister, R0, 1);
+          case  8: __ xvinsgr2vr_d($dst$$FloatRegister, R0, 1);
+          case 16: __ xvinsgr2vr_d($dst$$FloatRegister, R0, 2);
+                   __ xvinsgr2vr_d($dst$$FloatRegister, R0, 3);
+                   break;
+          default:
+            ShouldNotReachHere();
+        }
+      } else if (length_in_bytes_dst == 16) {
+        switch (length_in_bytes_src) {
+          case 4: __ vinsgr2vr_w($dst$$FloatRegister, R0, 1);
+          case 8: __ vinsgr2vr_d($dst$$FloatRegister, R0, 1); break;
+          default:
+            ShouldNotReachHere();
+        }
+      } else if (length_in_bytes_dst == 8) {
+        assert(length_in_bytes_src == 4, "invalid vector length");
+        __ vinsgr2vr_w($dst$$FloatRegister, R0, 1);
+      } else {
+        ShouldNotReachHere();
+      }
     }
   %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reinterpretY2X(vecX dst, vecY src)
-%{
-  predicate(Matcher::vector_length_in_bytes(n) == 16 && Matcher::vector_length_in_bytes(n->in(1)) == 32);
-  match(Set dst (VectorReinterpret src));
-  format %{ "vreinterpret    $dst, $src\t# @reinterpretY2X" %}
-  ins_encode %{
-    if ($dst$$FloatRegister ==  $src$$FloatRegister) {
-      // empty
-    } else {
-      __ vori_b($dst$$FloatRegister, $src$$FloatRegister, 0);
-    }
-  %}
-  ins_pipe( pipe_slow );
+  ins_pipe( empty );
 %}
 
 // ------------------------------ VectorInsert --------------------------------
 
-instruct insert16B(vecX dst, mRegI val, immIU4 idx) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_BYTE);
+instruct insertV(vReg dst, mRegI val, immIU4 idx) %{
+  predicate(Matcher::vector_length_in_bytes(n) <= 16);
   match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "vinsgr2vr.b    $dst, $val, $idx\t# @insert16B" %}
+  format %{ "(x)vinsgr2vr    $dst, $val, $idx\t# @insertV" %}
   ins_encode %{
-    __ vinsgr2vr_b($dst$$FloatRegister, $val$$Register, $idx$$constant);
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_BYTE : __ vinsgr2vr_b($dst$$FloatRegister, $val$$Register, $idx$$constant); break;
+      case T_SHORT: __ vinsgr2vr_h($dst$$FloatRegister, $val$$Register, $idx$$constant); break;
+      case T_INT  : __ vinsgr2vr_w($dst$$FloatRegister, $val$$Register, $idx$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct insert8S(vecX dst, mRegI val, immIU3 idx) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_SHORT);
+instruct insertVL(vReg dst, mRegL val, immIU2 idx) %{
   match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "vinsgr2vr.h    $dst, $val, $idx\t# @insert8S" %}
+  format %{ "(x)vinsgr2vr.d    $dst, $val, $idx\t# @insertVL" %}
   ins_encode %{
-    __ vinsgr2vr_h($dst$$FloatRegister, $val$$Register, $idx$$constant);
+    switch (Matcher::vector_length(this)) {
+      case 2: __  vinsgr2vr_d($dst$$FloatRegister, $val$$Register, $idx$$constant); break;
+      case 4: __ xvinsgr2vr_d($dst$$FloatRegister, $val$$Register, $idx$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct insert4I(vecX dst, mRegI val, immIU2 idx) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_INT);
+instruct insertVF(vReg dst, regF val, immIU3 idx) %{
   match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "vinsgr2vr.w    $dst, $val, $idx\t# @insert4I" %}
+  format %{ "(x)vinsert    $dst, $val, $idx\t# @insertVF" %}
   ins_encode %{
-    __ vinsgr2vr_w($dst$$FloatRegister, $val$$Register, $idx$$constant);
+    switch (Matcher::vector_length(this)) {
+      case 2:
+      case 4: __ movfr2gr_s(AT, $val$$FloatRegister);
+              __ vinsgr2vr_w($dst$$FloatRegister, AT, $idx$$constant); break;
+      case 8: __ xvinsve0_w($dst$$FloatRegister, $val$$FloatRegister, $idx$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct insert2L(vecX dst, mRegL val, immIU1 idx) %{
-  predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_LONG);
+instruct insertVD(vReg dst, regD val, immIU2 idx) %{
   match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "vinsgr2vr.d    $dst, $val, $idx\t# @insert2L" %}
+  format %{ "(x)vinsert    $dst, $val, $idx\t# @insertVD" %}
   ins_encode %{
-    __ vinsgr2vr_d($dst$$FloatRegister, $val$$Register, $idx$$constant);
+    switch (Matcher::vector_length(this)) {
+      case 2: __ movfr2gr_d(AT, $val$$FloatRegister);
+              __ vinsgr2vr_d($dst$$FloatRegister, AT, $idx$$constant); break;
+      case 4: __ xvinsve0_d($dst$$FloatRegister, $val$$FloatRegister, $idx$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct insert4F(vecX dst, regF val, immIU2 idx) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_FLOAT);
-  match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "vinsert    $dst, $val, $idx\t# @insert4F" %}
-  ins_encode %{
-    __ vpickve2gr_w(AT, $val$$FloatRegister, 0);
-    __ vinsgr2vr_w($dst$$FloatRegister, AT, $idx$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct insert2D(vecX dst, regD val, immIU1 idx) %{
-  predicate(Matcher::vector_length(n) == 2 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "vinsert    $dst, $val, $idx\t# @insert2D" %}
-  ins_encode %{
-    __ vpickve2gr_d(AT, $val$$FloatRegister, 0);
-    __ vinsgr2vr_d($dst$$FloatRegister, AT, $idx$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct insert32B(vecY dst, mRegI val, immIU5 idx) %{
+instruct insert32B(vReg dst, mRegI val, immIU5 idx) %{
   predicate(Matcher::vector_length(n) == 32 && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "xvinsert    $dst, $val, $idx\t# @insert32B" %}
+  format %{ "(x)vinsert    $dst, $val, $idx\t# @insert32B" %}
   ins_encode %{
     int idx = $idx$$constant;
     int msbw, lsbw;
@@ -16668,10 +14742,10 @@ instruct insert32B(vecY dst, mRegI val, immIU5 idx) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct insert16S(vecY dst, mRegI val, immIU4 idx) %{
+instruct insert16S(vReg dst, mRegI val, immIU4 idx) %{
   predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "xvinsert    $dst, $val, $idx\t# @insert16S" %}
+  format %{ "(x)vinsert    $dst, $val, $idx\t# @insert16S" %}
   ins_encode %{
     int idx = $idx$$constant;
     int msbw = (idx % 2) ? 31 : 15;
@@ -16683,144 +14757,200 @@ instruct insert16S(vecY dst, mRegI val, immIU4 idx) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct insert8I(vecY dst, mRegI val, immIU3 idx) %{
+instruct insert8I(vReg dst, mRegI val, immIU3 idx) %{
   predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "vinsgr2vr.w    $dst, $val, $idx\t# @insert8I" %}
+  format %{ "(x)vinsgr2vr.w    $dst, $val, $idx\t# @insert8I" %}
   ins_encode %{
     __ xvinsgr2vr_w($dst$$FloatRegister, $val$$Register, $idx$$constant);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct insert4L(vecY dst, mRegL val, immIU2 idx) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_LONG);
-  match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "vinsgr2vr.d    $dst, $val, $idx\t# @insert4L" %}
-  ins_encode %{
-    __ xvinsgr2vr_d($dst$$FloatRegister, $val$$Register, $idx$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct insert8F(vecY dst, regF val, immIU3 idx) %{
-  predicate(Matcher::vector_length(n) == 8 && Matcher::vector_element_basic_type(n) == T_FLOAT);
-  match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "xvinsve0.w    $dst, $val, $idx\t# @insert8F" %}
-  ins_encode %{
-    __ xvinsve0_w($dst$$FloatRegister, $val$$FloatRegister, $idx$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct insert4D(vecY dst, regD val, immIU2 idx) %{
-  predicate(Matcher::vector_length(n) == 4 && Matcher::vector_element_basic_type(n) == T_DOUBLE);
-  match(Set dst (VectorInsert (Binary dst val) idx));
-  format %{ "xvinsve0.d    $dst, $val, $idx\t# @insert4D" %}
-  ins_encode %{
-    __ xvinsve0_d($dst$$FloatRegister, $val$$FloatRegister, $idx$$constant);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
 // -------------------------------- Vector Blend ------------------------------
 
-instruct blendV16(vecX dst, vecX src1, vecX src2, vecX mask)
+instruct blendV(vReg dst, vReg src1, vReg src2, vReg mask)
 %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
   match(Set dst (VectorBlend (Binary src1 src2) mask));
-  format %{ "vbitsel.v    $dst, $src1, $src2, $mask\t# @blendV16" %}
+  format %{ "(x)vbitsel.v    $dst, $src1, $src2, $mask\t# @blendV" %}
   ins_encode %{
-    __ vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $mask$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct blendV32(vecY dst, vecY src1, vecY src2, vecY mask)
-%{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (VectorBlend (Binary src1 src2) mask));
-  format %{ "xvbitsel.v    $dst, $src1, $src2, $mask\t# @blendV32" %}
-  ins_encode %{
-    __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $mask$$FloatRegister);
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4:
+      case  8:
+      case 16: __  vbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $mask$$FloatRegister); break;
+      case 32: __ xvbitsel_v($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, $mask$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // -------------------------------- LoadMask ----------------------------------
 
-instruct loadmask16B(vecX dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_BYTE);
+instruct loadmaskV(vReg dst, vReg src) %{
   match(Set dst (VectorLoadMask src));
-  format %{ "vneg.b    $dst, $src\t# @loadmask16B" %}
+  format %{ "(x)vloadmask    $dst, $src\t# @loadmaskV" %}
   ins_encode %{
-    __ vneg_b($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct loadmask32B(vecY dst, vecY src) %{
-  predicate(Matcher::vector_length(n) == 32 && Matcher::vector_element_basic_type(n) == T_BYTE);
-  match(Set dst (VectorLoadMask src));
-  format %{ "xvneg.b    $dst, $src\t# @loadmask32B" %}
-  ins_encode %{
-    __ xvneg_b($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct loadmask16S(vecY dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_SHORT);
-  match(Set dst (VectorLoadMask src));
-  format %{ "vloadmask    $dst, $src\t# @loadmask16S" %}
-  ins_encode %{
-    __ vext2xv_h_b($dst$$FloatRegister, $src$$FloatRegister);
-    __ xvneg_h($dst$$FloatRegister, $dst$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ xvneg_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_SHORT : __ vext2xv_h_b($dst$$FloatRegister, $src$$FloatRegister);
+                       __ xvneg_h($dst$$FloatRegister, $dst$$FloatRegister); break;
+        case T_FLOAT :
+        case T_INT   : __ vext2xv_w_b($dst$$FloatRegister, $src$$FloatRegister);
+                       __ xvneg_w($dst$$FloatRegister, $dst$$FloatRegister); break;
+        case T_DOUBLE:
+        case T_LONG  : __ vext2xv_d_b($dst$$FloatRegister, $src$$FloatRegister);
+                       __ xvneg_d($dst$$FloatRegister, $dst$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE : __ vneg_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_SHORT: __ vext2xv_h_b($dst$$FloatRegister, $src$$FloatRegister);
+                      __ vneg_h($dst$$FloatRegister, $dst$$FloatRegister); break;
+        case T_FLOAT:
+        case T_INT  : __ vext2xv_w_b($dst$$FloatRegister, $src$$FloatRegister);
+                      __ vneg_w($dst$$FloatRegister, $dst$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 //-------------------------------- StoreMask ----------------------------------
 
-instruct storemask16B(vecX dst, vecX src, immI_1 size) %{
-  predicate(Matcher::vector_length(n) == 16);
+instruct storemaskV(vReg dst, vReg src, immIU4 size) %{
   match(Set dst (VectorStoreMask src size));
-  format %{ "vneg.b    $dst, $src\t# @storemask16B" %}
+  format %{ "(x)vstoremask    $dst, $src\t# @storemaskV" %}
   ins_encode %{
-    __ vneg_b($dst$$FloatRegister, $src$$FloatRegister);
+    uint size = $size$$constant;
+    if (Matcher::vector_length_in_bytes(this, $src) > 16 && size != 1 /* byte */)
+      __ xvpermi_d(fscratch, $src$$FloatRegister, 0b00001110);
+
+    switch (size) {
+      case 8: /* long or double */
+        __ vsrlni_w_d(fscratch, $src$$FloatRegister, 0);
+        __ vsrlni_h_w(fscratch, fscratch, 0);
+        __ vsrlni_b_h(fscratch, fscratch, 0);
+        __ vneg_b($dst$$FloatRegister, fscratch);
+        break;
+      case 4: /* int or float */
+        __ vsrlni_h_w(fscratch, $src$$FloatRegister, 0);
+        __ vsrlni_b_h(fscratch, fscratch, 0);
+        __ vneg_b($dst$$FloatRegister, fscratch);
+        break;
+      case 2: /* short */
+        __ vsrlni_b_h(fscratch, $src$$FloatRegister, 0);
+        __ vneg_b($dst$$FloatRegister, fscratch);
+        break;
+      case 1: /* byte */
+        if (Matcher::vector_length_in_bytes(this, $src) > 16)
+          __ xvneg_b($dst$$FloatRegister, $src$$FloatRegister);
+        else
+          __ vneg_b($dst$$FloatRegister, $src$$FloatRegister);
+        break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct storemask32B(vecY dst, vecY src, immI_1 size) %{
-  predicate(Matcher::vector_length(n) == 32);
-  match(Set dst (VectorStoreMask src size));
-  format %{ "xvneg.b    $dst, $src\t# @storemask32B" %}
+// ----------------------------- VectorMaskCast -----------------------------------
+
+instruct vmaskcast_eq(vReg dst) %{
+  predicate(Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
+  match(Set dst (VectorMaskCast dst));
+  format %{ "(x)vmaskcast    $dst\t# @vmaskcast_eq" %}
+  ins_encode(/* empty encoding */);
+  ins_pipe( pipe_slow );
+%}
+
+instruct vmaskcast_gt(vReg dst, vReg src) %{
+  predicate(Matcher::vector_length_in_bytes(n) > Matcher::vector_length_in_bytes(n->in(1)));
+  match(Set dst (VectorMaskCast src));
+  format %{ "(x)vmaskcast    $dst\t# @vmaskcast_gt" %}
   ins_encode %{
-    __ xvneg_b($dst$$FloatRegister, $src$$FloatRegister);
+    if (Matcher::vector_element_basic_type(this, $src) == T_BYTE) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_SHORT : __ vext2xv_h_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_FLOAT :
+        case T_INT   : __ vext2xv_w_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_DOUBLE:
+        case T_LONG  : __ vext2xv_d_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else if (Matcher::vector_element_basic_type(this, $src) == T_SHORT) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_FLOAT :
+        case T_INT   : __ vext2xv_w_h($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_DOUBLE:
+        case T_LONG  : __ vext2xv_d_h($dst$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else if (type2aelembytes(Matcher::vector_element_basic_type(this, $src)) == 4 /* int or float */) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_DOUBLE:
+        case T_LONG  : __ vext2xv_d_w($dst$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct storemask16S(vecX dst, vecY src, immI_2 size) %{
-  predicate(Matcher::vector_length(n) == 16);
-  match(Set dst (VectorStoreMask src size));
-  format %{ "vstoremask    $dst, $src\t# @storemask16S" %}
+instruct vmaskcast_lt(vReg dst, vReg src) %{
+  predicate(Matcher::vector_length_in_bytes(n) < Matcher::vector_length_in_bytes(n->in(1)));
+  match(Set dst (VectorMaskCast src));
+  effect(TEMP_DEF dst);
+  format %{ "(x)vmaskcast    $dst\t# @vmaskcast_lt" %}
   ins_encode %{
-    __ xvpermi_d(fscratch, $src$$FloatRegister, 0b00001110);
-    __ vsrlni_b_h(fscratch, $src$$FloatRegister, 0);
-    __ vneg_b($dst$$FloatRegister, fscratch);
+    if (Matcher::vector_length_in_bytes(this, $src) > 16)
+      __ xvpermi_d($dst$$FloatRegister, $src$$FloatRegister, 0b00001110);
+
+    if (type2aelembytes(Matcher::vector_element_basic_type(this, $src)) == 8 /* long or double */) {
+      if (type2aelembytes(Matcher::vector_element_basic_type(this)) <= 4) {
+        __ vsrlni_w_d($dst$$FloatRegister, $src$$FloatRegister, 0);
+        if (type2aelembytes(Matcher::vector_element_basic_type(this)) <= 2) {
+          __ vsrlni_h_w($dst$$FloatRegister, $dst$$FloatRegister, 0);
+          if (type2aelembytes(Matcher::vector_element_basic_type(this)) == 1) {
+            __ vsrlni_b_h($dst$$FloatRegister, $dst$$FloatRegister, 0);
+          }
+        }
+      }
+    } else if (type2aelembytes(Matcher::vector_element_basic_type(this, $src)) == 4 /* int or float */) {
+      if (type2aelembytes(Matcher::vector_element_basic_type(this)) <= 2) {
+        __ vsrlni_h_w($dst$$FloatRegister, $src$$FloatRegister, 0);
+        if (type2aelembytes(Matcher::vector_element_basic_type(this)) == 1) {
+          __ vsrlni_b_h($dst$$FloatRegister, $dst$$FloatRegister, 0);
+        }
+      }
+    } else if (Matcher::vector_element_basic_type(this, $src) == T_SHORT) {
+      __ vsrlni_b_h($dst$$FloatRegister, $src$$FloatRegister, 0);
+    } else {
+      ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ----------------------------- VectorTest -----------------------------------
 
-instruct anytrue_in_maskV16_branch(cmpOp cop, vecX op1, vecX op2, label labl) %{
-  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::ne);
+instruct anytrue_in_maskV16_branch(cmpOp cop, vReg op1, vReg op2, label labl) %{
+  predicate(Matcher::vector_length_in_bytes(n->in(2)->in(1)) == 16 && static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::ne);
   match(If cop (VectorTest op1 op2));
   effect(USE labl);
-  format %{ "b$cop   $op1, $op2(not used), $labl\t# @anytrue_in_maskV16__branch" %}
+  format %{ "b$cop   $op1, $op2(not used), $labl\t# @anytrue_in_maskV16_branch" %}
 
   ins_encode %{
     Label    &L  = *($labl$$label);
@@ -16842,8 +14972,8 @@ instruct anytrue_in_maskV16_branch(cmpOp cop, vecX op1, vecX op2, label labl) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct alltrue_in_maskV16_branch(cmpOp cop, vecX op1, vecX op2, label labl) %{
-  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::overflow);
+instruct alltrue_in_maskV16_branch(cmpOp cop, vReg op1, vReg op2, label labl) %{
+  predicate(Matcher::vector_length_in_bytes(n->in(2)->in(1)) == 16 && static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::overflow);
   match(If cop (VectorTest op1 op2));
   effect(USE labl);
   format %{ "b$cop   $op1, $op2(not used), $labl\t# @alltrue_in_maskV16__branch" %}
@@ -16868,9 +14998,9 @@ instruct alltrue_in_maskV16_branch(cmpOp cop, vecX op1, vecX op2, label labl) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct CMoveI_anytrue_in_maskV16(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vecX op1, vecX op2, cmpOp cop, regF tmp1, regF tmp2)
+instruct CMoveI_anytrue_in_maskV16(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vReg op1, vReg op2, cmpOp cop, regF tmp1, regF tmp2)
 %{
-  predicate(static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::ne);
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(2)->in(1)) == 16 && static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::ne);
   match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary src1 src2)));
   effect(TEMP tmp1, TEMP tmp2);
   format %{ "cmovei_vtest($cop)    $dst, $src1, $src2, $op1, $op2(not used)\t# TEMP($tmp1, $tmp2) @CMoveI_anytrue_in_maskV16" %}
@@ -16894,9 +15024,9 @@ instruct CMoveI_anytrue_in_maskV16(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, 
   ins_pipe( pipe_slow );
 %}
 
-instruct CMoveI_alltrue_in_maskV16(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vecX op1, vecX op2, cmpOp cop, regF tmp1, regF tmp2)
+instruct CMoveI_alltrue_in_maskV16(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vReg op1, vReg op2, cmpOp cop, regF tmp1, regF tmp2)
 %{
-  predicate(static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::overflow);
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(2)->in(1)) == 16 && static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::overflow);
   match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary src1 src2)));
   effect(TEMP tmp1, TEMP tmp2);
   format %{ "cmovei_vtest($cop)    $dst, $src1, $src2, $op1, $op2(not used)\t# TEMP($tmp1, $tmp2) @CMoveI_alltrue_in_maskV16" %}
@@ -16920,8 +15050,8 @@ instruct CMoveI_alltrue_in_maskV16(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, 
   ins_pipe( pipe_slow );
 %}
 
-instruct anytrue_in_maskV32_branch(cmpOp cop, vecY op1, vecY op2, label labl) %{
-  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::ne);
+instruct anytrue_in_maskV32_branch(cmpOp cop, vReg op1, vReg op2, label labl) %{
+  predicate(Matcher::vector_length_in_bytes(n->in(2)->in(1)) == 32 && static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::ne);
   match(If cop (VectorTest op1 op2));
   effect(USE labl);
   format %{ "b$cop   $op1, $op2(not used), $labl\t# @anytrue_in_maskV32__branch" %}
@@ -16946,8 +15076,8 @@ instruct anytrue_in_maskV32_branch(cmpOp cop, vecY op1, vecY op2, label labl) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct alltrue_in_maskV32_branch(cmpOp cop, vecY op1, vecY op2, label labl) %{
-  predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::overflow);
+instruct alltrue_in_maskV32_branch(cmpOp cop, vReg op1, vReg op2, label labl) %{
+  predicate(Matcher::vector_length_in_bytes(n->in(2)->in(1)) == 32 && static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::overflow);
   match(If cop (VectorTest op1 op2));
   effect(USE labl);
   format %{ "b$cop   $op1, $op2(not used), $labl\t# @alltrue_in_maskV32__branch" %}
@@ -16972,9 +15102,9 @@ instruct alltrue_in_maskV32_branch(cmpOp cop, vecY op1, vecY op2, label labl) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct CMoveI_anytrue_in_maskV32(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vecY op1, vecY op2, cmpOp cop, regF tmp1, regF tmp2)
+instruct CMoveI_anytrue_in_maskV32(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vReg op1, vReg op2, cmpOp cop, regF tmp1, regF tmp2)
 %{
-  predicate(static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::ne);
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(2)->in(1)) == 32 && static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::ne);
   match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary src1 src2)));
   effect(TEMP tmp1, TEMP tmp2);
   format %{ "cmovei_xvtest($cop)    $dst, $src1, $src2, $op1, $op2(not used)\t# TEMP($tmp1, $tmp2) @CMoveI_anytrue_in_maskV32" %}
@@ -16998,9 +15128,9 @@ instruct CMoveI_anytrue_in_maskV32(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, 
   ins_pipe( pipe_slow );
 %}
 
-instruct CMoveI_alltrue_in_maskV32(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vecY op1, vecY op2, cmpOp cop, regF tmp1, regF tmp2)
+instruct CMoveI_alltrue_in_maskV32(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, vReg op1, vReg op2, cmpOp cop, regF tmp1, regF tmp2)
 %{
-  predicate(static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::overflow);
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(2)->in(1)) == 32 && static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::overflow);
   match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary src1 src2)));
   effect(TEMP tmp1, TEMP tmp2);
   format %{ "cmovei_xvtest($cop)    $dst, $src1, $src2, $op1, $op2(not used)\t# TEMP($tmp1, $tmp2) @CMoveI_alltrue_in_maskV32" %}
@@ -17026,74 +15156,85 @@ instruct CMoveI_alltrue_in_maskV32(mRegI dst, mRegIorL2I src1, mRegIorL2I src2, 
 
 // ----------------------------- VectorMaskTrueCount ----------------------------
 
-instruct vmask_truecount16B(mRegI dst, vecX src) %{
-  predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
-  match(Set dst (VectorMaskTrueCount src));
-  format %{ "vmask_truecount   $dst, $src\t# @vmask_truecount16B" %}
-  ins_encode %{
-    // Input "src" is a vector of boolean represented as bytes with
-    // 0x00/0x01 as element values.
-    __ vpcnt_d(fscratch, $src$$FloatRegister);
-    __ vhaddw_q_d(fscratch, fscratch, fscratch);
-    __ vpickve2gr_b($dst$$Register, fscratch, 0);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct vmask_truecount32B(mRegI dst, vecY src, vecY tmp) %{
-  predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
+instruct mask_truecountV(mRegI dst, vReg src, vReg tmp) %{
   match(Set dst (VectorMaskTrueCount src));
   effect(TEMP tmp);
-  format %{ "vmask_truecount   $dst, $src\t# TEMP($tmp) @vmask_truecount32B" %}
+  format %{ "(x)vmask_truecount   $dst, $src\t# TEMP($tmp) @mask_truecountV" %}
   ins_encode %{
     // Input "src" is a vector of boolean represented as bytes with
     // 0x00/0x01 as element values.
-    __ xvpcnt_d($tmp$$FloatRegister, $src$$FloatRegister);
-    __ xvhaddw_q_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
-    __ xvpermi_d(fscratch, $tmp$$FloatRegister, 0b00001110);
-    __ vadd_b($tmp$$FloatRegister, $tmp$$FloatRegister, fscratch);
-    __ vpickve2gr_b($dst$$Register, $tmp$$FloatRegister, 0);
+    if (Matcher::vector_length(this, $src) == 4) {
+      __ vpcnt_w(fscratch, $src$$FloatRegister);
+      __ vpickve2gr_b($dst$$Register, fscratch, 0);
+    } else if (Matcher::vector_length(this, $src) == 8) {
+      __ vpcnt_d(fscratch, $src$$FloatRegister);
+      __ vpickve2gr_b($dst$$Register, fscratch, 0);
+    } else if (Matcher::vector_length(this, $src) == 16) {
+      __ vpcnt_d(fscratch, $src$$FloatRegister);
+      __ vhaddw_q_d(fscratch, fscratch, fscratch);
+      __ vpickve2gr_b($dst$$Register, fscratch, 0);
+    } else if (Matcher::vector_length(this, $src) == 32) {
+      __ xvpcnt_d($tmp$$FloatRegister, $src$$FloatRegister);
+      __ xvhaddw_q_d($tmp$$FloatRegister, $tmp$$FloatRegister, $tmp$$FloatRegister);
+      __ xvpermi_d(fscratch, $tmp$$FloatRegister, 0b00001110);
+      __ vadd_b($tmp$$FloatRegister, $tmp$$FloatRegister, fscratch);
+      __ vpickve2gr_b($dst$$Register, $tmp$$FloatRegister, 0);
+    } else {
+      ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ----------------------------- VectorMaskFirstTrue ----------------------------
 
-instruct vmask_firsttrue16B(mRegI dst, vecX src) %{
-  predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
+instruct mask_firsttrue_le16B(mRegI dst, vReg src) %{
+  predicate(Matcher::vector_length(n->in(1)) <= 16);
   match(Set dst (VectorMaskFirstTrue src));
-  format %{ "vmask_firsttrue    $dst, $src\t# @vmask_firsttrue16B" %}
+  format %{ "(x)vmask_firsttrue    $dst, $src\t# @mask_firsttrue_le16B" %}
   ins_encode %{
     // Returns the index of the first active lane of the
-    // vector mask, or 16 (VLENGTH) if no lane is active.
+    // vector mask, or 4/8/16 (VLENGTH) if no lane is active.
     //
     // Input "src" is a vector of boolean represented as
     // bytes with 0x00/0x01 as element values.
 
-    Label FIRST_TRUE_INDEX;
+    if (Matcher::vector_length(this, $src) == 4) {
+      __ movfr2gr_s($dst$$Register, $src$$FloatRegister);
+      __ ctz_w($dst$$Register, $dst$$Register);
+      __ srli_w($dst$$Register, $dst$$Register, 3);
+    } else if (Matcher::vector_length(this, $src) == 8) {
+      __ movfr2gr_d($dst$$Register, $src$$FloatRegister);
+      __ ctz_d($dst$$Register, $dst$$Register);
+      __ srli_w($dst$$Register, $dst$$Register, 3);
+    } else if (Matcher::vector_length(this, $src) == 16) {
+      Label FIRST_TRUE_INDEX;
 
-    // Try to compute the result from lower 64 bits.
-    __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-    __ li(AT, (long)0);
-    __ bnez($dst$$Register, FIRST_TRUE_INDEX);
+      // Try to compute the result from lower 64 bits.
+      __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
+      __ li(AT, (long)0);
+      __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
-    // Compute the result from the higher 64 bits.
-    __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-    __ li(AT, (long)8);
+      // Compute the result from the higher 64 bits.
+      __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
+      __ li(AT, (long)8);
 
-    // Count the Trailing zero bytes.
-    __ bind(FIRST_TRUE_INDEX);
-    __ ctz_d($dst$$Register, $dst$$Register);
-    __ srli_w($dst$$Register, $dst$$Register, 3);
-    __ add_w($dst$$Register, AT, $dst$$Register);
+      // Count the Trailing zero bytes.
+      __ bind(FIRST_TRUE_INDEX);
+      __ ctz_d($dst$$Register, $dst$$Register);
+      __ srli_w($dst$$Register, $dst$$Register, 3);
+      __ add_w($dst$$Register, AT, $dst$$Register);
+    } else {
+      ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct vmask_firsttrue32B(mRegI dst, vecY src) %{
-  predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
+instruct vmask_firsttrue32B(mRegI dst, vReg src) %{
+  predicate(Matcher::vector_length(n->in(1)) == 32);
   match(Set dst (VectorMaskFirstTrue src));
-  format %{ "vmask_firsttrue    $dst, $src\t# @vmask_firsttrue32B" %}
+  format %{ "(x)vmask_firsttrue    $dst, $src\t# @vmask_firsttrue32B" %}
   ins_encode %{
     // Returns the index of the first active lane of the
     // vector mask, or 32 (VLENGTH) if no lane is active.
@@ -17133,10 +15274,10 @@ instruct vmask_firsttrue32B(mRegI dst, vecY src) %{
 
 // ----------------------------- VectorMaskLastTrue ----------------------------
 
-instruct vmask_lasttrue16B(mRegI dst, vecX src) %{
-  predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
+instruct mask_lasttrue_le16B(mRegI dst, vReg src) %{
+  predicate(Matcher::vector_length(n->in(1)) <= 16);
   match(Set dst (VectorMaskLastTrue src));
-  format %{ "vmask_lasttrue    $dst, $src\t# @vmask_lasttrue16B" %}
+  format %{ "(x)vmask_lasttrue    $dst, $src\t# @mask_lasttrue_le16B" %}
   ins_encode %{
     // Returns the index of the last active lane of the
     // vector mask, or -1 if no lane is active.
@@ -17144,30 +15285,46 @@ instruct vmask_lasttrue16B(mRegI dst, vecX src) %{
     // Input "src" is a vector of boolean represented as
     // bytes with 0x00/0x01 as element values.
 
-    Label FIRST_TRUE_INDEX;
+    if (Matcher::vector_length(this, $src) == 4) {
+      __ movfr2gr_s($dst$$Register, $src$$FloatRegister);
+      __ clz_w($dst$$Register, $dst$$Register);
+      __ srli_w($dst$$Register, $dst$$Register, 3);
+      __ addi_w($dst$$Register, $dst$$Register, -3);
+      __ sub_w($dst$$Register, R0, $dst$$Register);
+    } else if (Matcher::vector_length(this, $src) == 8) {
+      __ movfr2gr_d($dst$$Register, $src$$FloatRegister);
+      __ clz_d($dst$$Register, $dst$$Register);
+      __ srli_w($dst$$Register, $dst$$Register, 3);
+      __ addi_w($dst$$Register, $dst$$Register, -7);
+      __ sub_w($dst$$Register, R0, $dst$$Register);
+    } else if (Matcher::vector_length(this, $src) == 16) {
+      Label FIRST_TRUE_INDEX;
 
-    // Try to compute the result from higher 64 bits.
-    __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-    __ li(AT, (long)16 - 1);
-    __ bnez($dst$$Register, FIRST_TRUE_INDEX);
+      // Try to compute the result from higher 64 bits.
+      __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
+      __ li(AT, (long)16 - 1);
+      __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
-    // Compute the result from the lower 64 bits.
-    __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-    __ li(AT, (long)8 - 1);
+      // Compute the result from the lower 64 bits.
+      __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
+      __ li(AT, (long)8 - 1);
 
-    // Count the Trailing zero bytes.
-    __ bind(FIRST_TRUE_INDEX);
-    __ clz_d($dst$$Register, $dst$$Register);
-    __ srli_w($dst$$Register, $dst$$Register, 3);
-    __ sub_w($dst$$Register, AT, $dst$$Register);
+      // Count the Trailing zero bytes.
+      __ bind(FIRST_TRUE_INDEX);
+      __ clz_d($dst$$Register, $dst$$Register);
+      __ srli_w($dst$$Register, $dst$$Register, 3);
+      __ sub_w($dst$$Register, AT, $dst$$Register);
+    } else {
+      ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct vmask_lasttrue32B(mRegI dst, vecY src) %{
-  predicate(Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
+instruct vmask_lasttrue32B(mRegI dst, vReg src) %{
+  predicate(Matcher::vector_length(n->in(1)) == 32 && Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
   match(Set dst (VectorMaskLastTrue src));
-  format %{ "vmask_lasttrue    $dst, $src\t# @vmask_lasttrue32B" %}
+  format %{ "(x)vmask_lasttrue    $dst, $src\t# @vmask_lasttrue32B" %}
   ins_encode %{
     // Returns the index of the last active lane of the
     // vector mask, or -1 if no lane is active.
@@ -17207,36 +15364,23 @@ instruct vmask_lasttrue32B(mRegI dst, vecY src) %{
 
 // ----------------------------- Vector comparison ----------------------------
 
-instruct cmpV16(vecX dst, vecX src1, vecX src2, immI cond)
+instruct cmpV(vReg dst, vReg src1, vReg src2, immI cond)
 %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
-  format %{ "vcompare    $dst, $src1, $src2, $cond\t# @cmpV16" %}
+  format %{ "(x)vcompare    $dst, $src1, $src2, $cond\t# @cmpV" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 16);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct cmpV32(vecY dst, vecY src1, vecY src2, immI cond)
-%{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
-  format %{ "xvcompare    $dst, $src1, $src2, $cond\t# @cmpV32" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister, bt, $cond$$constant, 32);
+    __ vector_compare($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister,
+                      bt, $cond$$constant, Matcher::vector_length_in_bytes(this));
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ---------------------------- LOAD_IOTA_INDICES -----------------------------
 
-instruct loadconV16(vecX dst, immI_0 src) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 16);
+instruct loadconV(vReg dst, immI_0 src) %{
   match(Set dst (VectorLoadConst src));
-  format %{ "vld_con    $dst, CONSTANT_MEMORY\t# @loadconV16" %}
+  format %{ "(x)vld_con    $dst, CONSTANT_MEMORY\t# @loadconV" %}
   ins_encode %{
     // The iota indices are ordered by type B/S/I/L/F/D, and the offset between two types is 32.
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -17245,258 +15389,139 @@ instruct loadconV16(vecX dst, immI_0 src) %{
       offset += 64;
     }
     __ li(AT, (long)(StubRoutines::la::vector_iota_indices() + offset));
-    __ vld($dst$$FloatRegister, AT, (int)0);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct loadconV32(vecY dst, immI_0 src) %{
-  predicate(Matcher::vector_length_in_bytes(n) == 32);
-  match(Set dst (VectorLoadConst src));
-  format %{ "xvld_con    $dst, CONSTANT_MEMORY\t# @loadconV32" %}
-  ins_encode %{
-    // The iota indices are ordered by type B/S/I/L/F/D, and the offset between two types is 32.
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    int offset = exact_log2(type2aelembytes(bt)) << 5;
-    if (is_floating_point_type(bt)) {
-      offset += 64;
+    switch (Matcher::vector_length_in_bytes(this)) {
+      case  4:
+      case  8:
+      case 16: __  vld($dst$$FloatRegister, AT, (int)0); break;
+      case 32: __ xvld($dst$$FloatRegister, AT, (int)0); break;
+      default:
+        ShouldNotReachHere();
     }
-    __ li(AT, (long)(StubRoutines::la::vector_iota_indices() + offset));
-    __ xvld($dst$$FloatRegister, AT, (int)0);
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ---------------------------- LOAD_SHUFFLE ----------------------------------
 
-instruct loadShuffle16B(vecX dst) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_BYTE);
+instruct loadShuffleVB(vReg dst) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorLoadShuffle dst));
-  format %{ "vld_shuffle    $dst\t# @loadShuffle16B" %}
+  format %{ "(x)vld_shuffle    $dst\t# @loadShuffleVB" %}
   ins_encode %{
     // empty
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct loadShuffle32B(vecY dst) %{
-  predicate(Matcher::vector_length(n) == 32 && Matcher::vector_element_basic_type(n) == T_BYTE);
-  match(Set dst (VectorLoadShuffle dst));
-  format %{ "xvld_shuffle    $dst\t# @loadShuffle32B" %}
-  ins_encode %{
-    // empty
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct loadShuffle16S(vecY dst, vecX src) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_SHORT);
+instruct loadShuffleV(vReg dst, vReg src) %{
+  predicate(Matcher::vector_element_basic_type(n) != T_BYTE);
   match(Set dst (VectorLoadShuffle src));
-  format %{ "vext2xv.hu.bu    $dst, $src\t# @loadShuffle16S" %}
+  format %{ "(x)vld_shuffle    $dst, $src\t# @loadShuffleV" %}
   ins_encode %{
-    __ vext2xv_hu_bu($dst$$FloatRegister, $src$$FloatRegister);
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_SHORT : __ vext2xv_hu_bu($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_FLOAT :
+      case T_INT   : __ vext2xv_wu_bu($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_DOUBLE:
+      case T_LONG  : __ vext2xv_du_bu($dst$$FloatRegister, $src$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ---------------------------- Rearrange -------------------------------------
 
-instruct rearrange16B(vecX dst, vecX src, vecX shuffle) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_BYTE);
-  match(Set dst (VectorRearrange src shuffle));
-  format %{ "vshuf.b    $dst, $src, $shuffle\t# @rearrange16B" %}
-  ins_encode %{
-    __ vshuf_b($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister, $shuffle$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rearrange32B(vecY dst, vecY src, vecY shuffle) %{
-  predicate(Matcher::vector_length(n) == 32 && Matcher::vector_element_basic_type(n) == T_BYTE);
-  match(Set dst (VectorRearrange src shuffle));
-  effect(TEMP_DEF dst);
-  format %{ "xvrearrange    $dst, $src, $shuffle\t# @rearrange32B" %}
-  ins_encode %{
-    __ xvpermi_q(fscratch, $src$$FloatRegister, 0x00);
-    __ xvpermi_q($dst$$FloatRegister, $src$$FloatRegister, 0x11);
-    __ xvshuf_b($dst$$FloatRegister, $dst$$FloatRegister, fscratch, $shuffle$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct rearrange16S(vecY dst, vecY src, vecY tmp) %{
-  predicate(Matcher::vector_length(n) == 16 && Matcher::vector_element_basic_type(n) == T_SHORT);
+instruct rearrangeV(vReg dst, vReg src, vReg tmp) %{
   match(Set dst (VectorRearrange src dst));
   effect(TEMP tmp);
-  format %{ "xvrearrange    $dst, $src, $dst\t# TEMP($tmp) @rearrange16S" %}
+  format %{ "(x)vrearrange    $dst, $src, $dst\t# TEMP($tmp) @rearrangeV" %}
   ins_encode %{
-    __ xvpermi_q($tmp$$FloatRegister, $src$$FloatRegister, 0x00);
-    __ xvpermi_q(fscratch, $src$$FloatRegister, 0x11);
-    __ xvshuf_h($dst$$FloatRegister, fscratch, $tmp$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      __ xvpermi_q($tmp$$FloatRegister, $src$$FloatRegister, 0x00);
+      __ xvpermi_q(fscratch, $src$$FloatRegister, 0x11);
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ xvshuf_b($dst$$FloatRegister, fscratch, $tmp$$FloatRegister, $dst$$FloatRegister); break;
+        case T_SHORT : __ xvshuf_h($dst$$FloatRegister, fscratch, $tmp$$FloatRegister); break;
+        case T_FLOAT :
+        case T_INT   : __ xvshuf_w($dst$$FloatRegister, fscratch, $tmp$$FloatRegister); break;
+        case T_DOUBLE:
+        case T_LONG  : __ xvshuf_d($dst$$FloatRegister, fscratch, $tmp$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ vshuf_b($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister, $dst$$FloatRegister); break;
+        case T_SHORT : __ vshuf_h($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister); break;
+        case T_FLOAT :
+        case T_INT   : __ vshuf_w($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister); break;
+        case T_DOUBLE:
+        case T_LONG  : __ vshuf_d($dst$$FloatRegister, $src$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ---------------------------- PopCount --------------------------------------
 
-instruct popcount16B(vecX dst, vecX src) %{
-  predicate(n->as_Vector()->length() == 16);
+instruct popcountV(vReg dst, vReg src) %{
   match(Set dst (PopCountVI src));
-  format %{ "vpcnt.b    $dst, $src\t# @popcount16B" %}
-  ins_encode %{
-    __ vpcnt_b($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct popcount8S(vecX dst, vecX src) %{
-  predicate(n->as_Vector()->length() == 8);
-  match(Set dst (PopCountVI src));
-  format %{ "vpcnt.h    $dst, $src\t# @popcount8S" %}
-  ins_encode %{
-    __ vpcnt_h($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct popcount4I(vecX dst, vecX src) %{
-  predicate(n->as_Vector()->length() == 4);
-  match(Set dst (PopCountVI src));
-  format %{ "vpcnt.w    $dst, $src\t# @popcount4I" %}
-  ins_encode %{
-    __ vpcnt_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct popcount2L(vecX dst, vecX src) %{
-  predicate(n->as_Vector()->length() == 2);
   match(Set dst (PopCountVL src));
-  format %{ "vpcnt.d    $dst, $src\t# @popcount2L" %}
+  format %{ "(x)vpcnt    $dst, $src\t# @popcountV" %}
   ins_encode %{
-    __ vpcnt_d($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct popcount32B(vecY dst, vecY src) %{
-  predicate(n->as_Vector()->length() == 32);
-  match(Set dst (PopCountVI src));
-  format %{ "xvpcnt.b    $dst, $src\t# @popcount32B" %}
-  ins_encode %{
-    __ xvpcnt_b($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct popcount16S(vecY dst, vecY src) %{
-  predicate(n->as_Vector()->length() == 16);
-  match(Set dst (PopCountVI src));
-  format %{ "xvpcnt.h    $dst, $src\t# @popcount16S" %}
-  ins_encode %{
-    __ xvpcnt_h($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct popcount8I(vecY dst, vecY src) %{
-  predicate(n->as_Vector()->length() == 8);
-  match(Set dst (PopCountVI src));
-  format %{ "xvpcnt.w    $dst, $src\t# @popcount8I" %}
-  ins_encode %{
-    __ xvpcnt_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct popcount4L(vecY dst, vecY src) %{
-  predicate(n->as_Vector()->length() == 4);
-  match(Set dst (PopCountVL src));
-  format %{ "xvpcnt.d    $dst, $src\t# @popcount4L" %}
-  ins_encode %{
-    __ xvpcnt_d($dst$$FloatRegister, $src$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ xvpcnt_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_SHORT : __ xvpcnt_h($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_INT   : __ xvpcnt_w($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_LONG  : __ xvpcnt_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ vpcnt_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_SHORT : __ vpcnt_h($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_INT   : __ vpcnt_w($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_LONG  : __ vpcnt_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
 // ---------------------------- CountLeadingZerosV --------------------------------------
 
-instruct clz16B(vecX dst, vecX src) %{
-  predicate(n->as_Vector()->length() == 16);
+instruct clzV(vReg dst, vReg src) %{
   match(Set dst (CountLeadingZerosV src));
-  format %{ "vclz.b    $dst, $src\t# @clz16B" %}
+  format %{ "(x)vclz    $dst, $src\t# @clzV" %}
   ins_encode %{
-    __ vclz_b($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct clz8S(vecX dst, vecX src) %{
-  predicate(n->as_Vector()->length() == 8);
-  match(Set dst (CountLeadingZerosV src));
-  format %{ "vclz.h    $dst, $src\t# @clz8S" %}
-  ins_encode %{
-    __ vclz_h($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct clz4I(vecX dst, vecX src) %{
-  predicate(n->as_Vector()->length() == 4);
-  match(Set dst (CountLeadingZerosV src));
-  format %{ "vclz.w    $dst, $src\t# @clz4I" %}
-  ins_encode %{
-    __ vclz_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct clz2L(vecX dst, vecX src) %{
-  predicate(n->as_Vector()->length() == 2);
-  match(Set dst (CountLeadingZerosV src));
-  format %{ "vclz.d    $dst, $src\t# @clz2L" %}
-  ins_encode %{
-    __ vclz_d($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct clz32B(vecY dst, vecY src) %{
-  predicate(n->as_Vector()->length() == 32);
-  match(Set dst (CountLeadingZerosV src));
-  format %{ "xvclz.b    $dst, $src\t# @clz32B" %}
-  ins_encode %{
-    __ xvclz_b($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct clz16S(vecY dst, vecY src) %{
-  predicate(n->as_Vector()->length() == 16);
-  match(Set dst (CountLeadingZerosV src));
-  format %{ "xvclz.h    $dst, $src\t# @clz16S" %}
-  ins_encode %{
-    __ xvclz_h($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct clz8I(vecY dst, vecY src) %{
-  predicate(n->as_Vector()->length() == 8);
-  match(Set dst (CountLeadingZerosV src));
-  format %{ "xvclz.w    $dst, $src\t# @clz8I" %}
-  ins_encode %{
-    __ xvclz_w($dst$$FloatRegister, $src$$FloatRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct clz4L(vecY dst, vecY src) %{
-  predicate(n->as_Vector()->length() == 4);
-  match(Set dst (CountLeadingZerosV src));
-  format %{ "xvclz.d    $dst, $src\t# @clz4L" %}
-  ins_encode %{
-    __ xvclz_d($dst$$FloatRegister, $src$$FloatRegister);
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ xvclz_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_SHORT : __ xvclz_h($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_INT   : __ xvclz_w($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_LONG  : __ xvclz_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : __ vclz_b($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_SHORT : __ vclz_h($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_INT   : __ vclz_w($dst$$FloatRegister, $src$$FloatRegister); break;
+        case T_LONG  : __ vclz_d($dst$$FloatRegister, $src$$FloatRegister); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -14767,6 +14767,108 @@ instruct insert8I(vReg dst, mRegI val, immIU3 idx) %{
   ins_pipe( pipe_slow );
 %}
 
+// ---------------------------------- Extract --------------------------------
+
+instruct extractVUB(mRegI dst, vReg src, mRegI idx, vReg tmp) %{
+  match(Set dst (ExtractUB src idx));
+  effect(TEMP tmp);
+  format %{ "(x)vextract $dst, $src, $idx\t# @extractVUB" %}
+  ins_encode %{
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    // "idx" is expected to be in range.
+
+    if (Matcher::vector_length_in_bytes(this, $src) > 16) {
+      __ xvreplgr2vr_b(fscratch, $idx$$Register);
+      __ xvpermi_q($tmp$$FloatRegister, $src$$FloatRegister, 0x01);
+      __ xvshuf_b(fscratch, $tmp$$FloatRegister, $src$$FloatRegister, fscratch);
+    } else {
+      __ vreplgr2vr_b(fscratch, $idx$$Register);
+      __ vshuf_b(fscratch, $src$$FloatRegister, $src$$FloatRegister, fscratch);
+    }
+    __ vpickve2gr_b($dst$$Register, fscratch, 0);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct extractV(mRegI dst, vReg src, immIU5 idx) %{
+  match(Set dst (ExtractUB src idx));
+  match(Set dst (ExtractB src idx));
+  match(Set dst (ExtractS src idx));
+  match(Set dst (ExtractI src idx));
+  format %{ "(x)vextract $dst, $src, $idx\t# @extractV" %}
+  ins_encode %{
+    int idx = $idx$$constant;
+    FloatRegister src = $src$$FloatRegister;
+
+    if (type2aelembytes(Matcher::vector_element_basic_type(this, $src)) == 1 && idx >= 16) {
+      idx = idx - 16;
+      src = fscratch;
+      __ xvpermi_q(fscratch, $src$$FloatRegister, 0x01);
+    } else if (type2aelembytes(Matcher::vector_element_basic_type(this, $src)) == 2 && idx >= 8) {
+      idx = idx - 8;
+      src = fscratch;
+      __ xvpermi_q(fscratch, $src$$FloatRegister, 0x01);
+    }
+
+    switch (Matcher::vector_element_basic_type(this, $src)) {
+      case T_BOOLEAN:
+      case T_BYTE   : __  vpickve2gr_b($dst$$Register, src, idx); break;
+      case T_SHORT  : __  vpickve2gr_h($dst$$Register, src, idx); break;
+      case T_INT    : Matcher::vector_length_in_bytes(this, $src) > 16 ?
+                      __ xvpickve2gr_w($dst$$Register, src, idx) :
+                      __  vpickve2gr_w($dst$$Register, src, idx); break;
+      default:
+        ShouldNotReachHere();
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct extractVL(mRegL dst, vReg src, immIU2 idx) %{
+  match(Set dst (ExtractL src idx));
+  format %{ "(x)vpickve2gr.d    $dst, $src, $idx\t# @extractVL" %}
+  ins_encode %{
+    switch (Matcher::vector_length(this, $src)) {
+      case 2: __  vpickve2gr_d($dst$$Register, $src$$FloatRegister, $idx$$constant); break;
+      case 4: __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, $idx$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct extractVF(regF dst, vReg src, immIU3 idx) %{
+  match(Set dst (ExtractF src idx));
+  format %{ "(x)vextract    $dst, $src, $idx\t# @extractVF" %}
+  ins_encode %{
+    switch (Matcher::vector_length(this, $src)) {
+      case 2:
+      case 4:  __ vshuf4i_w($dst$$FloatRegister, $src$$FloatRegister, $idx$$constant); break;
+      case 8: __ xvpickve_w($dst$$FloatRegister, $src$$FloatRegister, $idx$$constant); break;
+      default:
+        ShouldNotReachHere();
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct extractVD(regD dst, vReg src, immIU2 idx) %{
+  match(Set dst (ExtractD src idx));
+  format %{ "(x)vextract    $dst, $src, $idx\t# @extractVD" %}
+  ins_encode %{
+    int idx = $idx$$constant;
+    switch (Matcher::vector_length(this, $src)) {
+      case 2:  __ vshuf4i_d($dst$$FloatRegister, $src$$FloatRegister, idx+2); break;
+      case 4: __ xvpickve_d($dst$$FloatRegister, $src$$FloatRegister, idx);   break;
+      default:
+        ShouldNotReachHere();
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 // -------------------------------- Vector Blend ------------------------------
 
 instruct blendV(vReg dst, vReg src1, vReg src2, vReg mask)

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -2869,6 +2869,15 @@ operand immL10() %{
   interface(CONST_INTER);
 %}
 
+operand immAlign16() %{
+  predicate((-65536 <= n->get_long()) && (n->get_long() <= 65535) && ((n->get_long() & 0x3) == 0));
+  match(ConL);
+
+  op_cost(10);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 operand immL12() %{
   predicate((-2048 <= n->get_long()) && (n->get_long() <= 2047));
   match(ConL);
@@ -3980,6 +3989,22 @@ operand indOffset12I2L(mRegP reg, immI12 off)
     disp($off);
   %}
 %}
+
+operand indOffset16(p_has_s6_mRegP reg, immAlign16 off)
+%{
+  constraint(ALLOC_IN_RC(p_reg));
+  match(AddP reg off);
+
+  op_cost(10);
+  format %{ "[$reg + $off (16-bit)] @ indOffset16" %}
+  interface(MEMORY_INTER) %{
+    base($reg);
+    index(0xffffffff); /* NO_INDEX */
+    scale(0x0);
+    disp($off);
+  %}
+%}
+
 // Indirect Memory Plus Index Register
 operand indIndex(mRegP addr, mRegL index) %{
   constraint(ALLOC_IN_RC(p_reg));
@@ -4166,6 +4191,7 @@ operand stackSlotL(sRegL reg) %{
 opclass memory( indirect, indOffset12, indOffset12I2L, indIndex, indIndexI2L,
                 indirectNarrow, indOffset12Narrow);
 opclass memory_loadRange(indOffset12, indirect);
+opclass memory_exclusive(indOffset16, indirect);
 
 opclass mRegLorI2L(mRegI2L, mRegL);
 opclass mRegIorL2I(mRegI, mRegL2I);
@@ -11721,7 +11747,7 @@ instruct partialSubtypeCheckVsZero_short( mRegP sub, mRegP super, mRegP tmp1, mR
   ins_short_branch(1);
 %}
 
-instruct compareAndSwapI(mRegI res, mRegP mem_ptr, mRegI oldval, mRegI newval) %{
+instruct compareAndSwapI(mRegI res, memory_exclusive mem_ptr, mRegI oldval, mRegI newval) %{
   match(Set res (CompareAndSwapI mem_ptr (Binary oldval newval)));
   effect(TEMP_DEF res);
   ins_cost(3 * MEMORY_REF_COST);
@@ -11730,14 +11756,14 @@ instruct compareAndSwapI(mRegI res, mRegP mem_ptr, mRegI oldval, mRegI newval) %
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address  addr($mem_ptr$$Register, 0);
+    Address  addr(as_Register($mem_ptr$$base), $mem_ptr$$disp);
 
     __ cmpxchg32(addr, oldval, newval, res, true, false, true /* acquire */);
   %}
   ins_pipe( long_memory_op );
 %}
 
-instruct compareAndSwapL(mRegI res, mRegP mem_ptr, mRegL oldval, mRegL newval) %{
+instruct compareAndSwapL(mRegI res, memory_exclusive mem_ptr, mRegL oldval, mRegL newval) %{
   predicate(VM_Version::supports_cx8());
   match(Set res (CompareAndSwapL mem_ptr (Binary oldval newval)));
   effect(TEMP_DEF res);
@@ -11747,14 +11773,14 @@ instruct compareAndSwapL(mRegI res, mRegP mem_ptr, mRegL oldval, mRegL newval) %
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address  addr($mem_ptr$$Register, 0);
+    Address  addr(as_Register($mem_ptr$$base), $mem_ptr$$disp);
 
     __ cmpxchg(addr, oldval, newval, res, false, true /* acquire */);
   %}
   ins_pipe( long_memory_op );
 %}
 
-instruct compareAndSwapP(mRegI res, mRegP mem_ptr, mRegP oldval, mRegP newval) %{
+instruct compareAndSwapP(mRegI res,  memory_exclusive mem_ptr, mRegP oldval, mRegP newval) %{
   match(Set res (CompareAndSwapP mem_ptr (Binary oldval newval)));
   effect(TEMP_DEF res);
   predicate(n->as_LoadStore()->barrier_data() == 0);
@@ -11764,14 +11790,14 @@ instruct compareAndSwapP(mRegI res, mRegP mem_ptr, mRegP oldval, mRegP newval) %
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address  addr($mem_ptr$$Register, 0);
+    Address  addr(as_Register($mem_ptr$$base), $mem_ptr$$disp);
 
     __ cmpxchg(addr, oldval, newval, res, false, true /* acquire */);
   %}
   ins_pipe( long_memory_op );
 %}
 
-instruct compareAndSwapN(mRegI res, mRegP mem_ptr, mRegN oldval, mRegN newval) %{
+instruct compareAndSwapN(mRegI res, indirect mem_ptr, mRegN oldval, mRegN newval) %{
   match(Set res (CompareAndSwapN mem_ptr (Binary oldval newval)));
   effect(TEMP_DEF res);
   ins_cost(3 * MEMORY_REF_COST);
@@ -11780,7 +11806,7 @@ instruct compareAndSwapN(mRegI res, mRegP mem_ptr, mRegN oldval, mRegN newval) %
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address  addr($mem_ptr$$Register, 0);
+    Address  addr(as_Register($mem_ptr$$base), $mem_ptr$$disp);
 
     __ cmpxchg32(addr, oldval, newval, res, false, false, true /* acquire */);
   %}
@@ -11913,7 +11939,7 @@ instruct get_and_addI_no_res(indirect mem, Universe dummy, mRegIorL2I incr) %{
   ins_pipe( pipe_serial );
 %}
 
-instruct compareAndExchangeI(mRegI res, indirect mem, mRegI oldval, mRegI newval) %{
+instruct compareAndExchangeI(mRegI res, memory_exclusive mem, mRegI oldval, mRegI newval) %{
 
   match(Set res (CompareAndExchangeI mem (Binary oldval newval)));
   ins_cost(2 * MEMORY_REF_COST);
@@ -11925,14 +11951,14 @@ instruct compareAndExchangeI(mRegI res, indirect mem, mRegI oldval, mRegI newval
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address addr(as_Register($mem$$base));
+    Address  addr(as_Register($mem$$base), $mem$$disp);
 
     __ cmpxchg32(addr, oldval, newval, res, true /* sign */, false /* retold */, true /* barrier */, false /* weak */, true /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct compareAndExchangeL(mRegL res, indirect mem, mRegL oldval, mRegL newval) %{
+instruct compareAndExchangeL(mRegL res, memory_exclusive mem, mRegL oldval, mRegL newval) %{
 
   match(Set res (CompareAndExchangeL mem (Binary oldval newval)));
   ins_cost(2 * MEMORY_REF_COST);
@@ -11944,14 +11970,14 @@ instruct compareAndExchangeL(mRegL res, indirect mem, mRegL oldval, mRegL newval
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address addr(as_Register($mem$$base));
+    Address  addr(as_Register($mem$$base), $mem$$disp);
 
     __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, false /* weak */, true /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct compareAndExchangeP(mRegP res, indirect mem, mRegP oldval, mRegP newval) %{
+instruct compareAndExchangeP(mRegP res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
   predicate(n->as_LoadStore()->barrier_data() == 0);
   match(Set res (CompareAndExchangeP mem (Binary oldval newval)));
   ins_cost(2 * MEMORY_REF_COST);
@@ -11963,14 +11989,14 @@ instruct compareAndExchangeP(mRegP res, indirect mem, mRegP oldval, mRegP newval
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address addr(as_Register($mem$$base));
+    Address  addr(as_Register($mem$$base), $mem$$disp);
 
     __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* barrier */, false /* weak */, true /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct compareAndExchangeN(mRegN res, indirect mem, mRegN oldval, mRegN newval) %{
+instruct compareAndExchangeN(mRegN res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
 
   match(Set res (CompareAndExchangeN mem (Binary oldval newval)));
   ins_cost(2 * MEMORY_REF_COST);
@@ -11982,13 +12008,14 @@ instruct compareAndExchangeN(mRegN res, indirect mem, mRegN oldval, mRegN newval
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address addr(as_Register($mem$$base));
+    Address  addr(as_Register($mem$$base), $mem$$disp);
+
     __ cmpxchg32(addr, oldval, newval, res, false /* sign */, false /* retold */, true /* acquire */, false /* weak */, true /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct weakCompareAndSwapI(mRegI res, indirect mem, mRegI oldval, mRegI newval) %{
+instruct weakCompareAndSwapI(mRegI res, memory_exclusive mem, mRegI oldval, mRegI newval) %{
 
   match(Set res (WeakCompareAndSwapI mem (Binary oldval newval)));
   effect(TEMP_DEF res);
@@ -12000,14 +12027,14 @@ instruct weakCompareAndSwapI(mRegI res, indirect mem, mRegI oldval, mRegI newval
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address addr(as_Register($mem$$base));
+    Address  addr(as_Register($mem$$base), $mem$$disp);
 
     __ cmpxchg32(addr, oldval, newval, res, true /* sign */, false /* retold */, true /* acquire */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct weakCompareAndSwapL(mRegI res, indirect mem, mRegL oldval, mRegL newval) %{
+instruct weakCompareAndSwapL(mRegI res, memory_exclusive mem, mRegL oldval, mRegL newval) %{
 
   match(Set res (WeakCompareAndSwapL mem (Binary oldval newval)));
   effect(TEMP_DEF res);
@@ -12019,14 +12046,14 @@ instruct weakCompareAndSwapL(mRegI res, indirect mem, mRegL oldval, mRegL newval
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address addr(as_Register($mem$$base));
+    Address  addr(as_Register($mem$$base), $mem$$disp);
 
     __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* acquire */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct weakCompareAndSwapP(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
+instruct weakCompareAndSwapP(mRegI res,  memory_exclusive mem, mRegP oldval, mRegP newval) %{
   predicate((((CompareAndSwapNode*)n)->order() != MemNode::acquire && ((CompareAndSwapNode*)n)->order() != MemNode::seqcst) && n->as_LoadStore()->barrier_data() == 0);
   match(Set res (WeakCompareAndSwapP mem (Binary oldval newval)));
   effect(TEMP_DEF res);
@@ -12038,14 +12065,14 @@ instruct weakCompareAndSwapP(mRegI res, indirect mem, mRegP oldval, mRegP newval
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address addr(as_Register($mem$$base));
+    Address  addr(as_Register($mem$$base), $mem$$disp);
 
   __ cmpxchg(addr, oldval, newval, res, false /* retold */, false /* acquire */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct weakCompareAndSwapP_acq(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
+instruct weakCompareAndSwapP_acq(mRegI res,  memory_exclusive mem, mRegP oldval, mRegP newval) %{
   predicate(n->as_LoadStore()->barrier_data() == 0);
   match(Set res (WeakCompareAndSwapP mem (Binary oldval newval)));
   effect(TEMP_DEF res);
@@ -12057,14 +12084,14 @@ instruct weakCompareAndSwapP_acq(mRegI res, indirect mem, mRegP oldval, mRegP ne
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address addr(as_Register($mem$$base));
+    Address  addr(as_Register($mem$$base), $mem$$disp);
 
     __ cmpxchg(addr, oldval, newval, res, false /* retold */, true /* acquire */, true /* weak */, false /* exchange */);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct weakCompareAndSwapN(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
+instruct weakCompareAndSwapN(mRegI res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
 
   match(Set res (WeakCompareAndSwapN mem (Binary oldval newval)));
   effect(TEMP_DEF res);
@@ -12076,7 +12103,7 @@ instruct weakCompareAndSwapN(mRegI res, indirect mem, mRegN oldval, mRegN newval
     Register newval = $newval$$Register;
     Register oldval = $oldval$$Register;
     Register res    = $res$$Register;
-    Address addr(as_Register($mem$$base));
+    Address  addr(as_Register($mem$$base), $mem$$disp);
 
     __ cmpxchg32(addr, oldval, newval, res, false /* sign */, false /* retold */, true /* acquire */, true /* weak */, false /* exchange */);
   %}

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -1346,7 +1346,7 @@ void MacroAssembler::bswap_w(Register dst, Register src) {
 }
 
 void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
-                             Register resflag, bool retold, bool barrier,
+                             Register resflag, bool retold, bool acquire,
                              bool weak, bool exchange) {
   assert(oldval != resflag, "oldval != resflag");
   assert(newval != resflag, "newval != resflag");
@@ -1369,8 +1369,11 @@ void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
   b(succ);
 
   bind(fail);
-  if (barrier)
+  if (acquire) {
+    membar(Assembler::Membar_mask_bits(LoadLoad|LoadStore));
+  } else {
     dbar(0x700);
+  }
   if (retold && oldval != R0)
     move(oldval, resflag);
   if (!exchange) {
@@ -1380,7 +1383,7 @@ void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
 }
 
 void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
-                             Register tmp, bool retold, bool barrier, Label& succ, Label* fail) {
+                             Register tmp, bool retold, bool acquire, Label& succ, Label* fail) {
   assert(oldval != tmp, "oldval != tmp");
   assert(newval != tmp, "newval != tmp");
   Label again, neq;
@@ -1394,8 +1397,11 @@ void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
   b(succ);
 
   bind(neq);
-  if (barrier)
+  if (acquire) {
+    membar(Assembler::Membar_mask_bits(LoadLoad|LoadStore));
+  } else {
     dbar(0x700);
+  }
   if (retold && oldval != R0)
     move(oldval, tmp);
   if (fail)
@@ -1403,7 +1409,7 @@ void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
 }
 
 void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval,
-                               Register resflag, bool sign, bool retold, bool barrier,
+                               Register resflag, bool sign, bool retold, bool acquire,
                                bool weak, bool exchange) {
   assert(oldval != resflag, "oldval != resflag");
   assert(newval != resflag, "newval != resflag");
@@ -1428,8 +1434,11 @@ void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval,
   b(succ);
 
   bind(fail);
-  if (barrier)
+  if (acquire) {
+    membar(Assembler::Membar_mask_bits(LoadLoad|LoadStore));
+  } else {
     dbar(0x700);
+  }
   if (retold && oldval != R0)
     move(oldval, resflag);
   if (!exchange) {
@@ -1439,7 +1448,7 @@ void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval,
 }
 
 void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval, Register tmp,
-                               bool sign, bool retold, bool barrier, Label& succ, Label* fail) {
+                               bool sign, bool retold, bool acquire, Label& succ, Label* fail) {
   assert(oldval != tmp, "oldval != tmp");
   assert(newval != tmp, "newval != tmp");
   Label again, neq;
@@ -1455,8 +1464,11 @@ void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval, R
   b(succ);
 
   bind(neq);
-  if (barrier)
+  if (acquire) {
+    membar(Assembler::Membar_mask_bits(LoadLoad|LoadStore));
+  } else {
     dbar(0x700);
+  }
   if (retold && oldval != R0)
     move(oldval, tmp);
   if (fail)

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -531,13 +531,13 @@ class MacroAssembler: public Assembler {
   void bswap_w(Register dst, Register src);
 
   void cmpxchg(Address addr, Register oldval, Register newval, Register resflag,
-               bool retold, bool barrier, bool weak = false, bool exchange = false);
+               bool retold, bool acquire, bool weak = false, bool exchange = false);
   void cmpxchg(Address addr, Register oldval, Register newval, Register tmp,
-               bool retold, bool barrier, Label& succ, Label* fail = nullptr);
+               bool retold, bool acquire, Label& succ, Label* fail = nullptr);
   void cmpxchg32(Address addr, Register oldval, Register newval, Register resflag,
-                 bool sign, bool retold, bool barrier, bool weak = false, bool exchange = false);
+                 bool sign, bool retold, bool acquire, bool weak = false, bool exchange = false);
   void cmpxchg32(Address addr, Register oldval, Register newval, Register tmp,
-                 bool sign, bool retold, bool barrier, Label& succ, Label* fail = nullptr);
+                 bool sign, bool retold, bool acquire, Label& succ, Label* fail = nullptr);
 
   void push (Register reg)      { addi_d(SP, SP, -8); st_d  (reg, SP, 0); }
   void push (FloatRegister reg) { addi_d(SP, SP, -8); fst_d (reg, SP, 0); }

--- a/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
@@ -53,8 +53,8 @@
   // the cpu only look at the lower 5/6 bits anyway?
   static const bool need_masked_shift_count = false;
 
-  // No support for generic vector operands.
-  static const bool supports_generic_vector_operands = false;
+  // LA supports generic vector operands: vReg.
+  static const bool supports_generic_vector_operands = true;
 
   static constexpr bool isSimpleConstant64(jlong value) {
     // Will one (StoreL ConL) be cheaper than two (StoreI ConI)?.

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1740,7 +1740,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ orr(swap_reg, swap_reg, AT);
 
       __ st_d(swap_reg, lock_reg, mark_word_offset);
-      __ cmpxchg(Address(obj_reg, 0), swap_reg, lock_reg, AT, true, false, count);
+      __ cmpxchg(Address(obj_reg, 0), swap_reg, lock_reg, AT, true, true /* acquire */, count);
       // Test if the oopMark is an obvious stack pointer, i.e.,
       //  1) (mark & 3) == 0, and
       //  2) sp <= mark < mark + os::pagesize()
@@ -1916,7 +1916,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ addi_d(lock_reg, FP, lock_slot_fp_offset);
       // Atomic swap old header if oop still contains the stack lock
       Label count;
-      __ cmpxchg(Address(obj_reg, 0), lock_reg, T8, AT, false, false, count, &slow_path_unlock);
+      __ cmpxchg(Address(obj_reg, 0), lock_reg, T8, AT, false, true /* acquire */, count, &slow_path_unlock);
       __ bind(count);
       __ decrement(Address(TREG, JavaThread::held_monitor_count_offset()), 1);
     } else {

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -190,11 +190,11 @@ void VM_Version::get_processor_features() {
   int min_vector_size = 0;
   if (UseLASX) {
     max_vector_size = 32;
-    min_vector_size = 16;
+    min_vector_size = 4;
   }
   else if (UseLSX) {
     max_vector_size = 16;
-    min_vector_size = 16;
+    min_vector_size = 4;
   }
 
   if (!FLAG_IS_DEFAULT(MaxVectorSize)) {

--- a/src/hotspot/os_cpu/linux_loongarch/atomic_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/atomic_linux_loongarch.hpp
@@ -167,6 +167,20 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
 
   switch (order) {
   case memory_order_relaxed:
+  case memory_order_release:
+    asm volatile (
+      "1: ll.w %[prev], %[dest]     \n\t"
+      "   bne  %[prev], %[_old], 2f \n\t"
+      "   move %[temp], %[_new]     \n\t"
+      "   sc.w %[temp], %[dest]     \n\t"
+      "   beqz %[temp], 1b          \n\t"
+      "   b    3f                   \n\t"
+      "2: dbar 0x700                \n\t"
+      "3:                           \n\t"
+      : [prev] "=&r" (prev), [temp] "=&r" (temp)
+      : [_old] "r" (compare_value), [_new] "r" (exchange_value), [dest] "ZC" (*dest)
+      : "memory");
+    break;
   default:
     asm volatile (
       "1: ll.w %[prev], %[dest]     \n\t"
@@ -175,7 +189,7 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
       "   sc.w %[temp], %[dest]     \n\t"
       "   beqz %[temp], 1b          \n\t"
       "   b    3f                   \n\t"
-      "2: dbar 0x700                 \n\t"
+      "2: dbar 0x14                \n\t"
       "3:                           \n\t"
       : [prev] "=&r" (prev), [temp] "=&r" (temp)
       : [_old] "r" (compare_value), [_new] "r" (exchange_value), [dest] "ZC" (*dest)
@@ -197,6 +211,20 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
 
   switch (order) {
   case memory_order_relaxed:
+  case memory_order_release:
+    asm volatile (
+      "1: ll.d %[prev], %[dest]     \n\t"
+      "   bne  %[prev], %[_old], 2f \n\t"
+      "   move %[temp], %[_new]     \n\t"
+      "   sc.d %[temp], %[dest]     \n\t"
+      "   beqz %[temp], 1b          \n\t"
+      "   b    3f                   \n\t"
+      "2: dbar 0x700                \n\t"
+      "3:                           \n\t"
+      : [prev] "=&r" (prev), [temp] "=&r" (temp)
+      : [_old] "r" (compare_value), [_new] "r" (exchange_value), [dest] "ZC" (*dest)
+      : "memory");
+    break;
   default:
     asm volatile (
       "1: ll.d %[prev], %[dest]     \n\t"
@@ -205,7 +233,7 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
       "   sc.d %[temp], %[dest]     \n\t"
       "   beqz %[temp], 1b          \n\t"
       "   b    3f                   \n\t"
-      "2: dbar 0x700                 \n\t"
+      "2: dbar 0x14                 \n\t"
       "3:                           \n\t"
       : [prev] "=&r" (prev), [temp] "=&r" (temp)
       : [_old] "r" (compare_value), [_new] "r" (exchange_value), [dest] "ZC" (*dest)

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -22,12 +22,6 @@
  *
  */
 
-/*
- * This file has been modified by Loongson Technology in 2021, These
- * modifications are Copyright (c) 2021, Loongson Technology, and are made
- * available on the same license terms set forth above.
- */
-
 #include "precompiled.hpp"
 #include "ci/ciMethodData.hpp"
 #include "ci/ciTypeFlow.hpp"
@@ -83,14 +77,6 @@ const Type::TypeInfo Type::_type_info[Type::lastype] = {
   { Bad,             T_ILLEGAL,    "vectord:",      false, Op_RegL,              relocInfo::none          },  // VectorD
   { Bad,             T_ILLEGAL,    "vectorx:",      false, 0,                    relocInfo::none          },  // VectorX
   { Bad,             T_ILLEGAL,    "vectory:",      false, 0,                    relocInfo::none          },  // VectorY
-  { Bad,             T_ILLEGAL,    "vectorz:",      false, 0,                    relocInfo::none          },  // VectorZ
-#elif defined(LOONGARCH64)
-  { Bad,             T_ILLEGAL,    "vectormask:",   false, Op_RegVectMask,       relocInfo::none          },  // VectorMask.
-  { Bad,             T_ILLEGAL,    "vectora:",      false, Op_VecA,              relocInfo::none          },  // VectorA.
-  { Bad,             T_ILLEGAL,    "vectors:",      false, 0,                    relocInfo::none          },  // VectorS
-  { Bad,             T_ILLEGAL,    "vectord:",      false, 0,                    relocInfo::none          },  // VectorD
-  { Bad,             T_ILLEGAL,    "vectorx:",      false, Op_VecX,              relocInfo::none          },  // VectorX
-  { Bad,             T_ILLEGAL,    "vectory:",      false, Op_VecY,              relocInfo::none          },  // VectorY
   { Bad,             T_ILLEGAL,    "vectorz:",      false, 0,                    relocInfo::none          },  // VectorZ
 #else // all other
   { Bad,             T_ILLEGAL,    "vectormask:",   false, Op_RegVectMask,       relocInfo::none          },  // VectorMask.


### PR DESCRIPTION
31942: Implement ExtractV
31838: 32 and 64 bits vector implementation
31751: Use base+disp for cmpxchg
31927: Typo in xBarrierSetAssembler_loongarch.cpp
30985: Insert acqure membar for load-exclusive with acquire
31863: [C2] Effect TEMP_DEF res for cmpxchg