### PR TITLE
Update (2024.05.24)

### DIFF
--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -242,12 +242,6 @@ void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index,
     get_2_byte_integer_at_bcp(index, AT, bcp_offset);
   } else if (index_size == sizeof(u4)) {
     get_4_byte_integer_at_bcp(index, bcp_offset);
-    // Check if the secondary index definition is still ~x, otherwise
-    // we have to change the following assembler code to calculate the
-    // plain index.
-    assert(ConstantPool::decode_invokedynamic_index(~123) == 123, "else change next line");
-    nor(index, index, R0);
-    slli_w(index, index, 0);
   } else if (index_size == sizeof(u1)) {
     ld_bu(index, BCP, bcp_offset);
   } else {

--- a/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,6 +116,11 @@
   // Does the CPU supports vector variable shift instructions?
   static constexpr bool supports_vector_variable_shifts(void) {
     return true;
+  }
+
+  // Does target support predicated operation emulation.
+  static bool supports_vector_predicate_op_emulation(int vopc, int vlen, BasicType bt) {
+    return false;
   }
 
   // Does the CPU supports vector variable rotate instructions?

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -563,7 +563,7 @@ class StubGenerator: public StubCodeGenerator {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
 
     {
-      UnsafeCopyMemoryMark ucmm(this, true, true);
+      UnsafeMemoryAccessMark umam(this, true, true);
       Label loop, le32, le16, le8, lt8;
 
       __ bind(entry);
@@ -666,7 +666,7 @@ class StubGenerator: public StubCodeGenerator {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
 
     {
-      UnsafeCopyMemoryMark ucmm(this, true, true);
+      UnsafeMemoryAccessMark umam(this, true, true);
       Label loop, le64, le32, le16, lt16;
 
       __ bind(entry);
@@ -759,7 +759,7 @@ class StubGenerator: public StubCodeGenerator {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
 
     {
-      UnsafeCopyMemoryMark ucmm(this, true, true);
+      UnsafeMemoryAccessMark umam(this, true, true);
       Label loop, le128, le64, le32, lt32;
 
       __ bind(entry);
@@ -849,7 +849,7 @@ class StubGenerator: public StubCodeGenerator {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
 
     {
-      UnsafeCopyMemoryMark ucmm(this, true, true);
+      UnsafeMemoryAccessMark umam(this, true, true);
       Label loop, le32, le16, le8, lt8;
 
       __ bind(entry);
@@ -949,7 +949,7 @@ class StubGenerator: public StubCodeGenerator {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
 
     {
-      UnsafeCopyMemoryMark ucmm(this, true, true);
+      UnsafeMemoryAccessMark umam(this, true, true);
       Label loop, le64, le32, le16, lt16;
 
       __ bind(entry);
@@ -1039,7 +1039,7 @@ class StubGenerator: public StubCodeGenerator {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
 
     {
-      UnsafeCopyMemoryMark ucmm(this, true, true);
+      UnsafeMemoryAccessMark umam(this, true, true);
       Label loop, le128, le64, le32, lt32;
 
       __ bind(entry);
@@ -2095,7 +2095,7 @@ class StubGenerator: public StubCodeGenerator {
     __ jr(RA);
 
     {
-      UnsafeCopyMemoryMark ucmm(this, true, true);
+      UnsafeMemoryAccessMark umam(this, true, true);
       // 1:
       __ bind(L1);
       bs->copy_load_at(_masm, decorators, type, 8, T8, Address(A0, 0), gct1);
@@ -5786,8 +5786,8 @@ static const int64_t right_3_bits = right_n_bits(3);
                                  SharedRuntime::throw_delayed_StackOverflowError));
 
     // Initialize table for copy memory (arraycopy) check.
-    if (UnsafeCopyMemory::_table == nullptr) {
-      UnsafeCopyMemory::create_table(8 + 4 ZGC_ONLY(+ (UseZGC && ZGenerational ? 14 : 0))); // 8 for copyMemory; 4 for setMemory
+    if (UnsafeMemoryAccess::_table == nullptr) {
+      UnsafeMemoryAccess::create_table(8 + 4 ZGC_ONLY(+ (UseZGC && ZGenerational ? 14 : 0))); // 8 for copyMemory; 4 for setMemory
     }
 
     if (UseCRC32Intrinsics) {

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5787,7 +5787,7 @@ static const int64_t right_3_bits = right_n_bits(3);
 
     // Initialize table for copy memory (arraycopy) check.
     if (UnsafeCopyMemory::_table == nullptr) {
-      UnsafeCopyMemory::create_table(8 ZGC_ONLY(+ (UseZGC && ZGenerational ? 14 : 0)));
+      UnsafeCopyMemory::create_table(8 + 4 ZGC_ONLY(+ (UseZGC && ZGenerational ? 14 : 0))); // 8 for copyMemory; 4 for setMemory
     }
 
     if (UseCRC32Intrinsics) {

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -3644,7 +3644,7 @@ void TemplateTable::_new() {
 
   // get instance_size in InstanceKlass (scaled to a count of bytes)
   __ ld_w(T0, T3, in_bytes(Klass::layout_helper_offset()) );
-  // test to see if it has a finalizer or is malformed in some way
+  // test to see if is malformed in some way
   __ test_bit(AT, T0, exact_log2(Klass::_lh_instance_slow_path_bit));
   __ bnez(AT, slow_case);
 

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -242,10 +242,10 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 #ifdef PRINT_SIGNAL_HANDLE
         tty->print("cb = %lx, nm = %lx\n", cb, nm);
 #endif
-        bool is_unsafe_arraycopy = (thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc));
-        if ((nm != nullptr && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
+        bool is_unsafe_memory_access = (thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc));
+        if ((nm != nullptr && nm->has_unsafe_access()) || is_unsafe_memory_access) {
           address next_pc = pc + NativeInstruction::nop_instruction_size;
-          if (is_unsafe_arraycopy) {
+          if (is_unsafe_memory_access) {
             next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
           }
           stub = SharedRuntime::handle_unsafe_access(thread, next_pc);

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -242,11 +242,11 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 #ifdef PRINT_SIGNAL_HANDLE
         tty->print("cb = %lx, nm = %lx\n", cb, nm);
 #endif
-        bool is_unsafe_memory_access = (thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc));
+        bool is_unsafe_memory_access = (thread->doing_unsafe_access() && UnsafeMemoryAccess::contains_pc(pc));
         if ((nm != nullptr && nm->has_unsafe_access()) || is_unsafe_memory_access) {
           address next_pc = pc + NativeInstruction::nop_instruction_size;
           if (is_unsafe_memory_access) {
-            next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
+            next_pc = UnsafeMemoryAccess::page_error_continue_pc(pc);
           }
           stub = SharedRuntime::handle_unsafe_access(thread, next_pc);
         }
@@ -292,8 +292,8 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       tty->print_cr("SIGBUS in vm thread \n");
 #endif
       address next_pc = pc + NativeInstruction::nop_instruction_size;
-      if (UnsafeCopyMemory::contains_pc(pc)) {
-        next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
+      if (UnsafeMemoryAccess::contains_pc(pc)) {
+        next_pc = UnsafeMemoryAccess::page_error_continue_pc(pc);
       }
       stub = SharedRuntime::handle_unsafe_access(thread, next_pc);
     }


### PR DESCRIPTION
34129: LA port of 8330388: Remove invokedynamic cache index encoding
34128: LA port of 8330821: Rename UnsafeCopyMemory
34127: LA port of 8329331: Intrinsify Unsafe::setMemory
34126: LA port of 8318650: Optimized subword gather for x86 targets.
34125: LA port of 8320522: Remove code related to `RegisterFinalizersAtInit`