### PR TITLE
Update (2025.03.31)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/g1/g1_loongarch.ad
+++ b/src/hotspot/cpu/loongarch/gc/g1/g1_loongarch.ad
@@ -76,7 +76,7 @@ static void write_barrier_post(MacroAssembler* masm,
 
 instruct g1StoreP(indirect mem, mRegP src, mRegP tmp1, mRegP tmp2, mRegP tmp3)
 %{
-  predicate(UseG1GC && n->as_Store()->barrier_data() != 0);
+  predicate(UseG1GC && !needs_releasing_store(n) && n->as_Store()->barrier_data() != 0);
   match(Set mem (StoreP mem src));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
   ins_cost(125);
@@ -99,9 +99,33 @@ instruct g1StoreP(indirect mem, mRegP src, mRegP tmp1, mRegP tmp2, mRegP tmp3)
   ins_pipe(pipe_slow);
 %}
 
+instruct g1StorePVolatile(indirect mem, mRegP src, mRegP tmp1, mRegP tmp2, mRegP tmp3)
+%{
+  predicate(UseG1GC && needs_releasing_store(n) && n->as_Store()->barrier_data() != 0);
+  match(Set mem (StoreP mem src));
+  effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
+  ins_cost(130);
+  format %{ "amswap_db_d    R0, $src, $mem # @g1StoreP" %}
+  ins_encode %{
+    write_barrier_pre(masm, this,
+                      $mem$$Register /* obj */,
+                      $tmp1$$Register /* pre_val */,
+                      $tmp2$$Register /* tmp1 */,
+                      $tmp3$$Register /* tmp2 */,
+                      RegSet::of($mem$$Register, $src$$Register) /* preserve */);
+    __ amswap_db_d(R0, $src$$Register, as_Register($mem$$base));
+    write_barrier_post(masm, this,
+                       $mem$$Register /* store_addr */,
+                       $src$$Register /* new_val */,
+                       $tmp2$$Register /* tmp1 */,
+                       $tmp3$$Register /* tmp2 */);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 instruct g1StoreN(indirect mem, mRegN src, mRegP tmp1, mRegP tmp2, mRegP tmp3)
 %{
-  predicate(UseG1GC && n->as_Store()->barrier_data() != 0);
+  predicate(UseG1GC && !needs_releasing_store(n) && n->as_Store()->barrier_data() != 0);
   match(Set mem (StoreN mem src));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
   ins_cost(125);
@@ -131,9 +155,40 @@ instruct g1StoreN(indirect mem, mRegN src, mRegP tmp1, mRegP tmp2, mRegP tmp3)
   ins_pipe(pipe_slow);
 %}
 
+instruct g1StoreNVolatile(indirect mem, mRegN src, mRegP tmp1, mRegP tmp2, mRegP tmp3)
+%{
+  predicate(UseG1GC && needs_releasing_store(n) && n->as_Store()->barrier_data() != 0);
+  match(Set mem (StoreN mem src));
+  effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
+  ins_cost(130);
+  format %{ "amswap_db_w    R0, $src, $mem # @g1StoreN" %}
+  ins_encode %{
+    write_barrier_pre(masm, this,
+                      $mem$$Register /* obj */,
+                      $tmp1$$Register /* pre_val */,
+                      $tmp2$$Register /* tmp1 */,
+                      $tmp3$$Register /* tmp2 */,
+                      RegSet::of($mem$$Register, $src$$Register) /* preserve */);
+    __ amswap_db_w(R0, $src$$Register, as_Register($mem$$base));
+    if ((barrier_data() & G1C2BarrierPost) != 0) {
+      if ((barrier_data() & G1C2BarrierPostNotNull) == 0) {
+        __ decode_heap_oop($tmp1$$Register, $src$$Register);
+      } else {
+        __ decode_heap_oop_not_null($tmp1$$Register, $src$$Register);
+      }
+    }
+    write_barrier_post(masm, this,
+                       $mem$$Register /* store_addr */,
+                       $tmp1$$Register /* new_val */,
+                       $tmp2$$Register /* tmp1 */,
+                       $tmp3$$Register /* tmp2 */);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 instruct g1EncodePAndStoreN(indirect mem, mRegP src, mRegP tmp1, mRegP tmp2, mRegP tmp3)
 %{
-  predicate(UseG1GC && n->as_Store()->barrier_data() != 0);
+  predicate(UseG1GC && !needs_releasing_store(n) && n->as_Store()->barrier_data() != 0);
   match(Set mem (StoreN mem (EncodeP src)));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
   ins_cost(125);
@@ -157,6 +212,35 @@ instruct g1EncodePAndStoreN(indirect mem, mRegP src, mRegP tmp1, mRegP tmp2, mRe
     write_barrier_post(masm, this,
                        $mem$$Register  /* store_addr */,
                        $src$$Register  /* new_val */,
+                       $tmp2$$Register /* tmp1 */,
+                       $tmp3$$Register /* tmp2 */);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct g1EncodePAndStoreNVolatile(indirect mem, mRegP src, mRegP tmp1, mRegP tmp2, mRegP tmp3)
+%{
+  predicate(UseG1GC && needs_releasing_store(n) && n->as_Store()->barrier_data() != 0);
+  match(Set mem (StoreN mem (EncodeP src)));
+  effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
+  ins_cost(130);
+  format %{ "encodeP_and_storeN    $src, [$mem]\t# TEMP($tmp1, $tmp2, $tmp3) @g1EncodePAndStoreNVolatile" %}
+  ins_encode %{
+    write_barrier_pre(masm, this,
+                      $mem$$Register /* obj */,
+                      $tmp1$$Register /* pre_val */,
+                      $tmp2$$Register /* tmp1 */,
+                      $tmp3$$Register /* tmp2 */,
+                      RegSet::of($mem$$Register, $src$$Register) /* preserve */);
+    if ((barrier_data() & G1C2BarrierPostNotNull) == 0) {
+      __ encode_heap_oop($tmp1$$Register, $src$$Register);
+    } else {
+      __ encode_heap_oop_not_null($tmp1$$Register, $src$$Register);
+    }
+    __ amswap_db_w(R0, $tmp1$$Register, as_Register($mem$$base));
+    write_barrier_post(masm, this,
+                       $mem$$Register /* store_addr */,
+                       $src$$Register /* new_val */,
                        $tmp2$$Register /* tmp1 */,
                        $tmp3$$Register /* tmp2 */);
   %}

--- a/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
@@ -113,7 +113,7 @@ instruct zLoadP(mRegP dst, memory mem, mRegP tmp)
 // Store Pointer
 instruct zStoreP(memory mem, mRegP src, mRegP tmp1, mRegP tmp2)
 %{
-  predicate(UseZGC && n->as_Store()->barrier_data() != 0);
+  predicate(UseZGC && !needs_releasing_store(n) && n->as_Store()->barrier_data() != 0);
   match(Set mem (StoreP mem src));
   effect(TEMP_DEF tmp1, TEMP tmp2);
 
@@ -128,20 +128,19 @@ instruct zStoreP(memory mem, mRegP src, mRegP tmp1, mRegP tmp2)
   ins_pipe(pipe_slow);
 %}
 
-// Store Null Pointer
-instruct zStorePNull(memory mem, immP_0 zero, mRegP tmp1, mRegP tmp2)
+instruct zStorePVolatile(indirect mem, mRegP src, mRegP tmp1, mRegP tmp2)
 %{
-  predicate(UseZGC && n->as_Store()->barrier_data() != 0);
-  match(Set mem (StoreP mem zero));
+  predicate(UseZGC && needs_releasing_store(n) && n->as_Store()->barrier_data() != 0);
+  match(Set mem (StoreP mem src));
   effect(TEMP_DEF tmp1, TEMP tmp2);
 
-  ins_cost(125); // XXX
-  format %{ "zStoreP    $mem, null\t# ptr" %}
+  ins_cost(130); // XXX
+  format %{ "zStorePVolatile    $mem, $src\t# ptr" %}
   ins_encode %{
-    Address ref_addr = Address(as_Register($mem$$base), as_Register($mem$$index), Address::no_scale, $mem$$disp);
-    __ block_comment("zStoreP null");
-    z_store_barrier(masm, this, ref_addr, noreg, $tmp1$$Register, $tmp2$$Register, false /* is_atomic */);
-    __ st_d($tmp1$$Register, ref_addr);
+    Address ref_addr = Address($mem$$Register);
+    __ block_comment("zStorePVolatile");
+    z_store_barrier(masm, this, ref_addr, $src$$Register, $tmp1$$Register, $tmp2$$Register, false /* is_atomic */);
+    __ amswap_db_d(R0, $tmp1$$Register, as_Register($mem$$base));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -24,8 +24,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2023. These
- * modifications are Copyright (c) 2021, 2023, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2025. These
+ * modifications are Copyright (c) 2021, 2025, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -4519,17 +4519,15 @@ void os::Linux::numa_init() {
       if (FLAG_IS_DEFAULT(UseNUMA)) {
         FLAG_SET_ERGO(UseNUMA, false);
       } else if (UseNUMA) {
-        log_info(os)("UseNUMA is disabled since insufficient initial heap size.");
-        UseNUMA = false;
+        disable_numa("UseNUMA is disabled since insufficient initial heap size.", false);
       }
     } else if (FLAG_IS_CMDLINE(NewSize) &&
                (NewSize < ScaleForWordSize(1*M) * os::numa_get_groups_num())) {
       if (FLAG_IS_DEFAULT(UseNUMA)) {
         FLAG_SET_ERGO(UseNUMA, false);
       } else if (UseNUMA) {
-        log_info(os)("Handcrafted MaxNewSize should be large enough "
-                     "to avoid GC trigger before VM initialization completed.");
-        UseNUMA = false;
+        disable_numa("Handcrafted MaxNewSize should be large enough "
+                     "to avoid GC trigger before VM initialization completed.", false);
       }
 #endif
     } else {

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2025, These
+ * modifications are Copyright (c) 2022, 2025, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "c1/c1_Compilation.hpp"
 #include "c1/c1_Compiler.hpp"
 #include "c1/c1_FrameMap.hpp"
@@ -42,12 +48,6 @@
 #include "runtime/vm_version.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/macros.hpp"
-
-/*
- * This file has been modified by Loongson Technology in 2024, These
- * modifications are Copyright (c) 2022, 2024, Loongson Technology, and are made
- * available on the same license terms set forth above.
- */
 
 
 Compiler::Compiler() : AbstractCompiler(compiler_c1) {

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -23,8 +23,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2022, These
- * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2025, These
+ * modifications are Copyright (c) 2022, 2025, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -39,12 +39,6 @@
 #include "code/vmreg.inline.hpp"
 #include "runtime/timerTrace.hpp"
 #include "utilities/bitMap.inline.hpp"
-
-/*
- * This file has been modified by Loongson Technology in 2022, These
- * modifications are Copyright (c) 2022, Loongson Technology, and are made
- * available on the same license terms set forth above.
- */
 
 #ifndef PRODUCT
 


### PR DESCRIPTION
35816: ZGC align with the StorePVolatile nodes in C2
35712: Align with the Store(P/N)Volatile nodes in C2
35699: Use disable_numa for LoongArch
35726: Fix two inappropriate copyrights