### PR TITLE
Update (2024.05.24)

### DIFF
--- a/src/hotspot/cpu/loongarch/compiledIC_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/compiledIC_loongarch.cpp
@@ -34,18 +34,14 @@
 
 // ----------------------------------------------------------------------------
 
-#define __ _masm.
-address CompiledDirectCall::emit_to_interp_stub(CodeBuffer &cbuf, address mark) {
-  precond(cbuf.stubs()->start() != badAddress);
-  precond(cbuf.stubs()->end() != badAddress);
+#define __ masm->
+address CompiledDirectCall::emit_to_interp_stub(MacroAssembler *masm, address mark) {
+  precond(__ code()->stubs()->start() != badAddress);
+  precond(__ code()->stubs()->end() != badAddress);
 
   if (mark == nullptr) {
-    mark = cbuf.insts_mark();  // get mark within main instrs section
+    mark = __ inst_mark();  // get mark within main instrs section.
   }
-
-  // Note that the code buffer's insts_mark is always relative to insts.
-  // That's why we must use the macroassembler to generate a stub.
-  MacroAssembler _masm(&cbuf);
 
   address base = __ start_a_stub(CompiledDirectCall::to_interp_stub_size());
   if (base == nullptr)  return nullptr;  // CodeBuffer::expand failed

--- a/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
@@ -229,7 +229,7 @@ inline int frame::frame_size() const {
 
 inline int frame::compiled_frame_stack_argsize() const {
   assert(cb()->is_nmethod(), "");
-  return (cb()->as_nmethod()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord;
+  return (cb()->as_nmethod()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord;
 }
 
 inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoah_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoah_loongarch_64.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2018, Red Hat, Inc. All rights reserved.
-// Copyright (c) 2023, Loongson Technology. All rights reserved.
+// Copyright (c) 2023, 2024, Loongson Technology. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -30,16 +30,14 @@ source_hpp %{
 
 encode %{
   enc_class loongarch_enc_cmpxchg_oop_shenandoah(indirect mem, mRegP oldval, mRegP newval, mRegI res) %{
-    MacroAssembler _masm(&cbuf);
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
 
   enc_class loongarch_enc_cmpxchg_acq_oop_shenandoah(indirect mem, mRegP oldval, mRegP newval, mRegI res) %{
-    MacroAssembler _masm(&cbuf);
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
 %}
@@ -65,7 +63,7 @@ instruct compareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN
 
   ins_encode %{
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
 
@@ -93,7 +91,7 @@ instruct compareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval, mR
 
   ins_encode %{
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
 
@@ -109,7 +107,7 @@ instruct compareAndExchangeN_shenandoah(mRegN res, indirect mem, mRegN oldval, m
 
   ins_encode %{
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ true, $res$$Register);
   %}
 
@@ -125,7 +123,7 @@ instruct compareAndExchangeP_shenandoah(mRegP res, indirect mem, mRegP oldval, m
 
   ins_encode %{
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ true, $res$$Register);
   %}
 
@@ -141,7 +139,7 @@ instruct compareAndExchangeNAcq_shenandoah(mRegN res, indirect mem, mRegN oldval
 
   ins_encode %{
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ true, $res$$Register);
   %}
 
@@ -157,7 +155,7 @@ instruct compareAndExchangePAcq_shenandoah(mRegP res, indirect mem, mRegP oldval
 
   ins_encode %{
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ true, $res$$Register);
   %}
 
@@ -173,7 +171,7 @@ instruct weakCompareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, m
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
 
@@ -190,7 +188,7 @@ instruct weakCompareAndSwapP_shenandoah(mRegI res, indirect mem, mRegP oldval, m
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
 
@@ -207,7 +205,7 @@ instruct weakCompareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
 
@@ -224,7 +222,7 @@ instruct weakCompareAndSwapPAcq_shenandoah(mRegI res, indirect mem, mRegP oldval
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
     Address  addr(as_Register($mem$$base), 0);
-    ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
+    ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
 

--- a/src/hotspot/cpu/loongarch/gc/x/x_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/x/x_loongarch_64.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
+// Copyright (c) 2021, 2024, Loongson Technology. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ source_hpp %{
 
 source %{
 
-static void x_load_barrier(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register ref, Register tmp, uint8_t barrier_data) {
+static void x_load_barrier(MacroAssembler *masm, const MachNode* node, Address ref_addr, Register ref, Register tmp, uint8_t barrier_data) {
   if (barrier_data == XLoadBarrierElided) {
     return;
   }
@@ -43,13 +43,13 @@ static void x_load_barrier(MacroAssembler& _masm, const MachNode* node, Address 
   __ bind(*stub->continuation());
 }
 
-static void x_load_barrier_slow_path(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register ref, Register tmp) {
+static void x_load_barrier_slow_path(MacroAssembler* masm, const MachNode* node, Address ref_addr, Register ref, Register tmp) {
   XLoadBarrierStubC2* const stub = XLoadBarrierStubC2::create(node, ref_addr, ref, tmp, XLoadBarrierStrong);
   __ b(*stub->entry());
   __ bind(*stub->continuation());
 }
 
-static void x_compare_and_swap(MacroAssembler& _masm, const MachNode* node,
+static void x_compare_and_swap(MacroAssembler* masm, const MachNode* node,
                                Register res, Register mem, Register oldval, Register newval,
                                Register tmp, bool weak, bool acquire) {
   // z-specific load barrier requires strong CAS operations.
@@ -69,14 +69,14 @@ static void x_compare_and_swap(MacroAssembler& _masm, const MachNode* node,
     __ ld_d(AT, Address(TREG, XThreadLocalData::address_bad_mask_offset()));
     __ andr(AT, AT, tmp);
     __ beqz(AT, good);
-    x_load_barrier_slow_path(_masm, node, addr, tmp, res /* used as tmp */);
+    x_load_barrier_slow_path(masm, node, addr, tmp, res /* used as tmp */);
     __ cmpxchg(addr, oldval, newval, tmp, false /* retold */, acquire /* acquire */, weak /* weak */, false /* exchange */);
     __ move(res, tmp);
     __ bind(good);
   }
 }
 
-static void x_compare_and_exchange(MacroAssembler& _masm, const MachNode* node,
+static void x_compare_and_exchange(MacroAssembler* masm, const MachNode* node,
                                    Register res, Register mem, Register oldval, Register newval, Register tmp,
                                    bool weak, bool acquire) {
   // z-specific load barrier requires strong CAS operations.
@@ -89,7 +89,7 @@ static void x_compare_and_exchange(MacroAssembler& _masm, const MachNode* node,
     __ ld_d(tmp, Address(TREG, XThreadLocalData::address_bad_mask_offset()));
     __ andr(tmp, tmp, res);
     __ beqz(tmp, good);
-    x_load_barrier_slow_path(_masm, node, addr, res /* ref */, tmp);
+    x_load_barrier_slow_path(masm, node, addr, res /* ref */, tmp);
     __ cmpxchg(addr, oldval, newval, res, false /* retold */, acquire /* barrier */, weak /* weak */, true /* exchange */);
     __ bind(good);
   }
@@ -112,7 +112,7 @@ instruct xLoadP(mRegP dst, memory mem, mRegP tmp)
     Address ref_addr = Address(as_Register($mem$$base), as_Register($mem$$index), Address::no_scale, $mem$$disp);
     __ block_comment("xLoadP");
     __ ld_d($dst$$Register, ref_addr);
-    x_load_barrier(_masm, this, ref_addr, $dst$$Register, $tmp$$Register, barrier_data());
+    x_load_barrier(masm, this, ref_addr, $dst$$Register, $tmp$$Register, barrier_data());
   %}
 
   ins_pipe(pipe_slow);
@@ -129,7 +129,7 @@ instruct xCompareAndSwapP(mRegI res, mRegP mem, mRegP oldval, mRegP newval, mReg
   format %{ "CMPXCHG $res, $mem, $oldval, $newval; as bool; ptr" %}
   ins_encode %{
     __ block_comment("xCompareAndSwapP");
-    x_compare_and_swap(_masm, this,
+    x_compare_and_swap(masm, this,
                        $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register,
                        $tmp$$Register, false /* weak */, false /* acquire */);
   %}
@@ -147,7 +147,7 @@ instruct xCompareAndSwapP_acq(mRegI res, mRegP mem, mRegP oldval, mRegP newval, 
   format %{ "CMPXCHG acq $res, $mem, $oldval, $newval; as bool; ptr" %}
   ins_encode %{
     __ block_comment("xCompareAndSwapP_acq");
-    x_compare_and_swap(_masm, this,
+    x_compare_and_swap(masm, this,
                        $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register,
                        $tmp$$Register, false /* weak */, true /* acquire */);
   %}
@@ -167,7 +167,7 @@ instruct xCompareAndSwapPWeak(mRegI res, mRegP mem, mRegP oldval, mRegP newval, 
   format %{ "weak CMPXCHG $res, $mem, $oldval, $newval; as bool; ptr" %}
   ins_encode %{
     __ block_comment("xCompareAndSwapPWeak");
-    x_compare_and_swap(_masm, this,
+    x_compare_and_swap(masm, this,
                        $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register,
                        $tmp$$Register, true /* weak */, false /* acquire */);
   %}
@@ -185,7 +185,7 @@ instruct xCompareAndSwapPWeak_acq(mRegI res, mRegP mem, mRegP oldval, mRegP newv
   format %{ "weak CMPXCHG acq $res, $mem, $oldval, $newval; as bool; ptr" %}
   ins_encode %{
     __ block_comment("xCompareAndSwapPWeak_acq");
-    x_compare_and_swap(_masm, this,
+    x_compare_and_swap(masm, this,
                        $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register,
                        $tmp$$Register, true /* weak */, true /* acquire */);
   %}
@@ -207,7 +207,7 @@ instruct xCompareAndExchangeP(mRegP res, mRegP mem, mRegP oldval, mRegP newval, 
   format %{ "CMPXCHG $res, $mem, $oldval, $newval; as ptr; ptr" %}
   ins_encode %{
     __ block_comment("xCompareAndExchangeP");
-    x_compare_and_exchange(_masm, this,
+    x_compare_and_exchange(masm, this,
                            $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register, $tmp$$Register,
                            false /* weak */, false /* acquire */);
   %}
@@ -228,7 +228,7 @@ instruct xCompareAndExchangeP_acq(mRegP res, mRegP mem, mRegP oldval, mRegP newv
   format %{ "CMPXCHG acq $res, $mem, $oldval, $newval; as ptr; ptr" %}
   ins_encode %{
     __ block_comment("xCompareAndExchangeP_acq");
-    x_compare_and_exchange(_masm, this,
+    x_compare_and_exchange(masm, this,
                            $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register, $tmp$$Register,
                            false /* weak */, true /* acquire */);
   %}
@@ -249,7 +249,7 @@ instruct xGetAndSetP(mRegP mem, mRegP newv, mRegP prev, mRegP tmp) %{
     Register addr = $mem$$Register;
     __ block_comment("xGetAndSetP");
     __ amswap_db_d(prev, newv, addr);
-    x_load_barrier(_masm, this, Address(noreg, 0), prev, $tmp$$Register, barrier_data());
+    x_load_barrier(masm, this, Address(noreg, 0), prev, $tmp$$Register, barrier_data());
   %}
 
   ins_pipe(pipe_slow);

--- a/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
+// Copyright (c) 2021, 2024, Loongson Technology. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ source %{
 
 #include "gc/z/zBarrierSetAssembler.hpp"
 
-static void z_load_barrier(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register ref, Register tmp) {
+static void z_load_barrier(MacroAssembler* masm, const MachNode* node, Address ref_addr, Register ref, Register tmp) {
   if (node->barrier_data() == ZBarrierElided) {
     __ z_uncolor(ref);
   } else {
@@ -54,33 +54,33 @@ static void z_load_barrier(MacroAssembler& _masm, const MachNode* node, Address 
   }
 }
 
-static void z_store_barrier(MacroAssembler& _masm, const MachNode* node, Address ref_addr, Register rnew_zaddress, Register rnew_zpointer, Register tmp, bool is_atomic) {
+static void z_store_barrier(MacroAssembler* masm, const MachNode* node, Address ref_addr, Register rnew_zaddress, Register rnew_zpointer, Register tmp, bool is_atomic) {
   if (node->barrier_data() == ZBarrierElided) {
     __ z_color(rnew_zpointer, rnew_zaddress, tmp);
   } else {
     bool is_native = (node->barrier_data() & ZBarrierNative) != 0;
     ZStoreBarrierStubC2* const stub = ZStoreBarrierStubC2::create(node, ref_addr, rnew_zaddress, rnew_zpointer, is_native, is_atomic);
     ZBarrierSetAssembler* bs_asm = ZBarrierSet::assembler();
-    bs_asm->store_barrier_fast(&_masm, ref_addr, rnew_zaddress, rnew_zpointer, tmp, true /* in_nmethod */, is_atomic, *stub->entry(), *stub->continuation());
+    bs_asm->store_barrier_fast(masm, ref_addr, rnew_zaddress, rnew_zpointer, tmp, true /* in_nmethod */, is_atomic, *stub->entry(), *stub->continuation());
   }
 }
 
-static void z_compare_and_swap(MacroAssembler& _masm, const MachNode* node,
+static void z_compare_and_swap(MacroAssembler* masm, const MachNode* node,
                                Register res, Register mem, Register oldval, Register newval,
                                Register oldval_tmp, Register newval_tmp, Register tmp, bool acquire) {
   Address addr(mem);
   __ z_color(oldval_tmp, oldval, tmp);
-  z_store_barrier(_masm, node, addr, newval, newval_tmp, tmp, true /* is_atomic */);
+  z_store_barrier(masm, node, addr, newval, newval_tmp, tmp, true /* is_atomic */);
   __ cmpxchg(addr, oldval_tmp, newval_tmp, res, false /* retold */, acquire /* acquire */,
              false /* weak */, false /* exchange */);
 }
 
-static void z_compare_and_exchange(MacroAssembler& _masm, const MachNode* node,
+static void z_compare_and_exchange(MacroAssembler* masm, const MachNode* node,
                                    Register res, Register mem, Register oldval, Register newval,
                                    Register oldval_tmp, Register newval_tmp, Register tmp, bool acquire) {
   Address addr(mem);
   __ z_color(oldval_tmp, oldval, tmp);
-  z_store_barrier(_masm, node, addr, newval, newval_tmp, tmp, true /* is_atomic */);
+  z_store_barrier(masm, node, addr, newval, newval_tmp, tmp, true /* is_atomic */);
   __ cmpxchg(addr, oldval_tmp, newval_tmp, res, false /* retold */, acquire /* acquire */,
              false /* weak */, true /* exchange */);
   __ z_uncolor(res);
@@ -103,7 +103,7 @@ instruct zLoadP(mRegP dst, memory mem, mRegP tmp)
     Address ref_addr = Address(as_Register($mem$$base), as_Register($mem$$index), Address::no_scale, $mem$$disp);
     __ block_comment("zLoadP");
     __ ld_d($dst$$Register, ref_addr);
-    z_load_barrier(_masm, this, ref_addr, $dst$$Register, $tmp$$Register);
+    z_load_barrier(masm, this, ref_addr, $dst$$Register, $tmp$$Register);
   %}
 
   ins_pipe(pipe_slow);
@@ -121,7 +121,7 @@ instruct zStoreP(memory mem, mRegP src, mRegP tmp1, mRegP tmp2)
   ins_encode %{
     Address ref_addr = Address(as_Register($mem$$base), as_Register($mem$$index), Address::no_scale, $mem$$disp);
     __ block_comment("zStoreP");
-    z_store_barrier(_masm, this, ref_addr, $src$$Register, $tmp1$$Register, $tmp2$$Register, false /* is_atomic */);
+    z_store_barrier(masm, this, ref_addr, $src$$Register, $tmp1$$Register, $tmp2$$Register, false /* is_atomic */);
     __ st_d($tmp1$$Register, ref_addr);
   %}
   ins_pipe(pipe_slow);
@@ -139,7 +139,7 @@ instruct zStorePNull(memory mem, immP_0 zero, mRegP tmp1, mRegP tmp2)
   ins_encode %{
     Address ref_addr = Address(as_Register($mem$$base), as_Register($mem$$index), Address::no_scale, $mem$$disp);
     __ block_comment("zStoreP null");
-    z_store_barrier(_masm, this, ref_addr, noreg, $tmp1$$Register, $tmp2$$Register, false /* is_atomic */);
+    z_store_barrier(masm, this, ref_addr, noreg, $tmp1$$Register, $tmp2$$Register, false /* is_atomic */);
     __ st_d($tmp1$$Register, ref_addr);
   %}
   ins_pipe(pipe_slow);
@@ -157,7 +157,7 @@ instruct zCompareAndSwapP(mRegI res, mRegP mem, mRegP oldval, mRegP newval, mReg
   format %{ "zCompareAndSwapP $res, $mem, $oldval, $newval; as bool; ptr" %}
   ins_encode %{
     __ block_comment("zCompareAndSwapP");
-    z_compare_and_swap(_masm, this,
+    z_compare_and_swap(masm, this,
                        $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register,
                        $oldval_tmp$$Register, $newval_tmp$$Register, $tmp$$Register, false /* acquire */);
   %}
@@ -177,7 +177,7 @@ instruct zCompareAndSwapP_acq(mRegI res, mRegP mem, mRegP oldval, mRegP newval, 
   format %{ "zCompareAndSwapP acq $res, $mem, $oldval, $newval; as bool; ptr" %}
   ins_encode %{
     __ block_comment("zCompareAndSwapP_acq");
-    z_compare_and_swap(_masm, this,
+    z_compare_and_swap(masm, this,
                        $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register,
                        $oldval_tmp$$Register, $newval_tmp$$Register, $tmp$$Register, true /* acquire */);
   %}
@@ -199,7 +199,7 @@ instruct zCompareAndExchangeP(mRegP res, mRegP mem, mRegP oldval, mRegP newval, 
   format %{ "zCompareAndExchangeP $res, $mem, $oldval, $newval; as ptr; ptr" %}
   ins_encode %{
     __ block_comment("zCompareAndExchangeP");
-    z_compare_and_exchange(_masm, this,
+    z_compare_and_exchange(masm, this,
                            $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register,
                            $oldval_tmp$$Register, $newval_tmp$$Register, $tmp$$Register, false /* acquire */);
   %}
@@ -220,7 +220,7 @@ instruct zCompareAndExchangeP_acq(mRegP res, mRegP mem, mRegP oldval, mRegP newv
   format %{ "zCompareAndExchangeP acq $res, $mem, $oldval, $newval; as ptr; ptr" %}
   ins_encode %{
     __ block_comment("zCompareAndExchangeP_acq");
-    z_compare_and_exchange(_masm, this,
+    z_compare_and_exchange(masm, this,
                            $res$$Register, $mem$$Register, $oldval$$Register, $newval$$Register,
                            $oldval_tmp$$Register, $newval_tmp$$Register, $tmp$$Register, true /* acquire */);
   %}
@@ -240,7 +240,7 @@ instruct zGetAndSetP(mRegP mem, mRegP newv, mRegP prev, mRegP tmp1, mRegP tmp2) 
     Register newv = $newv$$Register;
     Register addr = $mem$$Register;
     __ block_comment("zGetAndSetP");
-    z_store_barrier(_masm, this, Address(addr, 0), newv, prev, $tmp1$$Register, true /* is_atomic */);
+    z_store_barrier(masm, this, Address(addr, 0), newv, prev, $tmp1$$Register, true /* is_atomic */);
     __ amswap_db_d($tmp2$$Register, prev, addr);
     __ move(prev, $tmp2$$Register);
     __ z_uncolor(prev);

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -823,8 +823,8 @@ class HandlerImpl {
 
  public:
 
-  static int emit_exception_handler(CodeBuffer &cbuf);
-  static int emit_deopt_handler(CodeBuffer& cbuf);
+  static int emit_exception_handler(C2_MacroAssembler *masm);
+  static int emit_deopt_handler(C2_MacroAssembler* masm);
 
   static uint size_exception_handler() {
     // NativeCall instruction size is the same as NativeJump.
@@ -872,7 +872,7 @@ source %{
 #define V0_num    A0_num
 #define V0_H_num  A0_H_num
 
-#define __ _masm.
+#define __ masm->
 
 RegMask _ANY_REG32_mask;
 RegMask _ANY_REG_mask;
@@ -926,10 +926,9 @@ int MachNode::compute_padding(int current_offset) const {
 
 // Emit exception handler code.
 // Stuff framesize into a register and call a VM stub routine.
-int HandlerImpl::emit_exception_handler(CodeBuffer& cbuf) {
+int HandlerImpl::emit_exception_handler(C2_MacroAssembler* masm) {
   // Note that the code buffer's insts_mark is always relative to insts.
   // That's why we must use the macroassembler to generate a handler.
-  C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_exception_handler());
   if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
@@ -940,7 +939,6 @@ int HandlerImpl::emit_exception_handler(CodeBuffer& cbuf) {
 
   __ block_comment("; emit_exception_handler");
 
-  cbuf.set_insts_mark();
   __ relocate(relocInfo::runtime_call_type);
   __ patchable_jump((address)OptoRuntime::exception_blob()->entry_point());
   assert(__ offset() - offset <= (int) size_exception_handler(), "overflow");
@@ -949,10 +947,9 @@ int HandlerImpl::emit_exception_handler(CodeBuffer& cbuf) {
 }
 
 // Emit deopt handler code.
-int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf) {
+int HandlerImpl::emit_deopt_handler(C2_MacroAssembler* masm) {
   // Note that the code buffer's insts_mark is always relative to insts.
   // That's why we must use the macroassembler to generate a handler.
-  C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_deopt_handler());
   if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
@@ -963,7 +960,6 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf) {
 
   __ block_comment("; emit_deopt_handler");
 
-  cbuf.set_insts_mark();
   __ relocate(relocInfo::runtime_call_type);
   __ patchable_call(SharedRuntime::deopt_blob()->unpack());
   assert(__ offset() - offset <= (int) size_deopt_handler(), "overflow");
@@ -1310,8 +1306,7 @@ void MachBreakpointNode::format( PhaseRegAlloc *, outputStream* st ) const {
 }
 #endif
 
-void MachBreakpointNode::emit(CodeBuffer &cbuf, PhaseRegAlloc* ra_) const {
-  C2_MacroAssembler _masm(&cbuf);
+void MachBreakpointNode::emit(C2_MacroAssembler *masm, PhaseRegAlloc *ra_) const {
   __ brk(5);
 }
 
@@ -1353,11 +1348,10 @@ static enum RC rc_class( OptoReg::Name reg ) {
 }
 
 // Helper methods for MachSpillCopyNode::implementation().
-static int vec_mov_helper(CodeBuffer *cbuf, bool do_size, int src_lo, int dst_lo,
+static int vec_mov_helper(C2_MacroAssembler *masm, bool do_size, int src_lo, int dst_lo,
                           int src_hi, int dst_hi, uint ireg, outputStream* st) {
   int size = 0;
-  if (cbuf) {
-    MacroAssembler _masm(cbuf);
+  if (masm) {
     int offset = __ offset();
     switch (ireg) {
       case Op_VecS:
@@ -1399,11 +1393,11 @@ static int vec_mov_helper(CodeBuffer *cbuf, bool do_size, int src_lo, int dst_lo
   return size;
 }
 
-static int vec_spill_helper(CodeBuffer *cbuf, bool do_size, bool is_load,
+static int vec_spill_helper(C2_MacroAssembler *masm, bool do_size, bool is_load,
                             int stack_offset, int reg, uint ireg, outputStream* st) {
   int size = 0;
-  if (cbuf) {
-    MacroAssembler _masm(cbuf);
+  if (masm) {
+    int offset = __ offset();
     if (is_load) {
       switch (ireg) {
         case Op_VecS:
@@ -1502,11 +1496,10 @@ static int vec_spill_helper(CodeBuffer *cbuf, bool do_size, bool is_load,
   return size;
 }
 
-static int vec_stack_to_stack_helper(CodeBuffer *cbuf, int src_offset,
+static int vec_stack_to_stack_helper(C2_MacroAssembler *masm, int src_offset,
                                       int dst_offset, uint ireg, outputStream* st) {
   int size = 0;
-  if (cbuf) {
-    MacroAssembler _masm(cbuf);
+  if (masm) {
     switch (ireg) {
       case Op_VecS:
         __ fld_s(F23, SP, src_offset);
@@ -1559,7 +1552,7 @@ static int vec_stack_to_stack_helper(CodeBuffer *cbuf, int src_offset,
   return size;
 }
 
-uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bool do_size, outputStream* st ) const {
+uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *ra_, bool do_size, outputStream* st) const {
   // Get registers to move
   OptoReg::Name src_second = ra_->get_reg_second(in(1));
   OptoReg::Name src_first = ra_->get_reg_first(in(1));
@@ -1585,15 +1578,15 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
       // mem -> mem
       int src_offset = ra_->reg2offset(src_first);
       int dst_offset = ra_->reg2offset(dst_first);
-      vec_stack_to_stack_helper(cbuf, src_offset, dst_offset, ireg, st);
+      vec_stack_to_stack_helper(masm, src_offset, dst_offset, ireg, st);
     } else if (src_first_rc == rc_float && dst_first_rc == rc_float) {
-      vec_mov_helper(cbuf, do_size, src_first, dst_first, src_second, dst_second, ireg, st);
+      vec_mov_helper(masm, do_size, src_first, dst_first, src_second, dst_second, ireg, st);
     } else if (src_first_rc == rc_float && dst_first_rc == rc_stack) {
       int stack_offset = ra_->reg2offset(dst_first);
-      vec_spill_helper(cbuf, do_size, false, stack_offset, src_first, ireg, st);
+      vec_spill_helper(masm, do_size, false, stack_offset, src_first, ireg, st);
     } else if (src_first_rc == rc_stack && dst_first_rc == rc_float) {
       int stack_offset = ra_->reg2offset(src_first);
-      vec_spill_helper(cbuf, do_size, true,  stack_offset, dst_first, ireg, st);
+      vec_spill_helper(masm, do_size, true,  stack_offset, dst_first, ireg, st);
     } else {
       ShouldNotReachHere();
     }
@@ -1610,8 +1603,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         // 64-bit
         int src_offset = ra_->reg2offset(src_first);
         int dst_offset = ra_->reg2offset(dst_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ ld_d(AT, Address(SP, src_offset));
           __ st_d(AT, Address(SP, dst_offset));
 #ifndef PRODUCT
@@ -1628,8 +1620,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         // No pushl/popl, so:
         int src_offset = ra_->reg2offset(src_first);
         int dst_offset = ra_->reg2offset(dst_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ ld_w(AT, Address(SP, src_offset));
           __ st_w(AT, Address(SP, dst_offset));
 #ifndef PRODUCT
@@ -1647,8 +1638,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           (dst_first & 1) == 0 && dst_first + 1 == dst_second) {
         // 64-bit
         int offset = ra_->reg2offset(src_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ ld_d(as_Register(Matcher::_regEncode[dst_first]), Address(SP, offset));
 #ifndef PRODUCT
         } else {
@@ -1662,8 +1652,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         assert(!((src_first & 1) == 0 && src_first + 1 == src_second), "no transform");
         assert(!((dst_first & 1) == 0 && dst_first + 1 == dst_second), "no transform");
         int offset = ra_->reg2offset(src_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           if (this->ideal_reg() == Op_RegI)
             __ ld_w(as_Register(Matcher::_regEncode[dst_first]), Address(SP, offset));
           else {
@@ -1689,8 +1678,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           (dst_first & 1) == 0 && dst_first + 1 == dst_second) {
         // 64-bit
         int offset = ra_->reg2offset(src_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ fld_d( as_FloatRegister(Matcher::_regEncode[dst_first]), Address(SP, offset));
 #ifndef PRODUCT
         } else {
@@ -1704,8 +1692,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         assert(!((src_first & 1) == 0 && src_first + 1 == src_second), "no transform");
         assert(!((dst_first & 1) == 0 && dst_first + 1 == dst_second), "no transform");
         int offset = ra_->reg2offset(src_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ fld_s( as_FloatRegister(Matcher::_regEncode[dst_first]), Address(SP, offset));
 #ifndef PRODUCT
         } else {
@@ -1725,8 +1712,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           (dst_first & 1) == 0 && dst_first + 1 == dst_second) {
         // 64-bit
         int offset = ra_->reg2offset(dst_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ st_d(as_Register(Matcher::_regEncode[src_first]), Address(SP, offset));
 #ifndef PRODUCT
         } else {
@@ -1740,8 +1726,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         assert(!((src_first & 1) == 0 && src_first + 1 == src_second), "no transform");
         assert(!((dst_first & 1) == 0 && dst_first + 1 == dst_second), "no transform");
         int offset = ra_->reg2offset(dst_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ st_w(as_Register(Matcher::_regEncode[src_first]), Address(SP, offset));
 #ifndef PRODUCT
         } else {
@@ -1756,8 +1741,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
       if ((src_first & 1) == 0 && src_first + 1 == src_second &&
           (dst_first & 1) == 0 && dst_first + 1 == dst_second) {
         // 64-bit
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ move(as_Register(Matcher::_regEncode[dst_first]),
                   as_Register(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
@@ -1772,8 +1756,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         // 32-bit
         assert(!((src_first & 1) == 0 && src_first + 1 == src_second), "no transform");
         assert(!((dst_first & 1) == 0 && dst_first + 1 == dst_second), "no transform");
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           if (this->ideal_reg() == Op_RegI)
               __ move_u32(as_Register(Matcher::_regEncode[dst_first]), as_Register(Matcher::_regEncode[src_first]));
           else
@@ -1792,8 +1775,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
       if ((src_first & 1) == 0 && src_first + 1 == src_second &&
           (dst_first & 1) == 0 && dst_first + 1 == dst_second) {
         // 64-bit
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ movgr2fr_d(as_FloatRegister(Matcher::_regEncode[dst_first]), as_Register(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
@@ -1806,8 +1788,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         // 32-bit
         assert(!((src_first & 1) == 0 && src_first + 1 == src_second), "no transform");
         assert(!((dst_first & 1) == 0 && dst_first + 1 == dst_second), "no transform");
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ movgr2fr_w(as_FloatRegister(Matcher::_regEncode[dst_first]), as_Register(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
@@ -1827,8 +1808,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
           (dst_first & 1) == 0 && dst_first + 1 == dst_second) {
         // 64-bit
         int offset = ra_->reg2offset(dst_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ fst_d( as_FloatRegister(Matcher::_regEncode[src_first]), Address(SP, offset) );
 #ifndef PRODUCT
         } else {
@@ -1842,8 +1822,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         assert(!((src_first & 1) == 0 && src_first + 1 == src_second), "no transform");
         assert(!((dst_first & 1) == 0 && dst_first + 1 == dst_second), "no transform");
         int offset = ra_->reg2offset(dst_first);
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ fst_s(as_FloatRegister(Matcher::_regEncode[src_first]), Address(SP, offset));
 #ifndef PRODUCT
         } else {
@@ -1859,8 +1838,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
       if ((src_first & 1) == 0 && src_first + 1 == src_second &&
           (dst_first & 1) == 0 && dst_first + 1 == dst_second) {
         // 64-bit
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ movfr2gr_d( as_Register(Matcher::_regEncode[dst_first]), as_FloatRegister(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
@@ -1873,8 +1851,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         // 32-bit
         assert(!((src_first & 1) == 0 && src_first + 1 == src_second), "no transform");
         assert(!((dst_first & 1) == 0 && dst_first + 1 == dst_second), "no transform");
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ movfr2gr_s( as_Register(Matcher::_regEncode[dst_first]), as_FloatRegister(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
@@ -1890,8 +1867,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
       if ((src_first & 1) == 0 && src_first + 1 == src_second &&
           (dst_first & 1) == 0 && dst_first + 1 == dst_second) {
         // 64-bit
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ fmov_d( as_FloatRegister(Matcher::_regEncode[dst_first]), as_FloatRegister(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
@@ -1904,8 +1880,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
         // 32-bit
         assert(!((src_first & 1) == 0 && src_first + 1 == src_second), "no transform");
         assert(!((dst_first & 1) == 0 && dst_first + 1 == dst_second), "no transform");
-        if (cbuf) {
-          C2_MacroAssembler _masm(cbuf);
+        if (masm) {
           __ fmov_s( as_FloatRegister(Matcher::_regEncode[dst_first]), as_FloatRegister(Matcher::_regEncode[src_first]));
 #ifndef PRODUCT
         } else {
@@ -1930,8 +1905,8 @@ void MachSpillCopyNode::format( PhaseRegAlloc *ra_, outputStream* st ) const {
 }
 #endif
 
-void MachSpillCopyNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  implementation( &cbuf, ra_, false, nullptr );
+void MachSpillCopyNode::emit(C2_MacroAssembler *masm, PhaseRegAlloc *ra_) const {
+  implementation(masm, ra_, false, nullptr);
 }
 
 uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
@@ -1965,9 +1940,8 @@ void MachEpilogNode::format( PhaseRegAlloc *ra_, outputStream* st ) const {
 }
 #endif
 
-void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
+void MachEpilogNode::emit(C2_MacroAssembler *masm, PhaseRegAlloc *ra_) const {
   Compile *C = ra_->C;
-  C2_MacroAssembler _masm(&cbuf);
   int framesize = C->output()->frame_size_in_bytes();
 
   assert((framesize & (StackAlignmentInBytes-1)) == 0, "frame size not aligned");
@@ -2023,8 +1997,7 @@ uint BoxLockNode::size(PhaseRegAlloc *ra_) const {
      return 3 * 4;
 }
 
-void BoxLockNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  C2_MacroAssembler _masm(&cbuf);
+void BoxLockNode::emit(C2_MacroAssembler *masm, PhaseRegAlloc *ra_) const {
   int offset = ra_->reg2offset(in_RegMask(0).find_first_elem());
   int reg = ra_->get_encode(this);
 
@@ -2050,8 +2023,7 @@ void MachNopNode::format( PhaseRegAlloc *, outputStream* st ) const {
 }
 #endif
 
-void MachNopNode::emit(CodeBuffer &cbuf, PhaseRegAlloc * ) const {
-  C2_MacroAssembler _masm(&cbuf);
+void MachNopNode::emit(C2_MacroAssembler *masm, PhaseRegAlloc *) const {
   int i = 0;
   for(i = 0; i < _count; i++)
      __ nop();
@@ -2084,8 +2056,7 @@ void MachUEPNode::format( PhaseRegAlloc *ra_, outputStream* st ) const {
 #endif
 
 
-void MachUEPNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  C2_MacroAssembler _masm(&cbuf);
+void MachUEPNode::emit(C2_MacroAssembler *masm, PhaseRegAlloc *ra_) const {
   __ ic_check(InteriorEntryAlignment);
 }
 
@@ -2108,21 +2079,21 @@ void MachConstantBaseNode::postalloc_expand(GrowableArray <Node *> *nodes, Phase
   ShouldNotReachHere();
 }
 
-void MachConstantBaseNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const {
+void MachConstantBaseNode::emit(C2_MacroAssembler *masm, PhaseRegAlloc* ra_) const {
   Compile* C = ra_->C;
   ConstantTable& constant_table = C->output()->constant_table();
-  C2_MacroAssembler _masm(&cbuf);
 
   Register Rtoc = as_Register(ra_->get_encode(this));
-  CodeSection* consts_section = cbuf.consts();
-  int consts_size = cbuf.insts()->align_at_start(consts_section->size());
+  CodeSection* consts_section = __ code()->consts();
+  CodeSection* insts_section = __ code()->insts();
+  int consts_size = insts_section->align_at_start(consts_section->size());
   assert(constant_table.size() == consts_size, "must be equal");
 
   if (consts_section->size()) {
     assert((CodeBuffer::SECT_CONSTS + 1) == CodeBuffer::SECT_INSTS,
            "insts must be immediately follow consts");
     // Materialize the constant table base.
-    address baseaddr = cbuf.insts()->start() - consts_size + -(constant_table.table_base_offset());
+    address baseaddr = insts_section->start() - consts_size + -(constant_table.table_base_offset());
     jint offs = (baseaddr - __ pc()) >> 2;
     guarantee(Assembler::is_simm(offs, 20), "Not signed 20-bit offset");
     __ pcaddi(Rtoc, offs);
@@ -2187,9 +2158,8 @@ void MachPrologNode::format( PhaseRegAlloc *ra_, outputStream* st ) const {
 #endif
 
 
-void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
+void MachPrologNode::emit(C2_MacroAssembler* masm, PhaseRegAlloc *ra_) const {
   Compile* C = ra_->C;
-  C2_MacroAssembler _masm(&cbuf);
 
   int framesize = C->output()->frame_size_in_bytes();
   int bangsize = C->output()->bang_size_in_bytes();
@@ -2238,11 +2208,11 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
         guard = &stub->guard();
       }
       // In the C2 code, we move the non-hot part of nmethod entry barriers out-of-line to a stub.
-      bs->nmethod_entry_barrier(&_masm, slow_path, continuation, guard);
+      bs->nmethod_entry_barrier(masm, slow_path, continuation, guard);
     }
   }
 
-  C->output()->set_frame_complete(cbuf.insts_size());
+  C->output()->set_frame_complete(__ offset());
   if (C->has_mach_constant_base_node()) {
     // NOTE: We set the table base offset here because users might be
     // emitted before MachConstantBaseNode.
@@ -2429,7 +2399,6 @@ bool needs_releasing_store(const Node *n)
 encode %{
 
   enc_class Java_To_Runtime (method meth) %{    // CALL Java_To_Runtime, Java_To_Runtime_Leaf
-    C2_MacroAssembler _masm(&cbuf);
     // This is the instruction starting address for relocation info.
     __ block_comment("Java_To_Runtime");
     __ relocate(relocInfo::runtime_call_type);
@@ -2440,7 +2409,6 @@ encode %{
   enc_class Java_Static_Call (method meth) %{    // JAVA STATIC CALL
     // CALL to fixup routine.  Fixup routine uses ScopeDesc info to determine
     // who we intended to call.
-    C2_MacroAssembler _masm(&cbuf);
     address addr = (address)$meth$$method;
     address call;
     __ block_comment("Java_Static_Call");
@@ -2458,7 +2426,7 @@ encode %{
       __ nop();
       __ block_comment("call JVM_EnsureMaterializedForStackWalk (elided)");
     } else {
-      int method_index = resolved_method_index(cbuf);
+      int method_index = resolved_method_index(masm);
       RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index)
                                      : static_call_Relocation::spec(method_index);
       call = __ trampoline_call(AddressLiteral(addr, rspec));
@@ -2469,10 +2437,10 @@ encode %{
       if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
         // Calls of the same statically bound method can share
         // a stub to the interpreter.
-        cbuf.shared_stub_to_interp_for(_method, call - cbuf.insts_begin());
+        __ code()->shared_stub_to_interp_for(_method, call - (__ begin()));
       } else {
         // Emit stub for static call
-        address stub = CompiledDirectCall::emit_to_interp_stub(cbuf, call);
+        address stub = CompiledDirectCall::emit_to_interp_stub(masm, call);
         if (stub == nullptr) {
           ciEnv::current()->record_failure("CodeCache is full");
           return;
@@ -2487,9 +2455,8 @@ encode %{
   // [Ref: LIR_Assembler::ic_call() ]
   //
   enc_class Java_Dynamic_Call (method meth) %{    // JAVA DYNAMIC CALL
-    C2_MacroAssembler _masm(&cbuf);
     __ block_comment("Java_Dynamic_Call");
-    address call = __ ic_call((address)$meth$$method, resolved_method_index(cbuf));
+    address call = __ ic_call((address)$meth$$method, resolved_method_index(masm));
     if (call == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
@@ -2512,7 +2479,6 @@ encode %{
     //    4bc     mov   S2, nullptr #@loadConP
     //    4c0     beq   S1, S2, B21 #@branchConP  P=0.999999 C=-1.000000
     //
-    C2_MacroAssembler _masm(&cbuf);
     Label done;
     __ check_klass_subtype_slow_path<false>(sub, super, length, tmp,
         nullptr, &miss,
@@ -4829,8 +4795,7 @@ instruct RethrowException()
   ins_encode %{
     __ block_comment("@ RethrowException");
 
-    cbuf.set_insts_mark();
-    cbuf.relocate(cbuf.insts_mark(), runtime_call_Relocation::spec());
+    __ relocate(runtime_call_Relocation::spec());
 
     // call OptoRuntime::rethrow_stub to get the exception handler in parent method
     __ patchable_jump((address)OptoRuntime::rethrow_stub());

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1103,8 +1103,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
     __ b(exit);
 
-    CodeBuffer* cbuf = masm->code_section()->outer();
-    CompiledDirectCall::emit_to_interp_stub(*cbuf, mark);
+    CompiledDirectCall::emit_to_interp_stub(masm, mark);
   }
 
   // compiled entry
@@ -1168,8 +1167,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
     __ jr(T4);
   }
 
-  CodeBuffer* cbuf = masm->code_section()->outer();
-  CompiledDirectCall::emit_to_interp_stub(*cbuf, mark);
+  CompiledDirectCall::emit_to_interp_stub(masm, mark);
 }
 
 static void gen_continuation_yield(MacroAssembler* masm,

--- a/src/hotspot/cpu/loongarch/stackChunkFrameStream_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/stackChunkFrameStream_loongarch.inline.hpp
@@ -35,7 +35,7 @@ template <ChunkFrames frame_kind>
 inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   assert(!is_done(), "");
   intptr_t* p = (intptr_t*)p0;
-  int argsize = is_compiled() ? (_cb->as_nmethod()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord : 0;
+  int argsize = is_compiled() ? (_cb->as_nmethod()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord : 0;
   int frame_size = _cb->frame_size() + argsize;
   return p == sp() - 2 || ((p - unextended_sp()) >= 0 && (p - unextended_sp()) < frame_size);
 }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -23,8 +23,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2022. These
- * modifications are Copyright (c) 2019, 2022, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2024. These
+ * modifications are Copyright (c) 2019, 2024, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -1705,17 +1705,17 @@ void PhaseOutput::fill_buffer(C2_MacroAssembler* masm, uint* blk_starts) {
       n->emit(masm, C->regalloc());
       current_offset = masm->offset();
 #if defined(LOONGARCH)
-      if (!n->is_Proj() && (cb->insts()->end() != badAddress)) {
+      if (!n->is_Proj() && (masm->code()->insts()->end() != badAddress)) {
         // For LOONGARCH, the first instruction of the previous node (usually a instruction sequence) sometime
         // is not the instruction which access memory. adjust is needed. previous_offset points to the
-        // instruction which access memory. Instruction size is 4. cb->insts_size() and
-        // cb->insts()->end() are the location of current instruction.
+        // instruction which access memory. Instruction size is 4. masm->code()->insts_size() and
+        // masm->code()->insts()->end() are the location of current instruction.
         int adjust = 4;
-        NativeInstruction* inst = (NativeInstruction*) (cb->insts()->end() - 4);
+        NativeInstruction* inst = (NativeInstruction*) (masm->code()->insts()->end() - 4);
         if (inst->is_sync()) {
           // a sync may be the last instruction, see store_B_immI_enc_sync
           adjust += 4;
-          inst = (NativeInstruction*) (cb->insts()->end() - 8);
+          inst = (NativeInstruction*) (masm->code()->insts()->end() - 8);
         }
         previous_offset = current_offset - adjust;
       }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/loongarch64/linux/LinuxLoongArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/loongarch64/linux/LinuxLoongArch64Linker.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,11 +63,6 @@ public final class LinuxLoongArch64Linker extends AbstractLinker {
     @Override
     protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
         return LinuxLoongArch64CallArranger.arrangeUpcall(targetType, function, options);
-    }
-
-    @Override
-    protected ByteOrder linkerByteOrder() {
-        return ByteOrder.LITTLE_ENDIAN;
     }
 
     @Override


### PR DESCRIPTION
34102: LA port of 8241503: C2: Share MacroAssembler between mach nodes during code emission
34101: LA port of 8327743: JVM crash in hotspot/share/runtime/javaThread.cpp - failed: held monitor count should be equal to jni: 0 != 1
34100: LA port of 8325469: Freeze/Thaw code can crash in the presence of OSR frames
34099: LA port of 8330049: Remove unused AbstractLinker::linkerByteOrder