### PR TITLE
Update (2024.10.30)

### DIFF
--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -815,11 +815,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
 
     bind(slow_case);
     // Call the runtime routine for slow case
-    if (LockingMode == LM_LIGHTWEIGHT) {
-      call_VM(NOREG, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter_obj), scr_reg);
-    } else {
-      call_VM(NOREG, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter), lock_reg);
-    }
+    call_VM(NOREG, CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter), lock_reg);
     b(done);
 
     bind(count);

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -427,7 +427,7 @@ void MacroAssembler::reserved_stack_check() {
   // We have already removed our own frame.
   // throw_delayed_StackOverflowError will think that it's been
   // called by our caller.
-  li(AT, (long)StubRoutines::throw_delayed_StackOverflowError_entry());
+  li(AT, (long)SharedRuntime::throw_delayed_StackOverflowError_entry());
   jr(AT);
   should_not_reach_here();
 

--- a/src/hotspot/cpu/loongarch/methodHandles_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/methodHandles_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,7 @@ void MethodHandles::jump_from_method_handle(MacroAssembler* _masm, Register meth
   __ jr(T4);
 
   __ bind(L_no_such_method);
-  address wrong_method = StubRoutines::throw_AbstractMethodError_entry();
+  address wrong_method = SharedRuntime::throw_AbstractMethodError_entry();
   __ jmp(wrong_method, relocInfo::runtime_call_type);
 }
 
@@ -451,7 +451,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
 
     if (iid == vmIntrinsics::_linkToInterface) {
       __ bind(L_incompatible_class_change_error);
-      address icce_entry= StubRoutines::throw_IncompatibleClassChangeError_entry();
+      address icce_entry= SharedRuntime::throw_IncompatibleClassChangeError_entry();
       __ jmp(icce_entry, relocInfo::runtime_call_type);
     }
   }

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -43,6 +43,7 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stubRoutines.hpp"
+#include "runtime/timerTrace.hpp"
 #include "runtime/vframeArray.hpp"
 #include "vmreg_loongarch.inline.hpp"
 #ifdef COMPILER2
@@ -2684,5 +2685,194 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
   RuntimeStub* tmp= RuntimeStub::new_runtime_stub(name, &buffer, frame_complete, frame_size_words, oop_maps, true);
   return tmp;
 }
