### PR TITLE
Update (2025.01.09)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2024, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1162,6 +1162,7 @@ void LIR_Assembler::emit_opConvert(LIR_OpConvert* op) {
 void LIR_Assembler::emit_alloc_obj(LIR_OpAllocObj* op) {
   if (op->init_check()) {
     __ ld_bu(SCR1, Address(op->klass()->as_register(), InstanceKlass::init_state_offset()));
+    __ membar(MacroAssembler::Membar_mask_bits(MacroAssembler::LoadLoad | MacroAssembler::LoadStore));
     __ li(SCR2, InstanceKlass::fully_initialized);
     add_debug_info_for_null_check_here(op->stub()->info());
     __ bne_far(SCR1, SCR2, *op->stub()->entry());

--- a/src/hotspot/cpu/loongarch/c2_CodeStubs_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_CodeStubs_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,32 +60,6 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ bind(guard());
   __ relocate(entry_guard_Relocation::spec());
   __ emit_int32(0);  // nmethod guard value
-}
-
-int C2HandleAnonOMOwnerStub::max_size() const {
-  // Max size of stub has been determined by testing with 0, in which case
-  // C2CodeStubList::emit() will throw an assertion and report the actual size that
-  // is needed.
-  return 24;
-}
-
-void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
-  __ bind(entry());
-  Register mon = monitor();
-  Register t = tmp();
-  assert(t != noreg, "need tmp register");
-  // Fix owner to be the current thread.
-  __ st_d(TREG, Address(mon, ObjectMonitor::owner_offset()));
-
-  // Pop owner object from lock-stack.
-  __ ld_wu(t, Address(TREG, JavaThread::lock_stack_top_offset()));
-  __ addi_w(t, t, -oopSize);
-#ifdef ASSERT
-  __ stx_d(R0, TREG, t);
-#endif
-  __ st_w(t, Address(TREG, JavaThread::lock_stack_top_offset()));
-
-  __ b(continuation());
 }
 
 #undef __

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, 2024, Loongson Technology. All rights reserved.
+ * Copyright (c) 2017, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2866,6 +2866,7 @@ void MacroAssembler::clinit_barrier(Register klass, Register scratch, Label* L_f
 
   // Fast path check: class is fully initialized
   ld_b(scratch, Address(klass, InstanceKlass::init_state_offset()));
+  membar(Membar_mask_bits(LoadLoad | LoadStore));
   addi_d(scratch, scratch, -InstanceKlass::fully_initialized);
   beqz(scratch, *L_fast_path);
 

--- a/src/hotspot/os_cpu/linux_loongarch/vmStructs_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/vmStructs_linux_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,23 +30,9 @@
 // constants required by the Serviceability Agent. This file is
 // referenced by vmStructs.cpp.
 
-#define VM_STRUCTS_OS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field) \
-                                                                                                                                     \
-  /******************************/                                                                                                   \
-  /* Threads (NOTE: incomplete) */                                                                                                   \
-  /******************************/                                                                                                   \
-  nonstatic_field(OSThread,                      _thread_id,                                      pid_t)                             \
-  nonstatic_field(OSThread,                      _pthread_id,                                     pthread_t)
+#define VM_STRUCTS_OS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field)
 
-
-#define VM_TYPES_OS_CPU(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type, declare_c1_toplevel_type, declare_c2_type, declare_c2_toplevel_type) \
-                                                                          \
-  /**********************/                                                \
-  /* Posix Thread IDs   */                                                \
-  /**********************/                                                \
-                                                                          \
-  declare_integer_type(pid_t)                                             \
-  declare_unsigned_integer_type(pthread_t)
+#define VM_TYPES_OS_CPU(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type, declare_c1_toplevel_type, declare_c2_type, declare_c2_toplevel_type)
 
 #define VM_INT_CONSTANTS_OS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
 

--- a/test/jdk/java/foreign/TestUpcallStress.java
+++ b/test/jdk/java/foreign/TestUpcallStress.java
@@ -22,9 +22,15 @@
  */
 
 /*
+ * This file has been modified by Loongson Technology in 2025. These
+ * modifications are Copyright (c) 2025, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
+/*
  * @test
  * @requires jdk.foreign.linker != "FALLBACK"
- * @requires (os.arch == "aarch64" | os.arch=="riscv64") & os.name == "Linux"
+ * @requires (os.arch == "aarch64" | os.arch=="riscv64" | os.arch=="loongarch64") & os.name == "Linux"
  * @requires os.maxMemory > 4G
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase


### PR DESCRIPTION
35414: LA port of 8338379: Accesses to class init state should be properly synchronized
35413: LA port of 8341413: Stop including osThread_os.hpp in the middle of the OSThread class
35412: LA port of 8341451: Remove C2HandleAnonOMOwnerStub
35411: LA port of 8337753: Target class of upcall stub may be unloaded