### PR TITLE
Update (2023.09.21)

### DIFF
--- a/src/hotspot/cpu/loongarch/continuationFreezeThaw_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/continuationFreezeThaw_loongarch.inline.hpp
@@ -83,7 +83,7 @@ template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& calle
   intptr_t *sp, *fp; // sp is really our unextended_sp
   if (FKind::interpreted) {
     assert((intptr_t*)f.at(frame::interpreter_frame_last_sp_offset) == nullptr
-      || f.unextended_sp() == (intptr_t*)f.at(frame::interpreter_frame_last_sp_offset), "");
+      || f.unextended_sp() == (intptr_t*)f.at_relative(frame::interpreter_frame_last_sp_offset), "");
     intptr_t locals_offset = *f.addr_at(frame::interpreter_frame_locals_offset);
     // If the caller.is_empty(), i.e. we're freezing into an empty chunk, then we set
     // the chunk's argsize in finalize_freeze and make room for it above the unextended_sp
@@ -122,7 +122,7 @@ template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& calle
 
 void FreezeBase::adjust_interpreted_frame_unextended_sp(frame& f) {
   assert((f.at(frame::interpreter_frame_last_sp_offset) != 0) || (f.unextended_sp() == f.sp()), "");
-  intptr_t* real_unextended_sp = (intptr_t*)f.at(frame::interpreter_frame_last_sp_offset);
+  intptr_t* real_unextended_sp = (intptr_t*)f.at_relative_or_null(frame::interpreter_frame_last_sp_offset);
   if (real_unextended_sp != nullptr) {
     f.set_unextended_sp(real_unextended_sp); // can be null at a safepoint
   }
@@ -143,8 +143,8 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
     || (f.unextended_sp() == f.sp()), "");
   assert(f.fp() > (intptr_t*)f.at(frame::interpreter_frame_initial_sp_offset), "");
 
-  // at(frame::interpreter_frame_last_sp_offset) can be null at safepoint preempts
-  *hf.addr_at(frame::interpreter_frame_last_sp_offset) = hf.unextended_sp() - hf.fp();
+  // Make sure that last_sp is already relativized.
+  assert((intptr_t*)hf.at_relative(frame::interpreter_frame_last_sp_offset) == hf.unextended_sp(), "");
 
   relativize_one(vfp, hfp, frame::interpreter_frame_initial_sp_offset); // == block_top == block_bottom
 
@@ -277,7 +277,9 @@ static inline void derelativize_one(intptr_t* const fp, int offset) {
 inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
   intptr_t* vfp = f.fp();
 
-  derelativize_one(vfp, frame::interpreter_frame_last_sp_offset);
+  // Make sure that last_sp is kept relativized.
+  assert((intptr_t*)f.at_relative(frame::interpreter_frame_last_sp_offset) == f.unextended_sp(), "");
+
   derelativize_one(vfp, frame::interpreter_frame_initial_sp_offset);
 }
 

--- a/src/hotspot/cpu/loongarch/continuationHelper_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/continuationHelper_loongarch.inline.hpp
@@ -126,7 +126,8 @@ inline intptr_t* ContinuationHelper::InterpretedFrame::frame_top(const frame& f,
   assert(res == (intptr_t*)f.interpreter_frame_monitor_end() - expression_stack_sz, "");
   assert(res >= f.unextended_sp(),
     "res: " INTPTR_FORMAT " initial_sp: " INTPTR_FORMAT " last_sp: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " expression_stack_size: %d",
-    p2i(res), p2i(f.addr_at(frame::interpreter_frame_initial_sp_offset)), f.at(frame::interpreter_frame_last_sp_offset), p2i(f.unextended_sp()), expression_stack_sz);
+    p2i(res), p2i(f.addr_at(frame::interpreter_frame_initial_sp_offset)), f.at_relative_or_null(frame::interpreter_frame_last_sp_offset),
+    p2i(f.unextended_sp()), expression_stack_sz);
   return res;
 }
 

