### PR TITLE
Update (2024.10.17)

### DIFF
--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -4783,6 +4783,18 @@ instruct TailCalljmpInd(no_FP_mRegP jump_target, s3_RegP method_ptr) %{
   ins_pipe( pipe_jump );
 %}
 
+// Forward exception.
+instruct ForwardExceptionjmp()
+%{
+  match(ForwardException);
+
+  format %{ "jmp forward_exception_stub" %}
+  ins_encode %{
+    __ jmp(StubRoutines::forward_exception_entry(), relocInfo::runtime_call_type);
+  %}
+  ins_pipe( pipe_jump );
+%}
+
 // Create exception oop: created by stack-crawling runtime code.
 // Created exception is now available to this handler, and is setup
 // just prior to jumping to this handler.  No code emitted.

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -2750,8 +2750,8 @@ void MacroAssembler::lookup_secondary_supers_table_slow_path(Register r_super_kl
 
   // Check if bitmap is SECONDARY_SUPERS_BITMAP_FULL
   assert(Klass::SECONDARY_SUPERS_BITMAP_FULL == ~uintx(0), "Adjust this code");
-  addi_d(AT, r_bitmap, (u1)1);
-  beqz(AT, L_bitmap_full);
+  addi_w(AT, r_array_length, Klass::SECONDARY_SUPERS_TABLE_SIZE - 2);
+  blt(R0, AT, L_bitmap_full);
 
   // NB! Our caller has checked bits 0 and 1 in the bitmap. The
   // current slot (at secondary_supers[r_array_index]) has not yet


### PR DESCRIPTION
34730: LA port of 8337958: Out-of-bounds array access in secondary_super_cache
34729: LA port of 8337702: Use new ForwardExceptionNode to call StubRoutines::forward_exception_entry()