### PR TITLE
Update (2023.12.28)

### DIFF
--- a/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
@@ -178,4 +178,9 @@
     }
   }
 
+  // Is SIMD sort supported for this CPU?
+  static bool supports_simd_sort(BasicType bt) {
+    return false;
+  }
+
 #endif // CPU_LOONGARCH_MATCHER_LOONGARCH_HPP


### PR DESCRIPTION
33287: LA port of 8319577: x86_64 AVX2 intrinsics for Arrays.sort methods (int, float arrays)