### PR TITLE
Update (2023.09.22)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
@@ -61,7 +61,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   // Load object header
   ld_d(hdr, Address(obj, hdr_offset));
   if (LockingMode == LM_LIGHTWEIGHT) {
-    fast_lock(obj, hdr, SCR1, SCR2, slow_case);
+    lightweight_lock(obj, hdr, SCR1, SCR2, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     Label done;
     // and mark it as unlocked
@@ -125,7 +125,7 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
     // be encoded.
     andi(AT, hdr, markWord::monitor_value);
     bnez(AT, slow_case);
-    fast_unlock(obj, hdr, SCR1, SCR2, slow_case);
+    lightweight_unlock(obj, hdr, SCR1, SCR2, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     // test if object header is pointing to the displaced header, and if so, restore
     // the displaced header in the object - if the object header is not pointing to

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -93,7 +93,7 @@ void C2_MacroAssembler::fast_lock_c2(Register oop, Register box, Register flag,
     b(cont);
   } else {
     assert(LockingMode == LM_LIGHTWEIGHT, "must be");
-    fast_lock(oop, disp_hdr, flag, SCR1, no_count);
+    lightweight_lock(oop, disp_hdr, flag, SCR1, no_count);
     b(count);
   }
 
@@ -170,7 +170,7 @@ void C2_MacroAssembler::fast_unlock_c2(Register oop, Register box, Register flag
     b(cont);
   } else {
     assert(LockingMode == LM_LIGHTWEIGHT, "must be");
-    fast_unlock(oop, tmp, flag, box, no_count);
+    lightweight_unlock(oop, tmp, flag, box, no_count);
     b(count);
   }
 

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -845,7 +845,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
 
     if (LockingMode == LM_LIGHTWEIGHT) {
       ld_d(tmp_reg, Address(scr_reg, oopDesc::mark_offset_in_bytes()));
-      fast_lock(scr_reg, tmp_reg, SCR1, SCR2, slow_case);
+      lightweight_lock(scr_reg, tmp_reg, SCR1, SCR2, slow_case);
       b(count);
     } else if (LockingMode == LM_LEGACY) {
       // Load (object->mark() | 1) into tmp_reg
@@ -946,7 +946,7 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
       ld_d(hdr_reg, Address(scr_reg, oopDesc::mark_offset_in_bytes()));
       andi(AT, hdr_reg, markWord::monitor_value);
       bnez(AT, slow_case);
-      fast_unlock(scr_reg, hdr_reg, tmp_reg, SCR1, slow_case);
+      lightweight_unlock(scr_reg, hdr_reg, tmp_reg, SCR1, slow_case);
       b(count);
       bind(slow_case);
     } else if (LockingMode == LM_LEGACY) {

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -3701,7 +3701,7 @@ void MacroAssembler::double_move(VMRegPair src, VMRegPair dst, Register tmp) {
   }
 }
 
-// Implements fast-locking.
+// Implements lightweight-locking.
 // Branches to slow upon failure to lock the object.
 // Falls through upon success.
 //
@@ -3709,7 +3709,7 @@ void MacroAssembler::double_move(VMRegPair src, VMRegPair dst, Register tmp) {
 //  - hdr: the header, already loaded from obj, will be destroyed
 //  - flag: as cr for c2, but only as temporary regisgter for c1/interpreter
 //  - tmp: temporary registers, will be destroyed
-void MacroAssembler::fast_lock(Register obj, Register hdr, Register flag, Register tmp, Label& slow) {
+void MacroAssembler::lightweight_lock(Register obj, Register hdr, Register flag, Register tmp, Label& slow) {
   assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, hdr, flag, tmp);
 
@@ -3734,7 +3734,7 @@ void MacroAssembler::fast_lock(Register obj, Register hdr, Register flag, Regist
   st_w(tmp, Address(TREG, JavaThread::lock_stack_top_offset()));
 }
 
-// Implements fast-unlocking.
+// Implements lightweight-unlocking.
 // Branches to slow upon failure.
 // Falls through upon success.
 //
@@ -3742,7 +3742,7 @@ void MacroAssembler::fast_lock(Register obj, Register hdr, Register flag, Regist
 // - hdr: the (pre-loaded) header of the object
 // - flag: as cr for c2, but only as temporary regisgter for c1/interpreter
 // - tmp: temporary registers
-void MacroAssembler::fast_unlock(Register obj, Register hdr, Register flag, Register tmp, Label& slow) {
+void MacroAssembler::lightweight_unlock(Register obj, Register hdr, Register flag, Register tmp, Label& slow) {
   assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, hdr, tmp, flag);
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -711,8 +711,8 @@ class MacroAssembler: public Assembler {
     }
   }
 
-  void fast_lock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
-  void fast_unlock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
+  void lightweight_lock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
+  void lightweight_unlock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
 
 #if INCLUDE_ZGC
   void patchable_li16(Register rd, uint16_t value);

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1762,7 +1762,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ ld_d(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
       // FIXME
       Register tmp = T1;
-      __ fast_lock(obj_reg, swap_reg, tmp, SCR1, slow_path_lock);
+      __ lightweight_lock(obj_reg, swap_reg, tmp, SCR1, slow_path_lock);
     }
 
     __ bind(count);
@@ -1925,7 +1925,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ ld_d(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
       __ andi(AT, lock_reg, markWord::monitor_value);
       __ bnez(AT, slow_path_unlock);
-      __ fast_unlock(obj_reg, lock_reg, swap_reg, SCR1, slow_path_unlock);
+      __ lightweight_unlock(obj_reg, lock_reg, swap_reg, SCR1, slow_path_unlock);
       __ decrement(Address(TREG, JavaThread::held_monitor_count_offset()));
     }
 


### PR DESCRIPTION
32616: LA port of 8316179: Use consistent naming for lightweight locking in MacroAssembler