### PR TITLE
Update (2023.09.20)

### DIFF
--- a/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
@@ -919,6 +919,8 @@ class Assembler : public AbstractAssembler  {
     vnor_v_op          = 0b01110001001001111,
     vandn_v_op         = 0b01110001001010000,
     vorn_v_op          = 0b01110001001010001,
+    vfrstp_b_op        = 0b01110001001010110,
+    vfrstp_h_op        = 0b01110001001010111,
     vadd_q_op          = 0b01110001001011010,
     vsub_q_op          = 0b01110001001011011,
     vfadd_s_op         = 0b01110001001100001,
@@ -956,6 +958,8 @@ class Assembler : public AbstractAssembler  {
     vsubi_hu_op        = 0b01110010100011001,
     vsubi_wu_op        = 0b01110010100011010,
     vsubi_du_op        = 0b01110010100011011,
+    vfrstpi_b_op       = 0b01110010100110100,
+    vfrstpi_h_op       = 0b01110010100110101,
     vrotri_w_op        = 0b01110010101000001,
     vbitclri_w_op      = 0b01110011000100001,
     vbitseti_w_op      = 0b01110011000101001,
@@ -964,8 +968,6 @@ class Assembler : public AbstractAssembler  {
     vsrli_w_op         = 0b01110011001100001,
     vsrai_w_op         = 0b01110011001101001,
     vsrlni_h_w_op      = 0b01110011010000001,
-    vfrstpi_b_op       = 0b01110010100110100,
-    vfrstpi_h_op       = 0b01110010100110101,
     xvseq_b_op         = 0b01110100000000000,
     xvseq_h_op         = 0b01110100000000001,
     xvseq_w_op         = 0b01110100000000010,
@@ -1084,6 +1086,8 @@ class Assembler : public AbstractAssembler  {
     xvnor_v_op         = 0b01110101001001111,
     xvandn_v_op        = 0b01110101001010000,
     xvorn_v_op         = 0b01110101001010001,
+    xvfrstp_b_op       = 0b01110101001010110,
+    xvfrstp_h_op       = 0b01110101001010111,
     xvadd_q_op         = 0b01110101001011010,
     xvsub_q_op         = 0b01110101001011011,
     xvfadd_s_op        = 0b01110101001100001,
@@ -1122,6 +1126,8 @@ class Assembler : public AbstractAssembler  {
     xvsubi_hu_op       = 0b01110110100011001,
     xvsubi_wu_op       = 0b01110110100011010,
     xvsubi_du_op       = 0b01110110100011011,
+    xvfrstpi_b_op      = 0b01110110100110100,
+    xvfrstpi_h_op      = 0b01110110100110101,
     xvrotri_w_op       = 0b01110110101000001,
     xvbitclri_w_op     = 0b01110111000100001,
     xvbitseti_w_op     = 0b01110111000101001,
@@ -2605,8 +2611,15 @@ public:
   void xvbitrevi_w(FloatRegister xd, FloatRegister xj, int ui5) { ASSERT_LASX emit_int32(insn_I5RR(xvbitrevi_w_op, ui5, (int)xj->encoding(), (int)xd->encoding())); }
   void xvbitrevi_d(FloatRegister xd, FloatRegister xj, int ui6) { ASSERT_LASX emit_int32(insn_I6RR(xvbitrevi_d_op, ui6, (int)xj->encoding(), (int)xd->encoding())); }
 
+  void  vfrstp_b(FloatRegister vd, FloatRegister vj, FloatRegister vk) { ASSERT_LSX  emit_int32(insn_RRR( vfrstp_b_op, (int)vk->encoding(), (int)vj->encoding(), (int)vd->encoding())); }
+  void  vfrstp_h(FloatRegister vd, FloatRegister vj, FloatRegister vk) { ASSERT_LSX  emit_int32(insn_RRR( vfrstp_h_op, (int)vk->encoding(), (int)vj->encoding(), (int)vd->encoding())); }
+  void xvfrstp_b(FloatRegister xd, FloatRegister xj, FloatRegister xk) { ASSERT_LASX emit_int32(insn_RRR(xvfrstp_b_op, (int)xk->encoding(), (int)xj->encoding(), (int)xd->encoding())); }
+  void xvfrstp_h(FloatRegister xd, FloatRegister xj, FloatRegister xk) { ASSERT_LASX emit_int32(insn_RRR(xvfrstp_h_op, (int)xk->encoding(), (int)xj->encoding(), (int)xd->encoding())); }
+
   void  vfrstpi_b(FloatRegister vd, FloatRegister vj, int ui5) { ASSERT_LSX  emit_int32(insn_I5RR( vfrstpi_b_op, ui5, (int)vj->encoding(), (int)vd->encoding())); }
   void  vfrstpi_h(FloatRegister vd, FloatRegister vj, int ui5) { ASSERT_LSX  emit_int32(insn_I5RR( vfrstpi_h_op, ui5, (int)vj->encoding(), (int)vd->encoding())); }
+  void xvfrstpi_b(FloatRegister xd, FloatRegister xj, int ui5) { ASSERT_LASX emit_int32(insn_I5RR(xvfrstpi_b_op, ui5, (int)xj->encoding(), (int)xd->encoding())); }
+  void xvfrstpi_h(FloatRegister xd, FloatRegister xj, int ui5) { ASSERT_LASX emit_int32(insn_I5RR(xvfrstpi_h_op, ui5, (int)xj->encoding(), (int)xd->encoding())); }
 
   void  vfadd_s(FloatRegister vd, FloatRegister vj, FloatRegister vk) { ASSERT_LSX  emit_int32(insn_RRR( vfadd_s_op, (int)vk->encoding(), (int)vj->encoding(), (int)vd->encoding())); }
   void  vfadd_d(FloatRegister vd, FloatRegister vj, FloatRegister vk) { ASSERT_LSX  emit_int32(insn_RRR( vfadd_d_op, (int)vk->encoding(), (int)vj->encoding(), (int)vd->encoding())); }

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -9479,6 +9479,13 @@ instruct divI_Reg_Reg(mRegI dst, mRegI src1, mRegI src2) %{
   ins_pipe( ialu_div );
 %}
 
+// =================== DivMod nodes ==========================
+//
+// Since we already have the `div` result here,
+// combining the `mul` and the `sub` to calculate
+// the remainder is more efficient than
+// applying the `mod` instruction directly.
+//
 instruct divmodI_Reg_Reg(mT1RegI div, mT2RegI mod, mRegI src1, mRegI src2) %{
   match(DivModI src1 src2);
   effect(TEMP_DEF div, TEMP_DEF mod);
@@ -9492,9 +9499,10 @@ instruct divmodI_Reg_Reg(mT1RegI div, mT2RegI mod, mRegI src1, mRegI src2) %{
      Register mod  = $mod$$Register;
 
     __ div_w(div, src1, src2);
-    __ mod_w(mod, src1, src2);
-
+    __ mul_w(mod, div, src2);
+    __ sub_w(mod, src1, mod);
   %}
+
   ins_pipe( ialu_div );
 %}
 
@@ -9511,9 +9519,10 @@ instruct udivmodI_Reg_Reg(mT1RegI div, mT2RegI mod, mRegI src1, mRegI src2) %{
      Register mod  = $mod$$Register;
 
     __ div_wu(div, src1, src2);
-    __ mod_wu(mod, src1, src2);
-
+    __ mul_w(mod, div, src2);
+    __ sub_w(mod, src1, mod);
   %}
+
   ins_pipe( ialu_div );
 %}
 
@@ -9530,9 +9539,10 @@ instruct divmodL_Reg_Reg(t1RegL div, t2RegL mod, mRegL src1, mRegL src2) %{
      Register mod  = $mod$$Register;
 
     __ div_d(div, src1, src2);
-    __ mod_d(mod, src1, src2);
-
+    __ mul_d(mod, div, src2);
+    __ sub_d(mod, src1, mod);
   %}
+
   ins_pipe( ialu_div );
 %}
 
@@ -9549,11 +9559,14 @@ instruct udivmodL_Reg_Reg(t1RegL div, t2RegL mod, mRegL src1, mRegL src2) %{
      Register mod  = $mod$$Register;
 
     __ div_du(div, src1, src2);
-    __ mod_du(mod, src1, src2);
-
+    __ mul_d(mod, div, src2);
+    __ sub_d(mod, src1, mod);
   %}
+
   ins_pipe( ialu_div );
 %}
+
+// =================== End of DivMod nodes ==========================
 
 instruct udivI_Reg_Reg(mRegI dst, mRegI src1, mRegI src2) %{
   match(Set dst (UDivI src1 src2));

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -10251,7 +10251,8 @@ instruct orL_Reg_P2XReg(mRegL dst, mRegP src1, mRegLorI2L src2) %{
 %}
 
 // Xor Long Register with Register
-instruct xorL_Reg_Reg(mRegL dst, mRegL src1, mRegL src2) %{
+
+instruct xorL_Reg_Reg(mRegL dst, mRegLorI2L src1, mRegLorI2L src2) %{
   match(Set dst (XorL src1 src2));
   format %{ "XOR    $dst, $src1, $src2 @ xorL_Reg_Reg\t" %}
   ins_encode %{
@@ -10260,6 +10261,15 @@ instruct xorL_Reg_Reg(mRegL dst, mRegL src1, mRegL src2) %{
     Register src2_reg = as_Register($src2$$reg);
 
     __ xorr(dst_reg, src1_reg, src2_reg);
+  %}
+  ins_pipe( ialu_reg_reg );
+%}
+
+instruct xorL_Reg_P2XReg(mRegL dst, mRegP src1, mRegLorI2L src2) %{
+  match(Set dst (XorL (CastP2X src1) src2));
+  format %{ "XOR    $dst, $src1, $src2 @ xorL_Reg_P2XReg\t" %}
+  ins_encode %{
+    __ xorr($dst$$Register, $src1$$Register, $src2$$Register);
   %}
   ins_pipe( ialu_reg_reg );
 %}

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -15341,13 +15341,13 @@ instruct mask_truecountV(mRegI dst, vReg src, vReg tmp) %{
 
 // ----------------------------- VectorMaskFirstTrue ----------------------------
 
-instruct mask_firsttrue_le16B(mRegI dst, vReg src) %{
-  predicate(Matcher::vector_length(n->in(1)) <= 16);
+instruct mask_first_trueV(mRegI dst, vReg src, vReg tmp) %{
   match(Set dst (VectorMaskFirstTrue src));
-  format %{ "(x)vmask_firsttrue    $dst, $src\t# @mask_firsttrue_le16B" %}
+  effect(TEMP tmp);
+  format %{ "(x)vmask_first_true    $dst, $src\t# TEMP($tmp) @mask_first_trueV" %}
   ins_encode %{
     // Returns the index of the first active lane of the
-    // vector mask, or 4/8/16 (VLENGTH) if no lane is active.
+    // vector mask, or 4/8/16/32 (VLENGTH) if no lane is active.
     //
     // Input "src" is a vector of boolean represented as
     // bytes with 0x00/0x01 as element values.
@@ -15361,22 +15361,20 @@ instruct mask_firsttrue_le16B(mRegI dst, vReg src) %{
       __ ctz_d($dst$$Register, $dst$$Register);
       __ srli_w($dst$$Register, $dst$$Register, 3);
     } else if (Matcher::vector_length(this, $src) == 16) {
-      Label FIRST_TRUE_INDEX;
-
-      // Try to compute the result from lower 64 bits.
-      __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-      __ li(AT, (long)0);
-      __ bnez($dst$$Register, FIRST_TRUE_INDEX);
-
-      // Compute the result from the higher 64 bits.
-      __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-      __ li(AT, (long)8);
-
-      // Count the Trailing zero bytes.
-      __ bind(FIRST_TRUE_INDEX);
-      __ ctz_d($dst$$Register, $dst$$Register);
-      __ srli_w($dst$$Register, $dst$$Register, 3);
-      __ add_w($dst$$Register, AT, $dst$$Register);
+      __ vneg_b(fscratch, $src$$FloatRegister);
+      __ vfrstpi_b(fscratch, fscratch, 0);
+      __ vpickve2gr_b($dst$$Register, fscratch, 0);
+    } else if (Matcher::vector_length(this, $src) == 32) {
+      Label DONE;
+      __ xvneg_b($tmp$$FloatRegister, $src$$FloatRegister);
+      __ xvfrstpi_b($tmp$$FloatRegister, $tmp$$FloatRegister, 0);
+      __ xvpermi_q(fscratch, $tmp$$FloatRegister, 0x01);
+      __ vpickve2gr_b($dst$$Register, $tmp$$FloatRegister, 0);
+      __ li(AT, (long)16);
+      __ blt($dst$$Register, AT, DONE);
+      __ vpickve2gr_b($dst$$Register, fscratch, 0);
+      __ add_w($dst$$Register, $dst$$Register, AT);
+      __ bind(DONE);
     } else {
       ShouldNotReachHere();
     }
@@ -15384,53 +15382,11 @@ instruct mask_firsttrue_le16B(mRegI dst, vReg src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmask_firsttrue32B(mRegI dst, vReg src) %{
-  predicate(Matcher::vector_length(n->in(1)) == 32);
-  match(Set dst (VectorMaskFirstTrue src));
-  format %{ "(x)vmask_firsttrue    $dst, $src\t# @vmask_firsttrue32B" %}
-  ins_encode %{
-    // Returns the index of the first active lane of the
-    // vector mask, or 32 (VLENGTH) if no lane is active.
-    //
-    // Input "src" is a vector of boolean represented as
-    // bytes with 0x00/0x01 as element values.
-
-    Label FIRST_TRUE_INDEX;
-
-    // Try to compute the result from lower 64 bits.
-    __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-    __ li(AT, (long)0);
-    __ bnez($dst$$Register, FIRST_TRUE_INDEX);
-
-    // Compute the result from the mid-lower 64 bits.
-    __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-    __ li(AT, (long)8);
-    __ bnez($dst$$Register, FIRST_TRUE_INDEX);
-
-    // Compute the result from the mid-higher 64 bits.
-    __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 2);
-    __ li(AT, (long)16);
-    __ bnez($dst$$Register, FIRST_TRUE_INDEX);
-
-    // Compute the result from the higher 64 bits.
-    __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 3);
-    __ li(AT, (long)24);
-
-    // Count the Trailing zero bytes.
-    __ bind(FIRST_TRUE_INDEX);
-    __ ctz_d($dst$$Register, $dst$$Register);
-    __ srli_w($dst$$Register, $dst$$Register, 3);
-    __ add_w($dst$$Register, AT, $dst$$Register);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
 // ----------------------------- VectorMaskLastTrue ----------------------------
 
-instruct mask_lasttrue_le16B(mRegI dst, vReg src) %{
-  predicate(Matcher::vector_length(n->in(1)) <= 16);
+instruct mask_last_trueV(mRegI dst, vReg src) %{
   match(Set dst (VectorMaskLastTrue src));
-  format %{ "(x)vmask_lasttrue    $dst, $src\t# @mask_lasttrue_le16B" %}
+  format %{ "(x)vmask_last_true    $dst, $src\t# @mask_last_trueV" %}
   ins_encode %{
     // Returns the index of the last active lane of the
     // vector mask, or -1 if no lane is active.
@@ -15452,65 +15408,39 @@ instruct mask_lasttrue_le16B(mRegI dst, vReg src) %{
       __ sub_w($dst$$Register, R0, $dst$$Register);
     } else if (Matcher::vector_length(this, $src) == 16) {
       Label FIRST_TRUE_INDEX;
-
-      // Try to compute the result from higher 64 bits.
       __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-      __ li(AT, (long)16 - 1);
+      __ li(AT, (long)15);
       __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
-      // Compute the result from the lower 64 bits.
       __ vpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-      __ li(AT, (long)8 - 1);
-
-      // Count the Trailing zero bytes.
+      __ li(AT, (long)7);
       __ bind(FIRST_TRUE_INDEX);
       __ clz_d($dst$$Register, $dst$$Register);
       __ srli_w($dst$$Register, $dst$$Register, 3);
       __ sub_w($dst$$Register, AT, $dst$$Register);
-    } else {
-      ShouldNotReachHere();
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct vmask_lasttrue32B(mRegI dst, vReg src) %{
-  predicate(Matcher::vector_length(n->in(1)) == 32 && Matcher::vector_element_basic_type(n->in(1)) == T_BOOLEAN);
-  match(Set dst (VectorMaskLastTrue src));
-  format %{ "(x)vmask_lasttrue    $dst, $src\t# @vmask_lasttrue32B" %}
-  ins_encode %{
-    // Returns the index of the last active lane of the
-    // vector mask, or -1 if no lane is active.
-    //
-    // Input "src" is a vector of boolean represented as
-    // bytes with 0x00/0x01 as element values.
-
+    } else if (Matcher::vector_length(this, $src) == 32) {
     Label FIRST_TRUE_INDEX;
-
-    // Try to compute the result from higher 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 3);
-    __ li(AT, (long)32 - 1);
+    __ li(AT, (long)31);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
-    // Compute the result from the mid-higher 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 2);
-    __ li(AT, (long)24 - 1);
+    __ li(AT, (long)23);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
-    // Compute the result from the mid-lower 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 1);
-    __ li(AT, (long)16 - 1);
+    __ li(AT, (long)15);
     __ bnez($dst$$Register, FIRST_TRUE_INDEX);
 
-    // Compute the result from the lower 64 bits.
     __ xvpickve2gr_d($dst$$Register, $src$$FloatRegister, 0);
-    __ li(AT, (long)8 - 1);
-
-    // Count the Trailing zero bytes.
+    __ li(AT, (long)7);
     __ bind(FIRST_TRUE_INDEX);
     __ clz_d($dst$$Register, $dst$$Register);
     __ srli_w($dst$$Register, $dst$$Register, 3);
     __ sub_w($dst$$Register, AT, $dst$$Register);
+    } else {
+      ShouldNotReachHere();
+    }
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -5577,7 +5577,7 @@ instruct branchConP_0_long(cmpOpEqNe cmp, mRegP op1, immP_0 zero, label labl) %{
 
 instruct branchConN2P_0_long(cmpOpEqNe cmp, mRegN op1, immP_0 zero, label labl) %{
   match(If cmp (CmpP (DecodeN op1) zero));
-  predicate(CompressedOops::base() == nullptr && CompressedOops::shift() == 0);
+  predicate(CompressedOops::base() == nullptr);
   effect(USE labl);
 
   ins_cost(180);
@@ -6048,7 +6048,7 @@ instruct branchConP_0_short(cmpOpEqNe cmp, mRegP op1, immP_0 zero, label labl) %
 
 instruct branchConN2P_0_short(cmpOpEqNe cmp, mRegN op1, immP_0 zero, label labl) %{
   match(If cmp (CmpP (DecodeN op1) zero));
-  predicate(CompressedOops::base() == nullptr && CompressedOops::shift() == 0);
+  predicate(CompressedOops::base() == nullptr);
   effect(USE labl);
 
   ins_cost(180);

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1161,7 +1161,11 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
 
 // Max vector size in bytes. 0 if not supported.
 int Matcher::vector_width_in_bytes(BasicType bt) {
-  return (int)MaxVectorSize;
+  int size = (int)MaxVectorSize;
+  if (size < 2*type2aelembytes(bt)) size = 0;
+  // But never < 4
+  if (size < 4) size = 0;
+  return size;
 }
 
 // Limits on vector size (number of elements) loaded into vector.

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -43,6 +43,7 @@
 #include "runtime/arguments.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/frame.inline.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
@@ -1362,12 +1363,15 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   __ li(t, _thread_in_native_trans);
   if (os::is_MP()) {
     __ addi_d(AT, TREG, in_bytes(JavaThread::thread_state_offset()));
-    __ amswap_db_w(R0, t, AT);
+    __ amswap_db_w(R0, t, AT); // Release-Store
+
+    // Force this write out before the read below
+    if (!UseSystemMemoryBarrier) {
+      __ membar(__ AnyAny);
+    }
   } else {
     __ st_w(t, TREG, in_bytes(JavaThread::thread_state_offset()));
   }
-
-  if( os::is_MP() )  __ membar(__ AnyAny);
 
   // check for safepoint operation in progress and/or pending suspend requests
   { Label Continue;

--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "precompiled.hpp"
 #include "logging/log.hpp"
 #include "runtime/os.hpp"
@@ -43,6 +49,8 @@
   #define SYS_membarrier 283
   #elif defined(ALPHA)
   #define SYS_membarrier 517
+  #elif defined(LOONGARCH)
+  #define SYS_membarrier 283
   #else
   #error define SYS_membarrier for the arch
   #endif


### PR DESCRIPTION
32446: Fix the error of assert(v_align > 1) when MaxVectorSize is 4 or 8
30382: LA port of 8292591: Experimentally add back barrier-less Java thread transitions
32377: Optimize VectorMaskFirstTrue
32328: implement the intrinsic of ShiftRightImplWork
32365: Support comparison of DecodeN with zero
24480: [LA][C2] Eliminate unnecessary CastP2X
32304: Decompose the rem calculation in the DivMod nodes