### PR TITLE
Update (2024.09.10)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -1196,7 +1196,8 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
                       arrayOopDesc::base_offset_in_bytes(op->type()),
                       array_element_size(op->type()),
                       op->klass()->as_register(),
-                      *op->stub()->entry());
+                      *op->stub()->entry(),
+                      op->zero_array());
   }
   __ bind(*op->stub()->continuation());
 }
@@ -2772,7 +2773,9 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
     __ call_VM_leaf(entry, 3);
   }
 
-  __ bind(*stub->continuation());
+  if (stub != nullptr) {
+    __ bind(*stub->continuation());
+  }
 }
 
 void LIR_Assembler::emit_lock(LIR_OpLock* op) {

--- a/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
@@ -860,7 +860,13 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
   assert(x->number_of_arguments() == 5, "wrong type");
 
   // Make all state_for calls early since they can emit code
-  CodeEmitInfo* info = state_for(x, x->state());
+  CodeEmitInfo* info = nullptr;
+  if (x->state_before() != nullptr && x->state_before()->force_reexecute()) {
+    info = state_for(x, x->state_before());
+    info->set_force_reexecute();
+  } else {
+    info = state_for(x, x->state());
+  }
 
   LIRItem src(x->argument_at(0), this);
   LIRItem src_pos(x->argument_at(1), this);
@@ -893,6 +899,9 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
   int flags;
   ciArrayKlass* expected_type;
   arraycopy_helper(x, &flags, &expected_type);
+  if (x->check_flag(Instruction::OmitChecksFlag)) {
+    flags = 0;
+  }
 
   __ arraycopy(src.result(), src_pos.result(), dst.result(), dst_pos.result(),
                length.result(), tmp, expected_type, flags, info); // does add_safepoint
@@ -1128,7 +1137,13 @@ void LIRGenerator::do_NewInstance(NewInstance* x) {
 }
 
 void LIRGenerator::do_NewTypeArray(NewTypeArray* x) {
-  CodeEmitInfo* info = state_for(x, x->state());
+  CodeEmitInfo* info = nullptr;
+  if (x->state_before() != nullptr && x->state_before()->force_reexecute()) {
+    info = state_for(x, x->state_before());
+    info->set_force_reexecute();
+  } else {
+    info = state_for(x, x->state());
+  }
 
   LIRItem length(x->length(), this);
   length.load_item_force(FrameMap::s0_opr);
@@ -1145,7 +1160,7 @@ void LIRGenerator::do_NewTypeArray(NewTypeArray* x) {
   __ metadata2reg(ciTypeArrayKlass::make(elem_type)->constant_encoding(), klass_reg);
 
   CodeStub* slow_path = new NewTypeArrayStub(klass_reg, len, reg, info);
-  __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, elem_type, klass_reg, slow_path);
+  __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, elem_type, klass_reg, slow_path, x->zero_array());
 
   LIR_Opr result = rlock_result(x);
   __ move(reg, result);

--- a/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch.hpp
@@ -94,8 +94,9 @@ using MacroAssembler::null_check;
   // base_offset_in_bytes: offset of first array element, in bytes
   // f                   : element scale factor
   // slow_case           : exit to slow case implementation if fast allocation fails
+  // zero_array          : zero the allocated array or not
   void allocate_array(Register obj, Register len, Register t, Register t2, int base_offset_in_bytes,
-                      int f, Register klass, Label& slow_case);
+                      int f, Register klass, Label& slow_case, bool zero_array);
 
   int rsp_offset() const { return _rsp_offset; }
   void set_rsp_offset(int n) { _rsp_offset = n; }

--- a/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
@@ -252,7 +252,8 @@ void C1_MacroAssembler::initialize_object(Register obj, Register klass, Register
 }
 
 void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, Register t2,
-                                       int base_offset_in_bytes, int f, Register klass, Label& slow_case) {
+                                       int base_offset_in_bytes, int f, Register klass,
+                                       Label& slow_case, bool zero_array) {
   assert_different_registers(obj, len, t1, t2, klass);
 
   // determine alignment mask
@@ -277,7 +278,9 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, 
   // following the length field in initialize_header().
   int base_offset = align_up(base_offset_in_bytes, BytesPerWord);
   // clear rest of allocated space
-  initialize_body(obj, arr_size, base_offset, t1, t2);
+  if (zero_array) {
+    initialize_body(obj, arr_size, base_offset, t1, t2);
+  }
 
   membar(StoreStore);
 

--- a/src/hotspot/cpu/loongarch/relocInfo_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/relocInfo_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,7 @@
 #include "runtime/safepoint.hpp"
 
 
-void Relocation::pd_set_data_value(address x, intptr_t o, bool verify_only) {
-  x += o;
+void Relocation::pd_set_data_value(address x, bool verify_only) {
   typedef Assembler::WhichOperand WhichOperand;
   WhichOperand which = (WhichOperand) format(); // that is, disp32 or imm, call32, narrow oop
   assert(which == Assembler::disp32_operand ||

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -45,8 +45,8 @@
 #include "utilities/macros.hpp"
 
 /*
- * This file has been modified by Loongson Technology in 2022, These
- * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2024, These
+ * modifications are Copyright (c) 2022, 2024, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -241,7 +241,7 @@ bool Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_counterTime:
 #endif
   case vmIntrinsics::_getObjectSize:
-#if defined(X86) || defined(AARCH64)
+#if defined(X86) || defined(AARCH64) || defined(LOONGARCH64)
   case vmIntrinsics::_clone:
 #endif
     break;

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -23,8 +23,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2022, These
- * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2024, These
+ * modifications are Copyright (c) 2022, 2024, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -359,7 +359,7 @@ LIR_OpArrayCopy::LIR_OpArrayCopy(LIR_Opr src, LIR_Opr src_pos, LIR_Opr dst, LIR_
   , _tmp(tmp)
   , _expected_type(expected_type)
   , _flags(flags) {
-#if defined(X86) || defined(AARCH64)
+#if defined(X86) || defined(AARCH64) || defined(LOONGARCH64)
   if (expected_type != nullptr && flags == 0) {
     _stub = nullptr;
   } else {


### PR DESCRIPTION
34245: LA port of 8302850: Implement C1 clone intrinsic that reuses arraycopy code for primitive arrays
34244: LA port of 8331862: Remove split relocation info implementation