### PR TITLE
Update (2024.10.30)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch.hpp
@@ -56,8 +56,6 @@ friend class ArrayCopyStub;
   void casw(Register addr, Register newval, Register cmpval, Register result, bool sign);
   void casl(Register addr, Register newval, Register cmpval, Register result);
 
-  void poll_for_safepoint(relocInfo::relocType rtype, CodeEmitInfo* info = nullptr);
-
   static const int max_tableswitches = 20;
   struct tableswitch switches[max_tableswitches];
   int tableswitch_count;

--- a/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
@@ -52,8 +52,8 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(hdr, obj);
-    ld_w(hdr, Address(hdr, Klass::access_flags_offset()));
-    test_bit(SCR1, hdr, exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
+    ld_bu(hdr, Address(hdr, Klass::misc_flags_offset()));
+    test_bit(SCR1, hdr, exact_log2(KlassFlags::_misc_is_value_based_class));
     bnez(SCR1, slow_case);
   }
 

--- a/src/hotspot/cpu/loongarch/c1_Runtime1_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_Runtime1_loongarch_64.cpp
@@ -770,8 +770,8 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         Label register_finalizer;
         Register t = A5;
         __ load_klass(t, A0);
-        __ ld_w(t, Address(t, Klass::access_flags_offset()));
-        __ test_bit(SCR1, t, exact_log2(JVM_ACC_HAS_FINALIZER));
+        __ ld_bu(t, Address(t, Klass::misc_flags_offset()));
+        __ test_bit(SCR1, t, exact_log2(KlassFlags::_misc_has_finalizer));
         __ bnez(SCR1, register_finalizer);
         __ jr(RA);
 

--- a/src/hotspot/cpu/loongarch/c1_Runtime1_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_Runtime1_loongarch_64.cpp
@@ -217,8 +217,6 @@ StubFrame::~StubFrame() {
 
 #define __ sasm->
 
-const int float_regs_as_doubles_size_in_slots = pd_nof_fpu_regs_frame_map * 2;
-
 // Stack layout for saving/restoring  all the registers needed during a runtime
 // call (this includes deoptimization)
 // Note: note that users of this frame may well have arguments to some runtime

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -57,8 +57,8 @@ void C2_MacroAssembler::fast_lock_c2(Register oop, Register box, Register flag,
 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(flag, oop);
-    ld_wu(flag, Address(flag, Klass::access_flags_offset()));
-    test_bit(AT, flag, exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
+    ld_bu(flag, Address(flag, Klass::misc_flags_offset()));
+    test_bit(AT, flag, exact_log2(KlassFlags::_misc_is_value_based_class));
     move(flag, R0);
     bnez(AT, cont);
   }
@@ -233,8 +233,8 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
   move(flag, R0);
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(tmp1, obj);
-    ld_wu(tmp1, Address(tmp1, Klass::access_flags_offset()));
-    test_bit(tmp1, tmp1, exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
+    ld_bu(tmp1, Address(tmp1, Klass::misc_flags_offset()));
+    test_bit(tmp1, tmp1, exact_log2(KlassFlags::_misc_is_value_based_class));
     bnez(tmp1, slow_path);
   }
 

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -776,8 +776,8 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
 
     if (DiagnoseSyncOnValueBasedClasses != 0) {
       load_klass(tmp_reg, scr_reg);
-      ld_w(tmp_reg, Address(tmp_reg, Klass::access_flags_offset()));
-      test_bit(tmp_reg, tmp_reg, exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
+      ld_bu(tmp_reg, Address(tmp_reg, Klass::misc_flags_offset()));
+      test_bit(tmp_reg, tmp_reg, exact_log2(KlassFlags::_misc_is_value_based_class));
       bnez(tmp_reg, slow_case);
     }
 

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -494,8 +494,6 @@ address TemplateInterpreterGenerator::generate_abstract_entry(void) {
 
 
 const int method_offset = frame::interpreter_frame_method_offset * wordSize;
-const int bci_offset    = frame::interpreter_frame_bcp_offset    * wordSize;
-const int locals_offset = frame::interpreter_frame_locals_offset * wordSize;
 
 //-----------------------------------------------------------------------------
 

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -2123,9 +2123,9 @@ void TemplateTable::_return(TosState state) {
 
     __ ld_d(c_rarg1, aaddress(0));
     __ load_klass(LVP, c_rarg1);
-    __ ld_w(LVP, Address(LVP, Klass::access_flags_offset()));
+    __ ld_bu(LVP, Address(LVP, Klass::misc_flags_offset()));
     Label skip_register_finalizer;
-    __ test_bit(AT, LVP, exact_log2(JVM_ACC_HAS_FINALIZER));
+    __ test_bit(AT, LVP, exact_log2(KlassFlags::_misc_has_finalizer));
     __ beqz(AT, skip_register_finalizer);
 
     __ call_VM(noreg, CAST_FROM_FN_PTR(address,


### PR DESCRIPTION
34869: Builds fail after JDK-8339120
34868: LA port of 8339298: Remove unused function declaration poll_for_safepoint
34867: LA port of 8339112: Move JVM Klass flags out of AccessFlags