### PR TITLE
Update (2023.08.30)

### DIFF
--- a/src/hotspot/cpu/loongarch/frame_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.cpp
@@ -479,7 +479,7 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
 
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method* m = safe_interpreter_frame_method();
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -8316,6 +8316,27 @@ instruct cmovF_cmpL_reg_reg(regF dst, regF src, mRegL tmp1, mRegL tmp2, cmpOp co
   ins_pipe( pipe_slow );
 %}
 
+instruct cmovD_cmpN_reg_reg(regD dst, regD src, mRegN tmp1, mRegN tmp2, cmpOp cop) %{
+  match(Set dst (CMoveD (Binary cop (CmpN tmp1 tmp2)) (Binary dst src)));
+  ins_cost(200);
+  format %{
+             "CMP$cop  $tmp1, $tmp2\t  @cmovD_cmpN_reg_reg\n"
+             "\tCMOV  $dst, $src \t @cmovD_cmpN_reg_reg"
+         %}
+
+  ins_encode %{
+    Register op1 = $tmp1$$Register;
+    Register op2 = $tmp2$$Register;
+    FloatRegister dst = as_FloatRegister($dst$$reg);
+    FloatRegister src = as_FloatRegister($src$$reg);
+    int     flag = $cop$$cmpcode;
+
+    __ cmp_cmov(op1, op2, dst, src, (MacroAssembler::CMCompare) flag, false /* is_signed */);
+  %}
+
+  ins_pipe( pipe_slow );
+%}
+
 instruct cmovD_cmpI_reg_reg(regD dst, regD src, mRegI tmp1, mRegI tmp2, cmpOp cop) %{
   match(Set dst (CMoveD (Binary cop (CmpI tmp1 tmp2)) (Binary dst src)));
   ins_cost(200);

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -2983,22 +2983,31 @@ void MacroAssembler::cmp_cmov(Register      op1,
                               Register      op2,
                               FloatRegister dst,
                               FloatRegister src,
-                              CMCompare     cmp) {
+                              CMCompare     cmp,
+                              bool          is_signed) {
   switch (cmp) {
     case EQ:
     case NE:
       sub_d(AT, op1, op2);
-      slt(AT, R0, AT);
+      sltu(AT, R0, AT);
       break;
 
     case GT:
     case LE:
-      slt(AT, op2, op1);
+      if (is_signed) {
+        slt(AT, op2, op1);
+      } else {
+        sltu(AT, op2, op1);
+      }
       break;
 
     case GE:
     case LT:
-      slt(AT, op1, op2);
+      if (is_signed) {
+        slt(AT, op1, op2);
+      } else {
+        sltu(AT, op1, op2);
+      }
       break;
 
     default:

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -635,7 +635,8 @@ class MacroAssembler: public Assembler {
                 Register        op2,
                 FloatRegister   dst,
                 FloatRegister   src,
-                CMCompare       cmp = EQ);
+                CMCompare       cmp = EQ,
+                bool      is_signed = true);
 
   void membar(Membar_mask_bits hint);
 


### PR DESCRIPTION
32093: Add CMoveD-CmpN node
32079: LA port of 8313796: AsyncGetCallTrace crash on unreadable interpreter method pointer