### PR TITLE
Update (2023.12.28)

### DIFF
--- a/src/hotspot/cpu/loongarch/compiledIC_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/compiledIC_loongarch.cpp
@@ -28,6 +28,7 @@
 #include "code/compiledIC.hpp"
 #include "code/icBuffer.hpp"
 #include "code/nmethod.hpp"
+#include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
@@ -80,9 +81,9 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   address stub = find_stub();
   guarantee(stub != nullptr, "stub not found");
 
-  if (TraceICs) {
+  {
     ResourceMark rm;
-    tty->print_cr("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
+    log_trace(inlinecache)("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
                   p2i(instruction_address()),
                   callee->name_and_sig_as_C_string());
   }


### PR DESCRIPTION
33329: LA port of 8316197: Make tracing of inline cache available in unified logging