### PR TITLE
Update (2023.12.28)

### DIFF
--- a/src/hotspot/cpu/loongarch/globalDefinitions_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globalDefinitions_loongarch.hpp
@@ -53,4 +53,6 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 
 #define USE_POINTERS_TO_REGISTER_IMPL_ARRAY
 
+#define DEFAULT_CACHE_LINE_SIZE 64
+
 #endif // CPU_LOONGARCH_GLOBALDEFINITIONS_LOONGARCH_HPP

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -3535,7 +3535,9 @@ void MacroAssembler::count_positives(Register src, Register len, Register result
   bind(Done);
 }
 
-// Compress char[] to byte[]. len must be positive int.
+// Intrinsic for java.lang.StringUTF16.compress(char[] src, int srcOff, byte[] dst, int dstOff, int len)
+// Return the array length if every element in array can be encoded,
+// otherwise, the index of first non-latin1 (> 0xff) character.
 // jtreg: TestStringIntrinsicRangeChecks.java
 void MacroAssembler::char_array_compress(Register src, Register dst,
                                          Register len, Register result,
@@ -3543,9 +3545,6 @@ void MacroAssembler::char_array_compress(Register src, Register dst,
                                          FloatRegister vtemp1, FloatRegister vtemp2,
                                          FloatRegister vtemp3, FloatRegister vtemp4) {
   encode_iso_array(src, dst, len, result, tmp1, tmp2, tmp3, false, vtemp1, vtemp2, vtemp3, vtemp4);
-  // Adjust result: result == len ? len : 0
-  sub_w(tmp1, result, len);
-  masknez(result, result, tmp1);
 }
 
 // Inflate byte[] to char[]. len must be positive int.

--- a/src/hotspot/cpu/loongarch/upcallLinker_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/upcallLinker_loongarch_64.cpp
@@ -126,6 +126,9 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   const CallRegs call_regs = ForeignGlobals::parse_call_regs(jconv);
   int code_size = upcall_stub_code_base_size + (total_out_args * upcall_stub_size_per_arg);
   CodeBuffer buffer("upcall_stub", code_size, /* locs_size = */ 1);
+  if (buffer.blob() == nullptr) {
+    return nullptr;
+  }
 
   GrowableArray<VMStorage> unfiltered_out_regs;
   int out_arg_bytes = ForeignGlobals::java_calling_convention(out_sig_bt, total_out_args, unfiltered_out_regs);
@@ -322,6 +325,9 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                          &buffer,
                          receiver,
                          in_ByteSize(frame_data_offset));
+  if (blob == nullptr) {
+    return nullptr;
+  }
 
 #ifndef PRODUCT
   if (lt.is_enabled()) {


### PR DESCRIPTION
33231: LA port of 8311906: Improve robustness of String constructors with mutable array inputs
33230: LA port of 8321269: Require platforms to define DEFAULT_CACHE_LINE_SIZE
33229: LA port of 8318586: Explicitly handle upcall stub allocation failure