### PR TITLE
Avoid format string injection

### DIFF
--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -278,9 +278,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 
         // End life with a fatal error, message and detail message and the context.
         // Note: no need to do any post-processing here (e.g. signal chaining)
-        va_list va_dummy;
-        VMError::report_and_die(thread, uc, nullptr, 0, msg, detail_msg, va_dummy);
-        va_end(va_dummy);
+        VMError::report_and_die(thread, uc, nullptr, 0, msg, detail_msg);
 
         ShouldNotReachHere();
       }

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -278,7 +278,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 
         // End life with a fatal error, message and detail message and the context.
         // Note: no need to do any post-processing here (e.g. signal chaining)
-        VMError::report_and_die(thread, uc, nullptr, 0, msg, detail_msg);
+        VMError::report_and_die(thread, uc, nullptr, 0, msg, "%s", detail_msg);
 
         ShouldNotReachHere();
       }


### PR DESCRIPTION
- [LoongArch: Remove unused va_list to VMError::report_and_die](https://github.com/loongson/jdk/commit/a7be43f30296581af735e4be9de27aa2acda1d06)
  Remove construction va_list manually to avoid undefined behaviour.
- [LoongArch: Avoid formatter injection](https://github.com/loongson/jdk/commit/4b931e116196ab260e191a863db43b6fe3cd578e)
  Use `%s` as formatting string to avoid injection.