### PR TITLE
Update (2025.02.20)

### DIFF
--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -2559,12 +2559,3 @@ void C2_MacroAssembler::arrays_hashcode_elload(Register dst, Address src, BasicT
     ShouldNotReachHere();
   }
 }
-
-void C2_MacroAssembler::load_narrow_klass_compact_c2(Register dst, Register obj, int disp) {
-  // Note: Don't clobber obj anywhere in that method!
-
-  // The incoming address is pointing into obj-start + klass_offset_in_bytes. We need to extract
-  // obj-start, so that we can load from the object's mark-word instead.
-  ld_d(dst, Address(obj, disp - oopDesc::klass_offset_in_bytes()));
-  srli_d(dst, dst, markWord::klass_shift);
-}

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
@@ -150,8 +150,6 @@ public:
 
   void vector_compare(FloatRegister dst, FloatRegister src1, FloatRegister src2, BasicType type, int cond, int vector_size);
 
-  void load_narrow_klass_compact_c2(Register dst, Register obj, int disp);
-
 private:
   // Return true if the phase output is in the scratch emit size mode.
   virtual bool in_scratch_emit_size() override;

--- a/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,7 @@ define_pd_global(bool, OptoScheduling,               false);
 define_pd_global(bool, OptoBundling,                 false);
 define_pd_global(bool, OptoRegScheduling,            false);
 define_pd_global(bool, SuperWordLoopUnrollAnalysis,  true);
+define_pd_global(uint, SuperWordStoreToLoadForwardingFailureDetection, 16);
 define_pd_global(bool, IdealizeClearArrayNode,       true);
 
 define_pd_global(intx, ReservedCodeCacheSize,        48*M);

