### PR TITLE
Remove invalid 'd' suffix for double literals

### DIFF
--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
@@ -191,5 +191,5 @@ ATTRIBUTE_ALIGNED(64) jfloat StubRoutines::la::_round_float_imm[] = {
 };
 
 ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::la::_round_double_imm[] = {
-  -0.5d, 0.49999999999999994d // magic number for ties
+  -0.5, 0.49999999999999994 // magic number for ties
 };


### PR DESCRIPTION
Per C++ 14 specification, "2.14.4 Floating literals", 'd' is not a standardized floating-suffix.
The 'd' floating-suffix is a GCC extension, which worked on GCC by default but not supported by Clang and many other C compilers.

Having no suffix makes a constant of double, which is expected here, so it can be removed safely.

Fixes: 09ae79f2af71 ("Update (2023.12.08)")
Signed-off-by: Bingwu Zhang <xtex@aosc.io>
