### PR TITLE
Update (2024.09.10)

### DIFF
--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -28,7 +28,6 @@
 
 #include "asm/assembler.hpp"
 #include "code/vmreg.hpp"
-#include "runtime/rtmLocking.hpp"
 #include "utilities/macros.hpp"
 
 class OopMap;

--- a/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
@@ -150,6 +150,8 @@ class NativeCall: public NativeInstruction {
   // We have only bl.
   bool is_bl() const;
 
+  static int byte_size() { return instruction_size; }
+
   address instruction_address() const { return addr_at(instruction_offset); }
 
   address next_instruction_address() const {


### PR DESCRIPTION
34375: LA port of 8329141: Obsolete RTM flags and code
34374: LA port of 8333649: Allow different NativeCall encodings