--- a/src/hotspot/cpu/loongarch/frame_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.cpp
@@ -327,8 +327,10 @@ void frame::interpreter_frame_set_monitor_end(BasicObjectLock* value) {
 }
 
 // Used by template based interpreter deoptimization
-void frame::interpreter_frame_set_last_sp(intptr_t* sp) {
-  *((intptr_t**)addr_at(interpreter_frame_last_sp_offset)) = sp;
+void frame::interpreter_frame_set_last_sp(intptr_t* last_sp) {
+  assert(is_interpreted_frame(), "interpreted frame expected");
+  // set relativized last_sp
+  ptr_at_put(interpreter_frame_last_sp_offset, last_sp != nullptr ? (last_sp - fp()) : 0);
 }
 
 frame frame::sender_for_entry_frame(RegisterMap* map) const {

--- a/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
@@ -250,7 +250,9 @@ inline intptr_t* frame::interpreter_frame_locals() const {
 }
 
 inline intptr_t* frame::interpreter_frame_last_sp() const {
-  return (intptr_t*)at(interpreter_frame_last_sp_offset);
+  intptr_t n = *addr_at(interpreter_frame_last_sp_offset);
+  assert(n <= 0, "n: " INTPTR_FORMAT, n);
+  return n != 0 ? &fp()[n] : nullptr;
 }
 
 inline intptr_t* frame::interpreter_frame_bcp_addr() const {

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -518,7 +518,9 @@ void InterpreterMacroAssembler::prepare_to_jump_from_interpreted() {
   // set sender sp
   move(Rsender, SP);
   // record last_sp
-  st_d(SP, FP, frame::interpreter_frame_last_sp_offset * wordSize);
+  sub_d(AT, SP, FP);
+  srai_d(AT, AT, Interpreter::logStackElementSize);
+  st_d(AT, FP, frame::interpreter_frame_last_sp_offset * wordSize);
 }
 
 // Jump to from_interpreted entry of a call unless single stepping is possible

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -568,7 +568,8 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   address entry = __ pc();
 
   // Restore stack bottom in case i2c adjusted stack
-  __ ld_d(SP, Address(FP, frame::interpreter_frame_last_sp_offset * wordSize));
+  __ ld_d(AT, Address(FP, frame::interpreter_frame_last_sp_offset * wordSize));
+  __ alsl_d(SP, AT, FP, LogBytesPerWord-1);
   // and null it as marker that sp is now tos until next java call
   __ st_d(R0, FP, frame::interpreter_frame_last_sp_offset * wordSize);
 
@@ -1883,7 +1884,8 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   // fixup routine to move the mutated arguments onto the top of our
   // expression stack if necessary.
   __ move(T8, SP);
-  __ ld_d(A2, FP, frame::interpreter_frame_last_sp_offset * wordSize);
+  __ ld_d(AT, FP, frame::interpreter_frame_last_sp_offset * wordSize);
+  __ alsl_d(A2, AT, FP, LogBytesPerWord-1);
   // PC must point into interpreter here
   Label L;
   __ bind(L);
@@ -1891,7 +1893,8 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   __ super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::popframe_move_outgoing_args), TREG, T8, A2);
   __ reset_last_Java_frame(TREG, true);
   // Restore the last_sp and null it out
-  __ ld_d(SP, FP, frame::interpreter_frame_last_sp_offset * wordSize);
+  __ ld_d(AT, FP, frame::interpreter_frame_last_sp_offset * wordSize);
+  __ alsl_d(SP, AT, FP, LogBytesPerWord-1);
   __ st_d(R0, FP, frame::interpreter_frame_last_sp_offset * wordSize);
 
 


### PR DESCRIPTION
32275: LA port of 8313419: Template interpreter produces no safepoint check for return bytecodes
32274: LA port of 8308984: Relativize last_sp (and top_frame_sp) in interpreter frames