### PR TITLE
Update (2024.01.29)

### DIFF
--- a/src/hotspot/cpu/loongarch/frame_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,8 +154,6 @@
   // Used in frame::sender_for_{interpreter,compiled}_frame
   static void verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp);
 #endif
-
-  const ImmutableOopMap* get_oop_map() const;
 
  public:
   // Constructors

--- a/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
@@ -342,20 +342,6 @@ inline int frame::sender_sp_ret_address_offset() {
   return frame::sender_sp_offset - frame::return_addr_offset;
 }
 
-inline const ImmutableOopMap* frame::get_oop_map() const {
-  if (_cb == nullptr) return nullptr;
-  if (_cb->oop_maps() != nullptr) {
-    NativePostCallNop* nop = nativePostCallNop_at(_pc);
-    if (nop != nullptr && nop->displacement() != 0) {
-      int slot = ((nop->displacement() >> 24) & 0xff);
-      return _cb->oop_map_for_slot(slot, _pc);
-    }
-    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
-    return oop_map;
-  }
-  return nullptr;
-}
-
 //------------------------------------------------------------------------------
 // frame::sender
 frame frame::sender(RegisterMap* map) const {

--- a/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -183,7 +183,7 @@ inline bool frame::equal(frame other) const {
               unextended_sp() == other.unextended_sp() &&
               fp() == other.fp() &&
               pc() == other.pc();
-  assert(!ret || ret && cb() == other.cb() && _deopt_state == other._deopt_state, "inconsistent construction");
+  assert(!ret || (cb() == other.cb() && _deopt_state == other._deopt_state), "inconsistent construction");
   return ret;
 }
 

--- a/src/hotspot/cpu/loongarch/globalDefinitions_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globalDefinitions_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,10 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 
 #define USE_POINTERS_TO_REGISTER_IMPL_ARRAY
 
+// The expected size in bytes of a cache line.
 #define DEFAULT_CACHE_LINE_SIZE 64
+
+// The default padding size for data structures to avoid false sharing.
+#define DEFAULT_PADDING_SIZE DEFAULT_CACHE_LINE_SIZE
 
 #endif // CPU_LOONGARCH_GLOBALDEFINITIONS_LOONGARCH_HPP

--- a/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -536,15 +536,21 @@ public:
     return is_nop() && ((uint_at(4) & 0xffc0001f) == 0x03800000);
   }
 
-  jint displacement() const {
+  bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const {
     uint32_t first_ori = uint_at(4);
     uint32_t second_ori = uint_at(8);
     int lo = ((first_ori >> 5) & 0xffff);
     int hi = ((second_ori >> 5) & 0xffff);
-    return (jint) ((hi << 16) | lo);
+    uint32_t data = (hi << 16) | lo;
+    if (data == 0) {
+      return false; // no information encoded
+    }
+    cb_offset = (data & 0xffffff);
+    oopmap_slot = (data >> 24) & 0xff;
+    return true; // decoding succeeded
   }
 
-  void patch(jint diff);
+  bool patch(int32_t oopmap_slot, int32_t cb_offset);
   void make_deopt();
 };
 


### PR DESCRIPTION
33504: LA port of 8322294: Cleanup NativePostCallNop
33503: Eliminate -Wparentheses warnings in LoongArch code
33502: LA port of 8237842: Separate definitions for default cache line and padding sizes