### PR TITLE
Update (2023.12.27)

### DIFF
--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -2437,6 +2437,11 @@ encode %{
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
+    } else if (_method->intrinsic_id() == vmIntrinsicID::_ensureMaterializedForStackWalk) {
+      // The NOP here is purely to ensure that eliding a call to
+      // JVM_EnsureMaterializedForStackWalk doesn't change the code size.
+      __ nop();
+      __ block_comment("call JVM_EnsureMaterializedForStackWalk (elided)");
     } else {
       int method_index = resolved_method_index(cbuf);
       RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index)

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1040,6 +1040,9 @@ bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType bt) {
       if (vlen < 4 || !UseLASX)
         return false;
       break;
+    case Op_VectorUCastB2X:
+    case Op_VectorUCastS2X:
+    case Op_VectorUCastI2X:
     case Op_VectorCastB2X:
     case Op_VectorCastS2X:
     case Op_VectorCastI2X:
@@ -14525,6 +14528,54 @@ instruct roundVD(vReg dst, vReg src, immI rmode) %{
       }
     } else {
       ShouldNotReachHere();
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+// ---------------------------- Vector UCast B2X -------------------------------
+
+instruct cvtVUB(vReg dst, vReg src) %{
+  match(Set dst (VectorUCastB2X src));
+  format %{ "(x)vconvert    $dst, $src\t# @cvtVUB" %}
+  ins_encode %{
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_SHORT : __ vext2xv_hu_bu($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_INT   : __ vext2xv_wu_bu($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_LONG  : __ vext2xv_du_bu($dst$$FloatRegister, $src$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+// ---------------------------- Vector UCast S2X -------------------------------
+
+instruct cvtVUS(vReg dst, vReg src) %{
+  match(Set dst (VectorUCastS2X src));
+  format %{ "(x)vconvert    $dst, $src\t# @cvtVUS" %}
+  ins_encode %{
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_INT   : __ vext2xv_wu_hu($dst$$FloatRegister, $src$$FloatRegister); break;
+      case T_LONG  : __ vext2xv_du_hu($dst$$FloatRegister, $src$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+// ---------------------------- Vector UCast I2X -------------------------------
+
+instruct cvtVUI(vReg dst, vReg src) %{
+  match(Set dst (VectorUCastI2X src));
+  format %{ "(x)vconvert    $dst, $src\t# @cvtVUI" %}
+  ins_encode %{
+    switch (Matcher::vector_element_basic_type(this)) {
+      case T_LONG  : __ vext2xv_du_wu($dst$$FloatRegister, $src$$FloatRegister); break;
+      default:
+        ShouldNotReachHere();
     }
   %}
   ins_pipe( pipe_slow );

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -10885,24 +10885,30 @@ instruct convHF2F_reg_reg(regF dst, mRegI src, regF tmp) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct round_float_reg(mRegI dst, regF src, mRegL tmp)
+instruct round_float_reg(mRegI dst, regF src, regF vtemp1)
 %{
   match(Set dst (RoundF src));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "round_float $dst, $src\t# @round_float_reg" %}
+  effect(TEMP_DEF dst, TEMP vtemp1);
+  format %{ "round_float    $dst, $src\t# "
+            "TEMP($vtemp1) @round_float_reg" %}
   ins_encode %{
-    __ java_round_float($dst$$Register, $src$$FloatRegister, $tmp$$Register);
+    __ java_round_float($dst$$Register,
+                        $src$$FloatRegister,
+                        $vtemp1$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct round_double_reg(mRegL dst, regD src, mRegL tmp)
+instruct round_double_reg(mRegL dst, regD src, regD vtemp1)
 %{
   match(Set dst (RoundD src));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "round_double $dst, $src\t# @round_double_reg" %}
+  effect(TEMP_DEF dst, TEMP vtemp1);
+  format %{ "round_double    $dst, $src\t# "
+            "TEMP($vtemp1) @round_double_reg" %}
   ins_encode %{
-    __ java_round_double($dst$$Register, $src$$FloatRegister, $tmp$$Register);
+    __ java_round_double($dst$$Register,
+                         $src$$FloatRegister,
+                         $vtemp1$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -14443,7 +14449,8 @@ instruct round_float_lsx(vReg dst, vReg src, vReg vtemp1, vReg vtemp2) %{
   predicate(Matcher::vector_length_in_bytes(n) <= 16);
   match(Set dst (RoundVF src));
   effect(TEMP_DEF dst, TEMP vtemp1, TEMP vtemp2);
-  format %{ "round_float_lsx $dst, $src\t# @round_float_lsx" %}
+  format %{ "round_float_lsx    $dst, $src\t# "
+            "TEMP($vtemp1, $vtemp2) @round_float_lsx" %}
   ins_encode %{
     __ java_round_float_lsx($dst$$FloatRegister,
                             $src$$FloatRegister,
@@ -14457,7 +14464,8 @@ instruct round_float_lasx(vReg dst, vReg src, vReg vtemp1, vReg vtemp2) %{
   predicate(Matcher::vector_length_in_bytes(n) > 16);
   match(Set dst (RoundVF src));
   effect(TEMP_DEF dst, TEMP vtemp1, TEMP vtemp2);
-  format %{ "round_float_lasx $dst, $src\t# @round_float_lasx" %}
+  format %{ "round_float_lasx    $dst, $src\t# "
+            "TEMP($vtemp1, $vtemp2) @round_float_lasx" %}
   ins_encode %{
     __ java_round_float_lasx($dst$$FloatRegister,
                              $src$$FloatRegister,
@@ -14471,7 +14479,8 @@ instruct round_double_lsx(vReg dst, vReg src, vReg vtemp1, vReg vtemp2) %{
   predicate(Matcher::vector_length_in_bytes(n) <= 16);
   match(Set dst (RoundVD src));
   effect(TEMP_DEF dst, TEMP vtemp1, TEMP vtemp2);
-  format %{ "round_double_lsx $dst, $src\t# @round_double_lsx" %}
+  format %{ "round_double_lsx $dst, $src\t# "
+            "TEMP($vtemp1, $vtemp2) @round_double_lsx" %}
   ins_encode %{
     __ java_round_double_lsx($dst$$FloatRegister,
                              $src$$FloatRegister,
@@ -14485,7 +14494,8 @@ instruct round_double_lasx(vReg dst, vReg src, vReg vtemp1, vReg vtemp2) %{
   predicate(Matcher::vector_length_in_bytes(n) > 16);
   match(Set dst (RoundVD src));
   effect(TEMP_DEF dst, TEMP vtemp1, TEMP vtemp2);
-  format %{ "round_double_lasx $dst, $src\t# @round_double_lasx" %}
+  format %{ "round_double_lasx $dst, $src\t# "
+            "TEMP($vtemp1, $vtemp2) @round_double_lasx" %}
   ins_encode %{
     __ java_round_double_lasx($dst$$FloatRegister,
                               $src$$FloatRegister,

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -3717,25 +3717,31 @@ void MacroAssembler::encode_iso_array(Register src, Register dst,
 // in the IEEE-754-2008. For single-precision floatings,
 // the following algorithm can be used to effectively
 // implement rounding via standard operations.
-//
-// if src >= 0:
-//   dst = floor(src + 0.49999997f)
-// else:
-//   dst = floor(src + 0.5f)
 void MacroAssembler::java_round_float(Register dst,
                                       FloatRegister src,
-                                      Register tmp) {
+                                      FloatRegister vtemp1) {
   block_comment("java_round_float: { ");
+
+  Label L_abnormal, L_done;
+
   li(AT, StubRoutines::la::round_float_imm());
 
-  movfr2gr_s(tmp, src);
-  bstrpick_w(tmp, tmp, 31, 31);
-  slli_w(tmp, tmp, 2);
-  fldx_s(fscratch, AT, tmp);
-  fadd_s(fscratch, fscratch, src);
+  // if src is -0.5f, return 0 as result
+  fld_s(vtemp1, AT, 0);
+  fcmp_ceq_s(FCC0, vtemp1, src);
+  bceqz(FCC0, L_abnormal);
+  move(dst, R0);
+  b(L_done);
 
+  // else, floor src with the magic number
+  bind(L_abnormal);
+  fld_s(vtemp1, AT, 4);
+  fadd_s(fscratch, vtemp1, src);
   ftintrm_w_s(fscratch, fscratch);
   movfr2gr_s(dst, fscratch);
+
+  bind(L_done);
+
   block_comment("} java_round_float");
 }
 
@@ -3745,18 +3751,13 @@ void MacroAssembler::java_round_float_lsx(FloatRegister dst,
                                           FloatRegister vtemp2) {
   block_comment("java_round_float_lsx: { ");
   li(AT, StubRoutines::la::round_float_imm());
+  vldrepl_w(vtemp1, AT, 0);  // repl -0.5f
+  vldrepl_w(vtemp2, AT, 1);  // repl 0.49999997f
 
-  vldrepl_w(vtemp2, AT, 1);  // repl 0.5f
-  vslti_w(fscratch, src, 0);  // masked add
-  vand_v(vtemp2, fscratch, vtemp2);
-  vfadd_s(dst, src, vtemp2);
-
-  vldrepl_w(vtemp1, AT, 0);  // repl 0.49999997f
-  vnor_v(fscratch, fscratch, fscratch);  // rev mask
-  vand_v(vtemp1, fscratch, vtemp1);
-  vfadd_s(dst, dst, vtemp1);
-
-  vftintrm_w_s(dst, dst);
+  vfcmp_cne_s(fscratch, src, vtemp1);  // generate the mask
+  vand_v(fscratch, fscratch, src);     // clear the special
+  vfadd_s(dst, fscratch, vtemp2);      // plus the magic
+  vftintrm_w_s(dst, dst);              // floor the result
   block_comment("} java_round_float_lsx");
 }
 
@@ -3766,18 +3767,13 @@ void MacroAssembler::java_round_float_lasx(FloatRegister dst,
                                            FloatRegister vtemp2) {
   block_comment("java_round_float_lasx: { ");
   li(AT, StubRoutines::la::round_float_imm());
+  xvldrepl_w(vtemp1, AT, 0);  // repl -0.5f
+  xvldrepl_w(vtemp2, AT, 1);  // repl 0.49999997f
 
-  xvldrepl_w(vtemp2, AT, 1);  // repl 0.5f
-  xvslti_w(fscratch, src, 0);  // masked add
-  xvand_v(vtemp2, fscratch, vtemp2);
-  xvfadd_s(dst, src, vtemp2);
-
-  xvldrepl_w(vtemp1, AT, 0);  // repl 0.49999997f
-  xvnor_v(fscratch, fscratch, fscratch);  // rev mask
-  xvand_v(vtemp1, fscratch, vtemp1);
-  xvfadd_s(dst, dst, vtemp1);
-
-  xvftintrm_w_s(dst, dst);
+  xvfcmp_cne_s(fscratch, src, vtemp1);  // generate the mask
+  xvand_v(fscratch, fscratch, src);     // clear the special
+  xvfadd_s(dst, fscratch, vtemp2);      // plus the magic
+  xvftintrm_w_s(dst, dst);              // floor the result
   block_comment("} java_round_float_lasx");
 }
 
@@ -3786,25 +3782,31 @@ void MacroAssembler::java_round_float_lasx(FloatRegister dst,
 // in the IEEE-754-2008. For double-precision floatings,
 // the following algorithm can be used to effectively
 // implement rounding via standard operations.
-//
-// if src >= 0:
-//   dst = floor(src + 0.49999999999999994d)
-// else:
-//   dst = floor(src + 0.5d)
 void MacroAssembler::java_round_double(Register dst,
                                        FloatRegister src,
-                                       Register tmp) {
+                                       FloatRegister vtemp1) {
   block_comment("java_round_double: { ");
+
+  Label L_abnormal, L_done;
+
   li(AT, StubRoutines::la::round_double_imm());
 
-  movfr2gr_d(tmp, src);
-  bstrpick_d(tmp, tmp, 63, 63);
-  slli_d(tmp, tmp, 3);
-  fldx_d(fscratch, AT, tmp);
-  fadd_d(fscratch, fscratch, src);
+  // if src is -0.5d, return 0 as result
+  fld_d(vtemp1, AT, 0);
+  fcmp_ceq_d(FCC0, vtemp1, src);
+  bceqz(FCC0, L_abnormal);
+  move(dst, R0);
+  b(L_done);
 
+  // else, floor src with the magic number
+  bind(L_abnormal);
+  fld_d(vtemp1, AT, 8);
+  fadd_d(fscratch, vtemp1, src);
   ftintrm_l_d(fscratch, fscratch);
   movfr2gr_d(dst, fscratch);
+
+  bind(L_done);
+
   block_comment("} java_round_double");
 }
 
@@ -3814,18 +3816,13 @@ void MacroAssembler::java_round_double_lsx(FloatRegister dst,
                                            FloatRegister vtemp2) {
   block_comment("java_round_double_lsx: { ");
   li(AT, StubRoutines::la::round_double_imm());
+  vldrepl_d(vtemp1, AT, 0);  // repl -0.5d
+  vldrepl_d(vtemp2, AT, 1);  // repl 0.49999999999999994d
 
-  vldrepl_d(vtemp2, AT, 1);  // repl 0.5d
-  vslti_d(fscratch, src, 0);  // masked add
-  vand_v(vtemp2, fscratch, vtemp2);
-  vfadd_d(dst, src, vtemp2);
-
-  vldrepl_d(vtemp1, AT, 0);  // repl 0.49999999999999994d
-  vnor_v(fscratch, fscratch, fscratch);  // rev mask
-  vand_v(vtemp1, fscratch, vtemp1);
-  vfadd_d(dst, dst, vtemp1);
-
-  vftintrm_l_d(dst, dst);
+  vfcmp_cne_d(fscratch, src, vtemp1);  // generate the mask
+  vand_v(fscratch, fscratch, src);     // clear the special
+  vfadd_d(dst, fscratch, vtemp2);      // plus the magic
+  vftintrm_l_d(dst, dst);              // floor the result
   block_comment("} java_round_double_lsx");
 }
 
@@ -3835,18 +3832,13 @@ void MacroAssembler::java_round_double_lasx(FloatRegister dst,
                                             FloatRegister vtemp2) {
   block_comment("java_round_double_lasx: { ");
   li(AT, StubRoutines::la::round_double_imm());
+  xvldrepl_d(vtemp1, AT, 0);  // repl -0.5d
+  xvldrepl_d(vtemp2, AT, 1);  // repl 0.49999999999999994d
 
-  xvldrepl_d(vtemp2, AT, 1);  // repl 0.5d
-  xvslti_d(fscratch, src, 0);  // masked add
-  xvand_v(vtemp2, fscratch, vtemp2);
-  xvfadd_d(dst, src, vtemp2);
-
-  xvldrepl_d(vtemp1, AT, 0);  // repl 0.49999999999999994d
-  xvnor_v(fscratch, fscratch, fscratch);  // rev mask
-  xvand_v(vtemp1, fscratch, vtemp1);
-  xvfadd_d(dst, dst, vtemp1);
-
-  xvftintrm_l_d(dst, dst);
+  xvfcmp_cne_d(fscratch, src, vtemp1);  // generate the mask
+  xvand_v(fscratch, fscratch, src);     // clear the special
+  xvfadd_d(dst, fscratch, vtemp2);      // plus the magic
+  xvftintrm_l_d(dst, dst);              // floor the result
   block_comment("} java_round_double_lasx");
 }
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -316,12 +316,14 @@ class MacroAssembler: public Assembler {
   void sign_extend_byte(Register reg)  { ext_w_b(reg, reg); }
 
   // java.lang.Math::round intrinsics
-  void java_round_float(Register dst, FloatRegister src, Register tmp);
+  void java_round_float(Register dst, FloatRegister src,
+                        FloatRegister vtemp1);
   void java_round_float_lsx(FloatRegister dst, FloatRegister src,
                             FloatRegister vtemp1, FloatRegister vtemp2);
   void java_round_float_lasx(FloatRegister dst, FloatRegister src,
                              FloatRegister vtemp1, FloatRegister vtemp2);
-  void java_round_double(Register dst, FloatRegister src, Register tmp);
+  void java_round_double(Register dst, FloatRegister src,
+                         FloatRegister vtemp1);
   void java_round_double_lsx(FloatRegister dst, FloatRegister src,
                              FloatRegister vtemp1, FloatRegister vtemp2);
   void java_round_double_lasx(FloatRegister dst, FloatRegister src,

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -710,6 +710,12 @@ class MacroAssembler: public Assembler {
   // Code for java.math.BigInteger::mulAdd intrinsic.
   void mul_add(Register out, Register in, Register offset,
                Register len, Register k);
+  void cad(Register dst, Register src1, Register src2, Register carry);
+  void cadc(Register dst, Register src1, Register src2, Register carry);
+  void adc(Register dst, Register src1, Register src2, Register carry);
+  void wide_mul(Register prod_lo, Register prod_hi, Register n, Register m);
+  void wide_madd(Register sum_lo, Register sum_hi, Register n,
+                Register m, Register tmp1, Register tmp2);
 
   void movoop(Register dst, jobject obj);
 

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
@@ -187,11 +187,9 @@ ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::la::_pio2[] = {
 };
 
 ATTRIBUTE_ALIGNED(64) jfloat StubRoutines::la::_round_float_imm[] = {
-  0.49999997f, // round positive
-  0.5f,        // round negative
+  -0.5f, 0.49999997f // magic number for ties
 };
 
 ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::la::_round_double_imm[] = {
-  0.49999999999999994d, // round positive
-  0.5d,                 // round negative
+  -0.5d, 0.49999999999999994d // magic number for ties
 };

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -409,6 +409,11 @@ void VM_Version::get_processor_features() {
       UseFPUForSpilling = false;
     }
   }
+
+  if (FLAG_IS_DEFAULT(UsePoly1305Intrinsics)) {
+    FLAG_SET_DEFAULT(UsePoly1305Intrinsics, true);
+  }
+
 #endif
 
   // This machine allows unaligned memory accesses

--- a/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
@@ -103,13 +103,15 @@ static void commit(HelperType& helper) {
   assert(thread != nullptr, "invariant");
   if (thread->is_Java_thread()) {
     JavaThread* jt = JavaThread::cast(thread);
-    if (jt->thread_state() != _thread_in_vm) {
-      assert(jt->thread_state() == _thread_in_native, "invariant");
+    if (jt->thread_state() == _thread_in_native) {
       // For a JavaThread to take a JFR stacktrace, it must be in _thread_in_vm. Can safepoint here.
       ThreadInVMfromNative transition(jt);
       event.commit();
       return;
     }
+    // If a thread comes here still _thread_in_Java, which can happen for example
+    // when loading the disassembler library in response to traps in JIT code - all is ok.
+    // Since there is no ljf, an event will be committed without a stacktrace.
   }
   event.commit();
 }

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastLASX.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastLASX.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Loongson Technology. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi.reshape;
+
+import compiler.vectorapi.reshape.tests.TestVectorCast;
+import compiler.vectorapi.reshape.utils.TestCastMethods;
+import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
+
+/*
+ * @test
+ * @enablePreview
+ * @key randomness
+ * @modules jdk.incubator.vector
+ * @modules java.base/jdk.internal.misc
+ * @summary Test that vector cast intrinsics work as intended on lasx.
+ * @requires vm.cpu.features ~= ".*lasx.*"
+ * @library /test/lib /
+ * @run main compiler.vectorapi.reshape.TestVectorCastLASX
+ */
+public class TestVectorCastLASX {
+    public static void main(String[] args) {
+        VectorReshapeHelper.runMainHelper(
+                TestVectorCast.class,
+                TestCastMethods.LASX_CAST_TESTS.stream(),
+                "-XX:+UseLASX");
+    }
+}
+
+

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.vectorapi.reshape.utils;
 
 import java.util.List;
@@ -259,4 +265,62 @@ public class TestCastMethods {
             makePair(DSPEC128, LSPEC128),
             makePair(DSPEC128, FSPEC64)
     );
+
+    public static final List<VectorSpeciesPair> LASX_CAST_TESTS = List.of(
+            makePair(BSPEC64, SSPEC128),
+            makePair(BSPEC128, SSPEC256),
+            makePair(BSPEC64, ISPEC256),
+            makePair(BSPEC64, FSPEC256),
+            makePair(SSPEC128, BSPEC64),
+            makePair(SSPEC256, BSPEC128),
+            makePair(SSPEC64, ISPEC128),
+            makePair(SSPEC128, ISPEC256),
+            makePair(SSPEC64, LSPEC256),
+            makePair(SSPEC64, FSPEC128),
+            makePair(SSPEC128, FSPEC256),
+            makePair(SSPEC64, DSPEC256),
+            makePair(ISPEC256, BSPEC64),
+            makePair(ISPEC128, SSPEC64),
+            makePair(ISPEC256, SSPEC128),
+            makePair(ISPEC64, LSPEC128),
+            makePair(ISPEC128, LSPEC256),
+            makePair(ISPEC64, FSPEC64),
+            makePair(ISPEC128, FSPEC128),
+            makePair(ISPEC256, FSPEC256),
+            makePair(ISPEC64, DSPEC128),
+            makePair(ISPEC128, DSPEC256),
+            makePair(LSPEC256, SSPEC64),
+            makePair(LSPEC128, ISPEC64),
+            makePair(LSPEC256, ISPEC128),
+            makePair(LSPEC128, FSPEC64),
+            makePair(LSPEC256, FSPEC128),
+            makePair(LSPEC128, DSPEC128),
+            makePair(LSPEC256, DSPEC256),
+            makePair(FSPEC256, BSPEC64),
+            makePair(FSPEC128, SSPEC64),
+            makePair(FSPEC256, SSPEC128),
+            makePair(FSPEC64, ISPEC64),
+            makePair(FSPEC128, ISPEC128),
+            makePair(FSPEC256, ISPEC256),
+            makePair(FSPEC64, LSPEC128),
+            makePair(FSPEC128, LSPEC256),
+            makePair(FSPEC64, DSPEC128),
+            makePair(FSPEC128, DSPEC256),
+            makePair(DSPEC256, SSPEC64),
+            makePair(DSPEC128, ISPEC64),
+            makePair(DSPEC256, ISPEC128),
+            makePair(DSPEC128, LSPEC128),
+            makePair(DSPEC256, LSPEC256),
+            makePair(DSPEC128, FSPEC64),
+            makePair(DSPEC256, FSPEC128),
+            makePair(BSPEC64, SSPEC128, true),
+            makePair(BSPEC128, SSPEC256, true),
+            makePair(BSPEC64, ISPEC256, true),
+            makePair(SSPEC64, ISPEC128, true),
+            makePair(SSPEC128, ISPEC256, true),
+            makePair(SSPEC64, LSPEC256, true),
+            makePair(ISPEC64, LSPEC128, true),
+            makePair(ISPEC128, LSPEC256, true)
+    );
+
 }


### PR DESCRIPTION
33272: Implement ensureMaterializedForStackWalk intrinsic
32033: Add vector intrinsics for unsigned (zero extended) casts
33177: Implement poly1305 intrinsic
33257: java/lang/Math/RoundTests.java failed with -Xcomp after 32796
33134: 8320959: jdk/jfr/event/runtime/TestShutdownEvent.java crash with CONF=fastdebug -Xcomp