### PR TITLE
Update (2024.06.27)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
@@ -475,7 +475,7 @@ OptoReg::Name BarrierSetAssembler::refine_register(const Node* node, OptoReg::Na
 
 void SaveLiveRegisters::initialize(BarrierStubC2* stub) {
   // Record registers that needs to be saved/restored
-  RegMaskIterator rmi(stub->live());
+  RegMaskIterator rmi(stub->preserve_set());
   while (rmi.has_next()) {
     const OptoReg::Name opto_reg = rmi.next();
     if (OptoReg::is_reg(opto_reg)) {
@@ -495,12 +495,8 @@ void SaveLiveRegisters::initialize(BarrierStubC2* stub) {
     }
   }
 
-  // Remove C-ABI SOE registers, scratch regs and _ref register that will be updated
-  if (stub->result() != noreg) {
-    _gp_regs -= RegSet::range(S0, S7) + RegSet::of(SP, SCR1, SCR2, stub->result());
-  } else {
-    _gp_regs -= RegSet::range(S0, S7) + RegSet::of(SP, SCR1, SCR2);
-  }
+  // Remove C-ABI SOE registers and scratch regs
+  _gp_regs -= RegSet::range(S0, S7) + RegSet::of(SP, SCR1, SCR2);
 }
 
 SaveLiveRegisters::SaveLiveRegisters(MacroAssembler* masm, BarrierStubC2* stub)

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -592,6 +592,10 @@ reg_class no_CR_reg %{
   return _NO_CR_REG_mask;
 %}
 
+reg_class no_FP_reg %{
+  return _NO_FP_REG_mask;
+%}
+
 reg_class p_has_s6_reg %{
   return _PTR_HAS_S6_REG_mask;
 %}
@@ -799,6 +803,7 @@ extern RegMask _ANY_REG32_mask;
 extern RegMask _ANY_REG_mask;
 extern RegMask _PTR_REG_mask;
 extern RegMask _NO_CR_REG_mask;
+extern RegMask _NO_FP_REG_mask;
 extern RegMask _PTR_HAS_S6_REG_mask;
 
 class CallStubImpl {
@@ -878,6 +883,7 @@ RegMask _ANY_REG32_mask;
 RegMask _ANY_REG_mask;
 RegMask _PTR_REG_mask;
 RegMask _NO_CR_REG_mask;
+RegMask _NO_FP_REG_mask;
 RegMask _PTR_HAS_S6_REG_mask;
 
 void reg_mask_init() {
@@ -909,6 +915,9 @@ void reg_mask_init() {
 
   _NO_CR_REG_mask = _PTR_REG_mask;
   _NO_CR_REG_mask.SUBTRACT(_T0_LONG_REG_mask);
+
+  _NO_FP_REG_mask = _PTR_REG_mask;
+  _NO_FP_REG_mask.Remove(OptoReg::as_OptoReg(r22->as_VMReg()));
 
   _PTR_HAS_S6_REG_mask.OR(_S6_LONG_REG_mask);
 }
@@ -3276,6 +3285,17 @@ operand no_CR_mRegP() %{
   interface(REG_INTER);
 %}
 
+// This operand is not allowed to use FP even if
+// FP is not used to hold the frame pointer.
+operand no_FP_mRegP() %{
+  constraint(ALLOC_IN_RC(no_FP_reg));
+  match(RegP);
+  match(mRegP);
+
+  format %{  %}
+  interface(REG_INTER);
+%}
+
 operand p_has_s6_mRegP() %{
   constraint(ALLOC_IN_RC(p_has_s6_reg));
   match(RegP);
@@ -4729,7 +4749,9 @@ instruct loadConNKlass(mRegN dst, immNKlass src) %{
 // Also known as an 'interprocedural jump'.
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
-instruct TailCalljmpInd(mRegP jump_target, s3_RegP method_ptr) %{
+// Don't use FP for 'jump_target' because a MachEpilogNode has already been
+// emitted just above the TailCall which has reset FP to the caller state.
+instruct TailCalljmpInd(no_FP_mRegP jump_target, s3_RegP method_ptr) %{
   match(TailCall jump_target method_ptr);
 
   format %{ "JMP    $jump_target \t# @TailCalljmpInd" %}
@@ -10559,7 +10581,7 @@ instruct Ret() %{
 // "restore" before this instruction (in Epilogue), we need to materialize it
 // in %i0.
 //FIXME
-instruct tailjmpInd(mRegP jump_target, a0_RegP ex_oop, mA1RegI exception_pc) %{
+instruct tailjmpInd(no_FP_mRegP jump_target, a0_RegP ex_oop, mA1RegI exception_pc) %{
   match( TailJump jump_target ex_oop );
   ins_cost(200);
   format %{ "Jmp     $jump_target  ; ex_oop = $ex_oop #@tailjmpInd" %}


### PR DESCRIPTION
34182: LA port of 8329258: TailCall should not use frame pointer register for jump target
34180: LA port of 8331418: ZGC: generalize barrier liveness logic