### PR TITLE
Update (2025.01.09)

### DIFF
--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -2639,7 +2639,7 @@ bool MacroAssembler::lookup_secondary_supers_table(Register r_sub_klass,
   // Initialize result value to 1 which means mismatch.
   li(result, 1);
 
-  ld_d(r_bitmap, Address(r_sub_klass, Klass::bitmap_offset()));
+  ld_d(r_bitmap, Address(r_sub_klass, Klass::secondary_supers_bitmap_offset()));
 
   // First check the bitmap to see if super_klass might be present. If
   // the bit is zero, we are certain that super_klass is not one of


### PR DESCRIPTION
35428: LA port of 8331341: secondary_super_cache does not scale well: C1 and interpreter