### PR TITLE
Remove useless caller-saved float registers check

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LinearScan_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_LinearScan_loongarch.hpp
@@ -44,8 +44,6 @@ inline bool LinearScan::is_caller_save(int assigned_reg) {
     return true;
   if (assigned_reg > pd_last_callee_saved_reg && assigned_reg < pd_first_callee_saved_fpu_reg)
     return true;
-  if (assigned_reg > pd_last_callee_saved_fpu_reg && assigned_reg < pd_last_fpu_reg)
-    return true;
   return false;
 }
 


### PR DESCRIPTION
It never successes, because pd_last_callee_saved_fpu_reg is the same as pd_last_fpu_reg.
LoongArch ABI specified $f24-$f31 as callee-saved registers, while $f31 is also the last register. There is no hole between the last callee-saved float register and the last float register, so the check always evaluates to false.

Thanks to clang for finding this.

Fixes: 526ad75a343f ("Initial Linux/LoongArch64 Port")
Signed-off-by: Bingwu Zhang <xtex@aosc.io>