--- a/src/hotspot/cpu/loongarch/foreignGlobals_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/foreignGlobals_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,9 +83,9 @@ int RegSpiller::pd_reg_size(VMStorage reg) {
 
 void RegSpiller::pd_store_reg(MacroAssembler* masm, int offset, VMStorage reg) {
   if (reg.type() == StorageType::INTEGER) {
-    masm->st_d(as_Register(reg), SP, offset);
+    masm->st_d(as_Register(reg), Address(SP, offset));
   } else if (reg.type() == StorageType::FLOAT) {
-    masm->fst_d(as_FloatRegister(reg), SP, offset);
+    masm->fst_d(as_FloatRegister(reg), Address(SP, offset));
   } else {
     // stack and BAD
   }
@@ -93,9 +93,9 @@ void RegSpiller::pd_store_reg(MacroAssembler* masm, int offset, VMStorage reg) {
 
 void RegSpiller::pd_load_reg(MacroAssembler* masm, int offset, VMStorage reg) {
   if (reg.type() == StorageType::INTEGER) {
-    masm->ld_d(as_Register(reg), SP, offset);
+    masm->ld_d(as_Register(reg), Address(SP, offset));
   } else if (reg.type() == StorageType::FLOAT) {
-    masm->fld_d(as_FloatRegister(reg), SP, offset);
+    masm->fld_d(as_FloatRegister(reg), Address(SP, offset));
   } else {
     // stack and BAD
   }

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -4304,7 +4304,7 @@ instruct loadN2PKlass(mRegP dst, memory mem)
   ins_pipe( ialu_load );
 %}
 
-instruct loadNKlassCompactHeaders(mRegN dst, memory_loadRange mem)
+instruct loadNKlassCompactHeaders(mRegN dst, memory mem)
 %{
   predicate(UseCompactObjectHeaders);
   match(Set dst (LoadNKlass mem));
@@ -4312,8 +4312,8 @@ instruct loadNKlassCompactHeaders(mRegN dst, memory_loadRange mem)
   ins_cost(125);
   format %{ "load_narrow_klass_compact  $dst, $mem\t# compressed class ptr" %}
   ins_encode %{
-    assert($mem$$index$$Register == noreg, "must not have indexed address");
-    __ load_narrow_klass_compact_c2($dst$$Register, $mem$$base$$Register, $mem$$disp);
+    __ loadstore_enc($dst$$Register, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, C2_MacroAssembler::LOAD_U_INT);
+    __ srli_d($dst$$Register, $dst$$Register, (unsigned) markWord::klass_shift_at_offset);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/loongarch/upcallLinker_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/upcallLinker_loongarch_64.cpp
@@ -70,7 +70,7 @@ static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDesc
     Register reg = as_Register(i);
     if (reg == FP || reg == SP || reg == RA) continue; // saved/restored by prologue/epilogue
     if (!abi.is_volatile_reg(reg)) {
-      __ st_d(reg, SP, offset);
+      __ st_d(reg, Address(SP, offset));
       offset += 8;
     }
   }
@@ -78,7 +78,7 @@ static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDesc
   for (int i = 0; i < FloatRegister::number_of_registers; i++) {
     FloatRegister reg = as_FloatRegister(i);
     if (!abi.is_volatile_reg(reg)) {
-      __ fst_d(reg, SP, offset);
+      __ fst_d(reg, Address(SP, offset));
       offset += 8;
     }
   }
@@ -98,7 +98,7 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
     Register reg = as_Register(i);
     if (reg == FP || reg == SP || reg == RA) continue; // saved/restored by prologue/epilogue
     if (!abi.is_volatile_reg(reg)) {
-      __ ld_d(reg, SP, offset);
+      __ ld_d(reg, Address(SP, offset));
       offset += 8;
     }
   }
@@ -106,7 +106,7 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
   for (int i = 0; i < FloatRegister::number_of_registers; i++) {
     FloatRegister reg = as_FloatRegister(i);
     if (!abi.is_volatile_reg(reg)) {
-      __ fld_d(reg, SP, offset);
+      __ fld_d(reg, Address(SP, offset));
       offset += 8;
     }
   }
@@ -214,7 +214,8 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
   __ enter(); // set up frame
   assert((abi._stack_alignment_bytes % 16) == 0, "must be 16 byte aligned");
   // allocate frame (frame_size is also aligned, so stack is still aligned)
-  __ addi_d(SP, SP, -frame_size);
+  __ li(SCR1, frame_size);
+  __ sub_d(SP, SP, SCR1);
 
   // we have to always spill args since we need to do a call to get the thread
   // (and maybe attach it).

--- a/src/hotspot/os_cpu/linux_loongarch/globals_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/globals_linux_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
 
-define_pd_global(bool, DontYieldALot,            false);
 define_pd_global(intx, ThreadStackSize,          2048); // 0 => use system default
 define_pd_global(intx, VMThreadStackSize,        2048);
 

--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -22,6 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * This file has been modified by Loongson Technology in 2025, These
+ * modifications are Copyright (c) 2025, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
 package sun.tools.attach;
 
 import com.sun.tools.attach.AgentLoadException;
@@ -322,7 +328,8 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
     private static final String FIELD = "field";
     private static final String MASK  = "mask";
 
-    private static final Pattern SIGNAL_MASK_PATTERN = Pattern.compile("(?<" + FIELD + ">Sig\\p{Alpha}{3}):\\s+(?<" + MASK + ">\\p{XDigit}{16}).*");
+    // The length of Sig(Cgt) in some architecture is 32.
+    private static final Pattern SIGNAL_MASK_PATTERN = Pattern.compile("(?<" + FIELD + ">Sig\\p{Alpha}{3}):\\s+(?<" + MASK + ">\\p{XDigit}{16,32}).*");
 
     private static final long SIGQUIT = 0b100; // mask bit for SIGQUIT
 


### PR DESCRIPTION
35624: Fix 8342449 SigCgt wrong value
35637: Fix assert(is_simm(si12, 12))
35539: LA port of 8340453: C2: Improve encoding of LoadNKlass for compact headers
35538: LA port of 8334431: C2 SuperWord: fix performance regression due to store-to-load-forwarding failures
35537: LA port of 8344250: Obsolete the DontYieldALot flag