### PR TITLE
Update (2024.10.31)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/z/zAddress_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/z/zAddress_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2024, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,7 @@ static size_t probe_valid_max_address_bit() {
 }
 
 size_t ZPlatformAddressOffsetBits() {
-  const static size_t valid_max_address_offset_bits = probe_valid_max_address_bit() + 1;
+  static const size_t valid_max_address_offset_bits = probe_valid_max_address_bit() + 1;
   const size_t max_address_offset_bits = valid_max_address_offset_bits - 3;
   const size_t min_address_offset_bits = max_address_offset_bits - 2;
   const size_t address_offset = round_up_power_of_2(MaxHeapSize * ZVirtualToPhysicalRatio);

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -892,7 +892,7 @@ void reg_mask_init() {
   _PTR_REG_mask = _ALL_REG_mask;
   _PTR_HAS_S6_REG_mask = _ALL_REG_mask;
 
-  if (UseCompressedOops && (CompressedOops::ptrs_base() != nullptr)) {
+  if (UseCompressedOops && (CompressedOops::base() != nullptr)) {
     _ANY_REG32_mask.Remove(OptoReg::as_OptoReg(r28->as_VMReg()));
     _ANY_REG_mask.SUBTRACT(_S5_LONG_REG_mask);
     _PTR_REG_mask.SUBTRACT(_S5_LONG_REG_mask);

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -2384,10 +2384,10 @@ void MacroAssembler::reinit_heapbase() {
       if (CompressedOops::base() == nullptr) {
         move(S5_heapbase, R0);
       } else {
-        li(S5_heapbase, (int64_t)CompressedOops::ptrs_base());
+        li(S5_heapbase, (int64_t)CompressedOops::base());
       }
     } else {
-      li(S5_heapbase, (intptr_t)CompressedOops::ptrs_base_addr());
+      li(S5_heapbase, (intptr_t)CompressedOops::base_addr());
       ld_d(S5_heapbase, S5_heapbase, 0);
     }
   }


### PR DESCRIPTION
34982: LA port of 8340353: Remove CompressedOops::ptrs_base
34981: LA port of 8337674: ZGC: Consistent style for naming private static constants