### PR TITLE
Update (2024.09.10)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.cpp
@@ -230,7 +230,7 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
 
   // Does store cross heap regions?
   __ xorr(tmp1, store_addr, new_val);
-  __ srli_d(tmp1, tmp1, HeapRegion::LogOfHRGrainBytes);
+  __ srli_d(tmp1, tmp1, G1HeapRegion::LogOfHRGrainBytes);
   __ beqz(tmp1, done);
 
   // crosses regions, storing null?

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
@@ -302,20 +302,6 @@ void BarrierSetAssembler::tlab_allocate(MacroAssembler* masm, Register obj,
   // verify_tlab();
 }
 
-void BarrierSetAssembler::incr_allocated_bytes(MacroAssembler* masm,
-                                               Register var_size_in_bytes,
-                                               int con_size_in_bytes,
-                                               Register t1) {
-  assert(t1->is_valid(), "need temp reg");
-
-  __ ld_d(t1, Address(TREG, JavaThread::allocated_bytes_offset()));
-  if (var_size_in_bytes->is_valid())
-    __ add_d(t1, t1, var_size_in_bytes);
-  else
-    __ addi_d(t1, t1, con_size_in_bytes);
-  __ st_d(t1, Address(TREG, JavaThread::allocated_bytes_offset()));
-}
-
 static volatile uint32_t _patching_epoch = 0;
 
 address BarrierSetAssembler::patching_epoch_addr() {

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.hpp
@@ -47,12 +47,6 @@ enum class NMethodPatchingType {
 };
 
 class BarrierSetAssembler: public CHeapObj<mtGC> {
-private:
-  void incr_allocated_bytes(MacroAssembler* masm,
-                            Register var_size_in_bytes,
-                            int con_size_in_bytes,
-                            Register t1);
-
 public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
                                   Register src, Register dst, Register count, RegSet saved_regs) {}

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -1132,23 +1132,6 @@ void MacroAssembler::tlab_allocate(Register obj,
   bs->tlab_allocate(this, obj, var_size_in_bytes, con_size_in_bytes, t1, t2, slow_case);
 }
 
-void MacroAssembler::incr_allocated_bytes(Register thread,
-                                          Register var_size_in_bytes,
-                                          int con_size_in_bytes,
-                                          Register t1) {
-  if (!thread->is_valid()) {
-    thread = TREG;
-  }
-
-  ld_d(AT, Address(thread, JavaThread::allocated_bytes_offset()));
-  if (var_size_in_bytes->is_valid()) {
-    add_d(AT, AT, var_size_in_bytes);
-  } else {
-    addi_d(AT, AT, con_size_in_bytes);
-  }
-  st_d(AT, Address(thread, JavaThread::allocated_bytes_offset()));
-}
-
 void MacroAssembler::li(Register rd, jlong value) {
   jlong hi12 = bitfield(value, 52, 12);
   jlong lo52 = bitfield(value,  0, 52);

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -339,9 +339,6 @@ class MacroAssembler: public Assembler {
     Register t2,                       // temp register
     Label&   slow_case                 // continuation point if fast allocation fails
   );
-  void incr_allocated_bytes(Register thread,
-                            Register var_size_in_bytes, int con_size_in_bytes,
-                            Register t1 = noreg);
   // interface method calling
   void lookup_interface_method(Register recv_klass,
                                Register intf_klass,

--- a/src/hotspot/os_cpu/linux_loongarch/safefetch_linux_loongarch64.S
+++ b/src/hotspot/os_cpu/linux_loongarch/safefetch_linux_loongarch64.S
@@ -24,29 +24,17 @@
  *
  */
 
-    .globl SafeFetchN_impl
-    .globl _SafeFetchN_fault
-    .globl _SafeFetchN_continuation
-    .globl SafeFetch32_impl
-    .globl _SafeFetch32_fault
-    .globl _SafeFetch32_continuation
-
-    .hidden SafeFetchN_impl
-    .hidden _SafeFetchN_fault
-    .hidden _SafeFetchN_continuation
-    .hidden SafeFetch32_impl
-    .hidden _SafeFetch32_fault
-    .hidden _SafeFetch32_continuation
+#include "defs.S.inc"
 
     # Support for int SafeFetch32(int* address, int defaultval);
     #
     #  a0 : address
     #  a1 : defaultval
-SafeFetch32_impl:
-_SafeFetch32_fault:
+DECLARE_FUNC(SafeFetch32_impl):
+DECLARE_FUNC(_SafeFetch32_fault):
     ld.w  $r4, $r4, 0
     jr    $r1
-_SafeFetch32_continuation:
+DECLARE_FUNC(_SafeFetch32_continuation):
     or    $r4, $r5, $r0
     jr    $r1
 
@@ -54,10 +42,10 @@ _SafeFetch32_continuation:
     #
     #  a0 : address
     #  a1 : defaultval
-SafeFetchN_impl:
-_SafeFetchN_fault:
+DECLARE_FUNC(SafeFetchN_impl):
+DECLARE_FUNC(_SafeFetchN_fault):
     ld.d  $r4, $r4, 0
     jr    $r1
-_SafeFetchN_continuation:
+DECLARE_FUNC(_SafeFetchN_continuation):
     or    $r4, $r5, $r0
     jr    $r1


### PR DESCRIPTION
34351: LA port of 8331921: Hotspot assembler files should use common logic to setup exported functions
34350: LA port of 8330694: Rename 'HeapRegion' to 'G1HeapRegion'
34349: LA port of 8332082: Shenandoah: Use consistent tests to determine when pre-write barrier is active
34348: LA port of 8332676: Remove unused BarrierSetAssembler::incr_allocated_bytes