### PR TITLE
Update (2023.12.08)

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/loongarch64/linux/LinuxLoongArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/loongarch64/linux/LinuxLoongArch64Linker.java
@@ -28,13 +28,20 @@ package jdk.internal.foreign.abi.loongarch64.linux;
 
 import jdk.internal.foreign.abi.AbstractLinker;
 import jdk.internal.foreign.abi.LinkerOptions;
+import jdk.internal.foreign.abi.SharedUtils;
 
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.nio.ByteOrder;
+import java.util.Map;
 
 public final class LinuxLoongArch64Linker extends AbstractLinker {
+
+    static final Map<String, MemoryLayout> CANONICAL_LAYOUTS =
+            SharedUtils.canonicalLayouts(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT);
 
     public static LinuxLoongArch64Linker getInstance() {
         final class Holder {
@@ -61,5 +68,10 @@ public final class LinuxLoongArch64Linker extends AbstractLinker {
     @Override
     protected ByteOrder linkerByteOrder() {
         return ByteOrder.LITTLE_ENDIAN;
+    }
+
+    @Override
+    public Map<String, MemoryLayout> canonicalLayouts() {
+        return CANONICAL_LAYOUTS;
     }
 }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/StackWalkNativeToJava.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/StackWalkNativeToJava.java
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Utils;
@@ -33,7 +39,7 @@ import java.util.List;
  * @test StackWalkNativeToJava
  * @bug 8316309
  * @summary Check that walking the stack works fine when going from C++ frame to Java frame.
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="loongarch64"
  * @requires os.family != "windows"
  * @requires vm.flagless
  * @library /test/lib

--- a/test/jdk/java/foreign/callarranger/TestLoongArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestLoongArch64CallArranger.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires sun.arch.data.model == "64"
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign


### PR DESCRIPTION
32841: LA port of 8316309: AArch64: VMError::print_native_stack() crashes on Java native method frame
32840: LA port of 8312522: Implementation of Foreign Function & Memory API