### PR TITLE
Update (2024.09.11)

### DIFF
--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -1788,8 +1788,7 @@ void InterpreterMacroAssembler::notify_method_entry() {
     bind(L);
   }
 
-  {
-    SkipIfEqual skip(this, &DTraceMethodProbes, false);
+  if (DTraceMethodProbes) {
     get_method(c_rarg1);
     call_VM_leaf(
       CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry),
@@ -1827,8 +1826,7 @@ void InterpreterMacroAssembler::notify_method_exit(
     pop(state);
   }
 
-  {
-    SkipIfEqual skip(this, &DTraceMethodProbes, false);
+  if (DTraceMethodProbes) {
     push(state);
     get_method(c_rarg1);
     call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_exit),

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1714,8 +1714,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // We have all of the arguments setup at this point. We must not touch any register
   // argument registers at this point (what if we save/restore them there are no oop?
-  {
-    SkipIfEqual skip_if(masm, &DTraceMethodProbes, 0);
+  if (DTraceMethodProbes) {
     save_args(masm, total_c_args, c_arg, out_regs);
     __ mov_metadata(c_rarg1, method());
     __ call_VM_leaf(
@@ -1959,8 +1958,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
     __ bind(done);
   }
-  {
-    SkipIfEqual skip_if(masm, &DTraceMethodProbes, 0);
+  if (DTraceMethodProbes) {
     // Tell dtrace about this method exit
     save_native_result(masm, ret_type, stack_slots);
     int metadata_index = __ oop_recorder()->find_index( (method()));

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -3685,8 +3685,7 @@ void TemplateTable::_new() {
     __ store_klass_gap(FSR, R0);
     __ store_klass(FSR, T3);
 
-    {
-      SkipIfEqual skip_if(_masm, &DTraceAllocProbes, 0);
+    if (DTraceAllocProbes) {
       // Trigger dtrace event for fastpath
       __ push(atos);
       __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)), FSR);


### PR DESCRIPTION
34505: LA port of 8335946: DTrace code snippets should be generated when DTrace flags are enabled