### PR TITLE
Remove unused partial initializers

### DIFF
--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -37,7 +37,7 @@
 # include "os_linux.inline.hpp"
 #endif
 
-VM_Version::CpuidInfo VM_Version::_cpuid_info   = { 0, };
+VM_Version::CpuidInfo VM_Version::_cpuid_info = {};
 bool VM_Version::_cpu_info_is_initialized = false;
 
 static BufferBlob* stub_blob;


### PR DESCRIPTION
The zero is not used for initializedness checking and it is causing compilation warnings on Clang because it only initializes the first field of CpuidInfo, leaving other fields uninitialized.