### PR TITLE
Fix current_stack_pointer for LLVM

### DIFF
--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -79,8 +79,9 @@
 #define REG_BCP 23
 
 NOINLINE address os::current_stack_pointer() {
-  register void *sp __asm__ ("$r3");
-  return (address) sp;
+  register void *sp __asm__("r3");
+  asm volatile("" : "=r"(sp));
+  return (address)sp;
 }
 
 char* os::non_memory_address_word() {


### PR DESCRIPTION
Due to limitations of LLVM IR, clang cannot pin `sp` to `$r3` unless `sp` is used by another line of inline assembly
(`asm volatile ("" : "=r" (sp))`).
When compiling with Clang, `os::current_stack_pointer` will return an unexpected value (from a randomly assigned register).

This patch changes `os::current_stack_pointer` to use inline assembly to obtain the stack pointer, which avoids the limitation of LLVM IR.

Thanks to Zixing Liu <liushuyu@aosc.io> for pointing out the reason (GitHub @liushuyu).