### PR TITLE
Update (2023.09.20)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoah_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoah_loongarch_64.ad
@@ -44,7 +44,7 @@ encode %{
   %}
 %}
 
-instruct compareAndSwapP_shenandoah(mRegI res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
+instruct compareAndSwapP_shenandoah(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahCompareAndSwapP mem (Binary oldval newval)));
 
   format %{
@@ -56,7 +56,7 @@ instruct compareAndSwapP_shenandoah(mRegI res, memory_exclusive mem, mRegP oldva
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndSwapN_shenandoah(mRegI res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
+instruct compareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahCompareAndSwapN mem (Binary oldval newval)));
 
   format %{
@@ -72,7 +72,7 @@ instruct compareAndSwapN_shenandoah(mRegI res, memory_exclusive mem, mRegN oldva
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndSwapPAcq_shenandoah(mRegI res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
+instruct compareAndSwapPAcq_shenandoah(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahCompareAndSwapP mem (Binary oldval newval)));
 
   format %{
@@ -84,7 +84,7 @@ instruct compareAndSwapPAcq_shenandoah(mRegI res, memory_exclusive mem, mRegP ol
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndSwapNAcq_shenandoah(mRegI res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
+instruct compareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahCompareAndSwapN mem (Binary oldval newval)));
 
  format %{
@@ -100,7 +100,7 @@ instruct compareAndSwapNAcq_shenandoah(mRegI res, memory_exclusive mem, mRegN ol
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndExchangeN_shenandoah(mRegN res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
+instruct compareAndExchangeN_shenandoah(mRegN res, indirect mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahCompareAndExchangeN mem (Binary oldval newval)));
 
   format %{
@@ -116,7 +116,7 @@ instruct compareAndExchangeN_shenandoah(mRegN res, memory_exclusive mem, mRegN o
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndExchangeP_shenandoah(mRegP res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
+instruct compareAndExchangeP_shenandoah(mRegP res, indirect mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahCompareAndExchangeP mem (Binary oldval newval)));
 
   format %{
@@ -132,7 +132,7 @@ instruct compareAndExchangeP_shenandoah(mRegP res, memory_exclusive mem, mRegP o
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndExchangeNAcq_shenandoah(mRegN res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
+instruct compareAndExchangeNAcq_shenandoah(mRegN res, indirect mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahCompareAndExchangeN mem (Binary oldval newval)));
 
   format %{
@@ -148,7 +148,7 @@ instruct compareAndExchangeNAcq_shenandoah(mRegN res, memory_exclusive mem, mReg
   ins_pipe(pipe_slow);
 %}
 
-instruct compareAndExchangePAcq_shenandoah(mRegP res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
+instruct compareAndExchangePAcq_shenandoah(mRegP res, indirect mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahCompareAndExchangeP mem (Binary oldval newval)));
 
   format %{
@@ -164,7 +164,7 @@ instruct compareAndExchangePAcq_shenandoah(mRegP res, memory_exclusive mem, mReg
   ins_pipe(pipe_slow);
 %}
 
-instruct weakCompareAndSwapN_shenandoah(mRegI res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
+instruct weakCompareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahWeakCompareAndSwapN mem (Binary oldval newval)));
 
   format %{
@@ -180,7 +180,7 @@ instruct weakCompareAndSwapN_shenandoah(mRegI res, memory_exclusive mem, mRegN o
   ins_pipe(pipe_slow);
 %}
 
-instruct weakCompareAndSwapP_shenandoah(mRegI res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
+instruct weakCompareAndSwapP_shenandoah(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahWeakCompareAndSwapP mem (Binary oldval newval)));
 
   format %{
@@ -197,7 +197,7 @@ instruct weakCompareAndSwapP_shenandoah(mRegI res, memory_exclusive mem, mRegP o
   ins_pipe(pipe_slow);
 %}
 
-instruct weakCompareAndSwapNAcq_shenandoah(mRegI res, memory_exclusive mem, mRegN oldval, mRegN newval) %{
+instruct weakCompareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN newval) %{
   match(Set res (ShenandoahWeakCompareAndSwapN mem (Binary oldval newval)));
 
   format %{
@@ -214,7 +214,7 @@ instruct weakCompareAndSwapNAcq_shenandoah(mRegI res, memory_exclusive mem, mReg
   ins_pipe(pipe_slow);
 %}
 
-instruct weakCompareAndSwapPAcq_shenandoah(mRegI res, memory_exclusive mem, mRegP oldval, mRegP newval) %{
+instruct weakCompareAndSwapPAcq_shenandoah(mRegI res, indirect mem, mRegP oldval, mRegP newval) %{
   match(Set res (ShenandoahWeakCompareAndSwapP mem (Binary oldval newval)));
 
   format %{

--- a/src/hotspot/cpu/loongarch/gc/x/x_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/x/x_loongarch_64.ad
@@ -248,12 +248,7 @@ instruct xGetAndSetP(mRegP mem, mRegP newv, mRegP prev, mRegP tmp) %{
     Register newv = $newv$$Register;
     Register addr = $mem$$Register;
     __ block_comment("xGetAndSetP");
-    if (prev == newv || prev == addr) {
-      __ amswap_db_d(AT, newv, addr);
-      __ move(prev, AT);
-    } else {
-      __ amswap_db_d(prev, newv, addr);
-    }
+    __ amswap_db_d(prev, newv, addr);
     x_load_barrier(_masm, this, Address(noreg, 0), prev, $tmp$$Register, barrier_data());
   %}
 

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -11955,36 +11955,30 @@ instruct compareAndSwapN(mRegI res, indirect mem_ptr, mRegN oldval, mRegN newval
 
 instruct get_and_setI(indirect mem, mRegI newv, mRegI prev) %{
   match(Set prev (GetAndSetI mem newv));
+  effect(TEMP_DEF prev);
   ins_cost(2 * MEMORY_REF_COST);
-  format %{ "amswap_db_w $prev, $newv, [$mem]" %}
+  format %{ "amswap_db_w $prev, $newv, [$mem] @get_and_setI" %}
   ins_encode %{
     Register prev = $prev$$Register;
     Register newv = $newv$$Register;
     Register addr = as_Register($mem$$base);
-    if (prev == newv || prev == addr) {
-      __ amswap_db_w(AT, newv, addr);
-      __ move(prev, AT);
-    } else {
-      __ amswap_db_w(prev, newv, addr);
-    }
+
+    __ amswap_db_w(prev, newv, addr);
   %}
   ins_pipe( pipe_serial );
 %}
 
 instruct get_and_setL(indirect mem, mRegL newv, mRegL prev) %{
   match(Set prev (GetAndSetL mem newv));
+  effect(TEMP_DEF prev);
   ins_cost(2 * MEMORY_REF_COST);
-  format %{ "amswap_db_d $prev, $newv, [$mem]" %}
+  format %{ "amswap_db_d $prev, $newv, [$mem] @get_and_setL" %}
   ins_encode %{
     Register prev = $prev$$Register;
     Register newv = $newv$$Register;
     Register addr = as_Register($mem$$base);
-    if (prev == newv || prev == addr) {
-      __ amswap_db_d(AT, newv, addr);
-      __ move(prev, AT);
-    } else {
-      __ amswap_db_d(prev, newv, addr);
-    }
+
+    __ amswap_db_d(prev, newv, addr);
   %}
   ins_pipe( pipe_serial );
 %}
@@ -11992,7 +11986,7 @@ instruct get_and_setL(indirect mem, mRegL newv, mRegL prev) %{
 instruct get_and_setN(indirect mem, mRegN newv, mRegN prev) %{
   match(Set prev (GetAndSetN mem newv));
   ins_cost(2 * MEMORY_REF_COST);
-  format %{ "amswap_db_w $prev, $newv, [$mem]" %}
+  format %{ "amswap_db_w $prev, $newv, [$mem] @get_and_setN" %}
   ins_encode %{
     Register prev = $prev$$Register;
     Register newv = $newv$$Register;
@@ -12005,36 +11999,30 @@ instruct get_and_setN(indirect mem, mRegN newv, mRegN prev) %{
 
 instruct get_and_setP(indirect mem, mRegP newv, mRegP prev) %{
   match(Set prev (GetAndSetP mem newv));
+  effect(TEMP_DEF prev);
   ins_cost(2 * MEMORY_REF_COST);
-  format %{ "amswap_db_d $prev, $newv, [$mem]" %}
+  format %{ "amswap_db_d $prev, $newv, [$mem] @get_and_setP" %}
   ins_encode %{
     Register prev = $prev$$Register;
     Register newv = $newv$$Register;
     Register addr = as_Register($mem$$base);
-    if (prev == newv || prev == addr) {
-      __ amswap_db_d(AT, newv, addr);
-      __ move(prev, AT);
-    } else {
-      __ amswap_db_d(prev, newv, addr);
-    }
+
+    __ amswap_db_d(prev, newv, addr);
   %}
   ins_pipe( pipe_serial );
 %}
 
 instruct get_and_addL(indirect mem, mRegL newval, mRegL incr) %{
   match(Set newval (GetAndAddL mem incr));
+  effect(TEMP_DEF newval);
   ins_cost(2 * MEMORY_REF_COST + 1);
-  format %{ "amadd_db_d $newval, [$mem], $incr" %}
+  format %{ "amadd_db_d $newval, [$mem], $incr @get_and_addL" %}
   ins_encode %{
     Register newv = $newval$$Register;
     Register incr = $incr$$Register;
     Register addr = as_Register($mem$$base);
-    if (newv == incr || newv == addr) {
-      __ amadd_db_d(AT, incr, addr);
-      __ move(newv, AT);
-    } else {
-      __ amadd_db_d(newv, incr, addr);
-    }
+
+    __ amadd_db_d(newv, incr, addr);
   %}
   ins_pipe( pipe_serial );
 %}
@@ -12043,7 +12031,7 @@ instruct get_and_addL_no_res(indirect mem, Universe dummy, mRegL incr) %{
   predicate(n->as_LoadStore()->result_not_used());
   match(Set dummy (GetAndAddL mem incr));
   ins_cost(2 * MEMORY_REF_COST);
-  format %{ "amadd_db_d [$mem], $incr" %}
+  format %{ "amadd_db_d [$mem], $incr @get_and_addL_no_res" %}
   ins_encode %{
     __ amadd_db_d(R0, $incr$$Register, as_Register($mem$$base));
   %}
@@ -12052,18 +12040,15 @@ instruct get_and_addL_no_res(indirect mem, Universe dummy, mRegL incr) %{
 
 instruct get_and_addI(indirect mem, mRegI newval, mRegIorL2I incr) %{
   match(Set newval (GetAndAddI mem incr));
+  effect(TEMP_DEF newval);
   ins_cost(2 * MEMORY_REF_COST + 1);
-  format %{ "amadd_db_w $newval, [$mem], $incr" %}
+  format %{ "amadd_db_w $newval, [$mem], $incr @get_and_addI" %}
   ins_encode %{
     Register newv = $newval$$Register;
     Register incr = $incr$$Register;
     Register addr = as_Register($mem$$base);
-    if (newv == incr || newv == addr) {
-      __ amadd_db_w(AT, incr, addr);
-      __ move(newv, AT);
-    } else {
-      __ amadd_db_w(newv, incr, addr);
-    }
+
+    __ amadd_db_w(newv, incr, addr);
   %}
   ins_pipe( pipe_serial );
 %}
@@ -12072,7 +12057,7 @@ instruct get_and_addI_no_res(indirect mem, Universe dummy, mRegIorL2I incr) %{
   predicate(n->as_LoadStore()->result_not_used());
   match(Set dummy (GetAndAddI mem incr));
   ins_cost(2 * MEMORY_REF_COST);
-  format %{ "amadd_db_w [$mem], $incr" %}
+  format %{ "amadd_db_w [$mem], $incr @get_and_addI_no_res" %}
   ins_encode %{
     __ amadd_db_w(R0, $incr$$Register, as_Register($mem$$base));
   %}

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -311,9 +311,9 @@ void RegisterSaver::restore_result_registers(MacroAssembler* masm) {
 }
 
 // Is vector's size (in bytes) bigger than a size saved by default?
-// 16 bytes XMM registers are saved by default using fxsave/fxrstor instructions.
+// 8 bytes registers are saved by default using fld/fst instructions.
 bool SharedRuntime::is_wide_vector(int size) {
-  return size > 16;
+  return size > 8;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
32268: [shenandoah] Use indirect memory operand for cmpxchg
32266: [C2] Effect TEMP_DEF res for get_and_set/add
32163: The size of is_wide_vector should be greater than 8 bytes