### PR TITLE
Update (2025.01.09)

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2025. These
+ * modifications are Copyright (c) 2025, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.lib.ir_framework.test;
 
 import compiler.lib.ir_framework.IR;
@@ -70,6 +76,7 @@ public class IREncodingPrinter {
         "arm",
         "ppc",
         "riscv64",
+        "loongarch64",
         "s390",
         "x64",
         "x86",
@@ -110,7 +117,10 @@ public class IREncodingPrinter {
         // Riscv64
         "rvv",
         "zvbb",
-        "zvfh"
+        "zvfh",
+        // LoongArch
+        "lsx",
+        "lasx"
     ));
 
     public IREncodingPrinter() {
@@ -356,6 +366,8 @@ public class IREncodingPrinter {
             arch = "ppc";
         } else if (Platform.isRISCV64()) {
             arch = "riscv64";
+        } else if (Platform.isLoongArch64()) {
+            arch = "loongarch64";
         } else if (Platform.isS390x()) {
             arch = "s390";
         } else if (Platform.isX64()) {

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloatConversionsVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloatConversionsVector.java
@@ -22,8 +22,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2023. These
- * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2025. These
+ * modifications are Copyright (c) 2023, 2025, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -57,8 +57,8 @@ public class TestFloatConversionsVector {
 
     @Test
     @IR(counts = {IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE + "min(max_float, max_short)", "> 0"},
-                  applyIfPlatformOr = {"x64", "true", "aarch64", "true", "riscv64", "true"},
-                  applyIfCPUFeatureOr = {"f16c", "true", "avx512f", "true", "zvfh", "true", "asimd", "true", "sve", "true"})
+                  applyIfPlatformOr = {"x64", "true", "aarch64", "true", "riscv64", "true", "loongarch64", "true"},
+                  applyIfCPUFeatureOr = {"f16c", "true", "avx512f", "true", "zvfh", "true", "asimd", "true", "sve", "true", "lasx", "true"})
     public void test_float_float16(short[] sout, float[] finp) {
         for (int i = 0; i < finp.length; i++) {
             sout[i] = Float.floatToFloat16(finp[i]);
@@ -120,8 +120,8 @@ public class TestFloatConversionsVector {
 
     @Test
     @IR(counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE + "min(max_float, max_short)", "> 0"},
-                  applyIfPlatformOr = {"x64", "true", "aarch64", "true", "riscv64", "true"},
-                  applyIfCPUFeatureOr = {"f16c", "true", "avx512f", "true", "zvfh", "true", "asimd", "true", "sve", "true"})
+                  applyIfPlatformOr = {"x64", "true", "aarch64", "true", "riscv64", "true", "loongarch64", "true"},
+                  applyIfCPUFeatureOr = {"f16c", "true", "avx512f", "true", "zvfh", "true", "asimd", "true", "sve", "true", "lasx", "true"})
     public void test_float16_float(float[] fout, short[] sinp) {
         for (int i = 0; i < sinp.length; i++) {
             fout[i] = Float.float16ToFloat(sinp[i]);


### PR DESCRIPTION
35422: LA port of 8338126: C2 SuperWord: VectorCastF2HF / vcvtps2ph produces wrong results for vector length 2