### PR TITLE
Update (2024.09.10)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/z/zBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/z/zBarrierSetAssembler_loongarch.cpp
@@ -1088,6 +1088,7 @@ public:
 #define __ masm->
 
 void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, ZLoadBarrierStubC2* stub) const {
+  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   BLOCK_COMMENT("ZLoadBarrierStubC2");
 
   // Stub entry
@@ -1105,6 +1106,7 @@ void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, Z
 }
 
 void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm, ZStoreBarrierStubC2* stub) const {
+  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   BLOCK_COMMENT("ZStoreBarrierStubC2");
 
   // Stub entry

--- a/src/hotspot/cpu/loongarch/register_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/register_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -466,14 +466,14 @@ typedef AbstractRegSet<FloatRegister> FloatRegSet;
 
 template <>
 inline Register AbstractRegSet<Register>::first() {
-  uint32_t first = _bitset & -_bitset;
-  return first ? as_Register(exact_log2(first)) : noreg;
+  if (_bitset == 0) { return noreg; }
+  return as_Register(count_trailing_zeros(_bitset));
 }
 
 template <>
 inline FloatRegister AbstractRegSet<FloatRegister>::first() {
-  uint32_t first = _bitset & -_bitset;
-  return first ? as_FloatRegister(exact_log2(first)) : fnoreg;
+  if (_bitset == 0) { return fnoreg; }
+  return as_FloatRegister(count_trailing_zeros(_bitset));
 }
 
 #endif //CPU_LOONGARCH_REGISTER_LOONGARCH_HPP


### PR DESCRIPTION
34357: LA port of 8319822: Use a linear-time algorithm for assert_different_registers()
34356: LA port of 8333226: Regressions 2-3% in Compress ZGC after 8331253