### PR TITLE
Update (2023.09.21)

### DIFF
--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -727,7 +727,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
   // Check that all monitors are unlocked
   {
     Label loop, exception, entry, restart;
-    const int entry_size = frame::interpreter_frame_monitor_size() * wordSize;
+    const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
     const Address monitor_block_top(FP,
         frame::interpreter_frame_monitor_block_top_offset * wordSize);
 

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -776,7 +776,7 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
   // generate_method_entry) so the guard should work for them too.
   //
 
-  const int entry_size    = frame::interpreter_frame_monitor_size() * wordSize;
+  const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
 
   // total overhead size: entry_size + (saved fp thru expr stack bottom).
   // be sure to change this if you add/subtract anything to/from the overhead area
@@ -843,7 +843,7 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
 // Rmethod - Method*
 void TemplateInterpreterGenerator::lock_method(void) {
   // synchronize method
-  const int entry_size = frame::interpreter_frame_monitor_size() * wordSize;
+  const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
 
 #ifdef ASSERT
   { Label L;

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -3933,7 +3933,7 @@ void TemplateTable::monitorenter() {
 
   const Address monitor_block_top(FP, frame::interpreter_frame_monitor_block_top_offset
       * wordSize);
-  const int entry_size = (frame::interpreter_frame_monitor_size()* wordSize);
+  const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
   Label allocated;
 
   const Register monitor_reg = T0;
@@ -4008,7 +4008,7 @@ void TemplateTable::monitorexit() {
 
   __ null_check(FSR);
 
-  const int entry_size =(frame::interpreter_frame_monitor_size()* wordSize);
+  const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
 
   const Register monitor_top = T0;
   const Register monitor_bot = T2;


### PR DESCRIPTION
32358: LA port of 8310596: Utilize existing method frame::interpreter_frame_monitor_size_in_bytes()