+
+// Continuation point for throwing of implicit exceptions that are
+// not handled in the current activation. Fabricates an exception
+// oop and initiates normal exception dispatching in this
+// frame. Since we need to preserve callee-saved values (currently
+// only for C2, but done for C1 as well) we need a callee-saved oop
+// map and therefore have to make these stubs into RuntimeStubs
+// rather than BufferBlobs.  If the compiler needs all registers to
+// be preserved between the fault point and the exception handler
+// then it must assume responsibility for that in
+// AbstractCompiler::continuation_for_implicit_null_exception or
+// continuation_for_implicit_division_by_zero_exception. All other
+// implicit exceptions (e.g., NullPointerException or
+// AbstractMethodError on entry) are either at call sites or
+// otherwise assume that stack unwinding will be initiated, so
+// caller saved registers were assumed volatile in the compiler.
+
+RuntimeStub* SharedRuntime::generate_throw_exception(const char* name, address runtime_entry) {
+  // Information about frame layout at time of blocking runtime call.
+  // Note that we only have to preserve callee-saved registers since
+  // the compilers are responsible for supplying a continuation point
+  // if they expect all registers to be preserved.
+  assert(frame::arg_reg_save_area_bytes == 0, "not expecting frame reg save area");
+
+  enum layout {
+    fp_off = 0,
+    fp_off2,
+    return_off,
+    return_off2,
+    framesize // inclusive of return address
+  };
+
+  const int insts_size = 1024;
+  const int locs_size  = 64;
+
+  ResourceMark rm;
+  const char* timer_msg = "SharedRuntime generate_throw_exception";
+  TraceTime timer(timer_msg, TRACETIME_LOG(Info, startuptime));
+
+  CodeBuffer code(name, insts_size, locs_size);
+  OopMapSet* oop_maps = new OopMapSet();
+  MacroAssembler* masm = new MacroAssembler(&code);
+
+  address start = __ pc();
+
+  // This is an inlined and slightly modified version of call_VM
+  // which has the ability to fetch the return PC out of
+  // thread-local storage and also sets up last_Java_sp slightly
+  // differently than the real call_VM
+
+  __ enter(); // Save FP and RA before call
+
+  // RA and FP are already in place
+  __ addi_d(SP, FP, 0 - ((unsigned)framesize << LogBytesPerInt)); // prolog
+
+  int frame_complete = __ pc() - start;
+
+  // Set up last_Java_sp and last_Java_fp
+  Label before_call;
+  address the_pc = __ pc();
+  __ bind(before_call);
+  __ set_last_Java_frame(SP, FP, before_call);
+
+  // TODO: the stack is unaligned before calling this stub
+  assert(StackAlignmentInBytes == 16, "must be");
+  __ bstrins_d(SP, R0, 3, 0);
+
+  __ move(c_rarg0, TREG);
+  __ call(runtime_entry, relocInfo::runtime_call_type);
+
+  // Generate oop map
+  OopMap* map = new OopMap(framesize, 0);
+  oop_maps->add_gc_map(the_pc - start, map);
+
+  __ reset_last_Java_frame(true);
+
+  __ leave();
+
+  // check for pending exceptions
+#ifdef ASSERT
+  Label L;
+  __ ld_d(AT, Address(TREG, Thread::pending_exception_offset()));
+  __ bnez(AT, L);
+  __ should_not_reach_here();
+  __ bind(L);
+#endif //ASSERT
+  __ jmp(StubRoutines::forward_exception_entry(), relocInfo::runtime_call_type);
+
+  // codeBlob framesize is in words (not VMRegImpl::slot_size)
+  RuntimeStub* stub =
+    RuntimeStub::new_runtime_stub(name,
+                                  &code,
+                                  frame_complete,
+                                  (framesize >> (LogBytesPerWord - LogBytesPerInt)),
+                                  oop_maps, false);
+
+  return stub;
+}
+
+#if INCLUDE_JFR
+
+// For c2: c_rarg0 is junk, call to runtime to write a checkpoint.
+// It returns a jobject handle to the event writer.
+// The handle is dereferenced and the return value is the event writer oop.
+RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
+  enum layout {
+    fp_off,
+    fp_off2,
+    return_off,
+    return_off2,
+    framesize // inclusive of return address
+  };
+
+  CodeBuffer code("jfr_write_checkpoint", 1024, 64);
+  MacroAssembler* masm = new MacroAssembler(&code);
+
+  address start = __ pc();
+  __ enter();
+  int frame_complete = __ pc() - start;
+
+  Label L;
+  address the_pc = __ pc();
+  __ bind(L);
+  __ set_last_Java_frame(TREG, SP, FP, L);
+  __ move(c_rarg0, TREG);
+  __ call_VM_leaf(CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::write_checkpoint), 1);
+  __ reset_last_Java_frame(true);
+  // A0 is jobject handle result, unpack and process it through a barrier.
+  // For zBarrierSet, tmp1 shall not be SCR1 or same as dst
+  __ resolve_global_jobject(A0, SCR2, SCR1);
+
+  __ leave();
+  __ jr(RA);
+
+  OopMapSet* oop_maps = new OopMapSet();
+  OopMap* map = new OopMap(framesize, 1);
+  oop_maps->add_gc_map(frame_complete, map);
+
+  RuntimeStub* stub =
+    RuntimeStub::new_runtime_stub(code.name(),
+                                  &code,
+                                  frame_complete,
+                                  (framesize >> (LogBytesPerWord - LogBytesPerInt)),
+                                  oop_maps,
+                                  false);
+  return stub;
+}
+
+// For c2: call to return a leased buffer.
+RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
+  enum layout {
+    fp_off,
+    fp_off2,
+    return_off,
+    return_off2,
+    framesize // inclusive of return address
+  };
+
+  int insts_size = 1024;
+  int locs_size = 64;
+  CodeBuffer code("jfr_return_lease", insts_size, locs_size);
+  OopMapSet* oop_maps = new OopMapSet();
+  MacroAssembler* masm = new MacroAssembler(&code);
+
+  Label L;
+  address start = __ pc();
+  __ enter();
+  int frame_complete = __ pc() - start;
+  address the_pc = __ pc();
+  __ bind(L);
+  __ set_last_Java_frame(TREG, SP, FP, L);
+  __ move(c_rarg0, TREG);
+  __ call_VM_leaf(CAST_FROM_FN_PTR(address, JfrIntrinsicSupport::return_lease), 1);
+
+  __ reset_last_Java_frame(true);
+  __ leave();
+  __ jr(RA);
+
+  OopMap* map = new OopMap(framesize, 1);
+  oop_maps->add_gc_map(the_pc - start, map);
+
+  RuntimeStub* stub = // codeBlob framesize is in words (not VMRegImpl::slot_size)
+    RuntimeStub::new_runtime_stub("jfr_return_lease", &code, frame_complete,
+                                  (framesize >> (LogBytesPerWord - LogBytesPerInt)),
+                                  oop_maps, false);
+  return stub;
+}
+
+#endif // INCLUDE_JFR
 
 extern "C" int SpinPause() {return 0;}

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -835,8 +835,8 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
   // Note: the restored frame is not necessarily interpreted.
   // Use the shared runtime version of the StackOverflowError.
   __ move(SP, Rsender);
-  assert(StubRoutines::throw_StackOverflowError_entry() != nullptr, "stub not yet generated");
-  __ jmp(StubRoutines::throw_StackOverflowError_entry(), relocInfo::runtime_call_type);
+  assert(SharedRuntime::throw_StackOverflowError_entry() != nullptr, "stub not yet generated");
+  __ jmp(SharedRuntime::throw_StackOverflowError_entry(), relocInfo::runtime_call_type);
 
   // all done with frame size check
   __ bind(after_frame_check);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -23,8 +23,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2022, These
- * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2024, These
+ * modifications are Copyright (c) 2022, 2024, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -393,7 +393,7 @@ bool ObjectSynchronizer::quick_notify(oopDesc* obj, JavaThread* current, bool al
 }
 
 static bool useHeavyMonitors() {
-#if defined(X86) || defined(AARCH64) || defined(PPC64) || defined(RISCV64) || defined(S390)
+#if defined(X86) || defined(AARCH64) || defined(PPC64) || defined(RISCV64) || defined(S390) || defined(LOONGARCH64)
   return LockingMode == LM_MONITOR;
 #else
   return false;


### PR DESCRIPTION
34775: LightweightSynchronizer::exit asserts, missing lock
34774: LA port of 8337987: Relocate jfr and throw_exception stubs from StubGenerator to SharedRuntime
34773: LA port of 8315884: New Object to ObjectMonitor mapping