### PR TITLE
Update (2025.04.02)

### DIFF
--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -204,11 +204,9 @@ void C2_MacroAssembler::fast_unlock_c2(Register oop, Register box, Register flag
   // StoreLoad achieves this.
   membar(MacroAssembler::StoreLoad);
 
-  // Check if the entry lists are empty (EntryList first - by convention).
-  ld_d(flag, Address(tmp, ObjectMonitor::EntryList_offset()));
-  ld_d(disp_hdr, Address(tmp, ObjectMonitor::cxq_offset()));
-  orr(AT, flag, disp_hdr);
-  beqz(AT, unlocked); // If so we are done.
+  // Check if the entry_list is empty.
+  ld_d(flag, Address(tmp, ObjectMonitor::entry_list_offset()));
+  beqz(flag, unlocked); // If so we are done.
 
   // Check if there is a successor.
   ld_d(AT, Address(tmp, ObjectMonitor::succ_offset()));
@@ -521,10 +519,8 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register box, Regi
     // StoreLoad achieves this.
     membar(MacroAssembler::StoreLoad);
 
-    // Check if the entry lists are empty (EntryList first - by convention).
-    ld_d(AT, Address(tmp1_monitor, ObjectMonitor::EntryList_offset()));
-    ld_d(tmp3_t, Address(tmp1_monitor, ObjectMonitor::cxq_offset()));
-    orr(AT, AT, tmp3_t);
+    // Check if the entry_list is empty.
+    ld_d(AT, Address(tmp1_monitor, ObjectMonitor::entry_list_offset()));
     beqz(AT, unlocked); // If so we are done.
 
     // Check if there is a successor.

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
@@ -317,11 +317,6 @@ void BarrierSetAssembler::clear_patching_epoch() {
 
 void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation, Label* guard) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-
-  if (bs_nm == nullptr) {
-    return;
-  }
-
   Label local_guard;
   NMethodPatchingType patching_type = nmethod_patching_type();
 
@@ -396,11 +391,6 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
 }
 
 void BarrierSetAssembler::c2i_entry_barrier(MacroAssembler* masm) {
-  BarrierSetNMethod* bs = BarrierSet::barrier_set()->barrier_set_nmethod();
-  if (bs == nullptr) {
-    return;
-  }
-
   Label bad_call;
   __ beqz(Rmethod, bad_call);
 

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.cpp
@@ -387,7 +387,8 @@ void ShenandoahBarrierSetAssembler::store_check(MacroAssembler* masm, Register o
 
   assert(CardTable::dirty_card_val() == 0, "must be");
 
-  __ load_byte_map_base(SCR1);
+  Address curr_ct_holder_addr(TREG, in_bytes(ShenandoahThreadLocalData::card_table_offset()));
+  __ ld_d(SCR1, curr_ct_holder_addr);
   __ add_d(SCR1, obj, SCR1);
 
   if (UseCondCardMark) {
@@ -649,7 +650,8 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
   // number of bytes to copy
   __ sub_d(count, end, start);
 
-  __ load_byte_map_base(tmp);
+  Address curr_ct_holder_addr(TREG, in_bytes(ShenandoahThreadLocalData::card_table_offset()));
+  __ ld_d(tmp, curr_ct_holder_addr);
   __ add_d(start, start, tmp);
 
   __ bind(L_loop);

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -2152,7 +2152,7 @@ void MachPrologNode::format( PhaseRegAlloc *ra_, outputStream* st ) const {
     }
   }
   st->print("addi_d   SP, SP, -%d \t",framesize);
-  if (C->stub_function() == nullptr && BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
+  if (C->stub_function() == nullptr) {
     st->print("\n\t");
     st->print("ld_d  T1, guard, 0\n\t");
     st->print("membar  LoadLoad\n\t");
@@ -2202,25 +2202,23 @@ void MachPrologNode::emit(C2_MacroAssembler* masm, PhaseRegAlloc *ra_) const {
 
   if (C->stub_function() == nullptr) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    if (BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
-      // Dummy labels for just measuring the code size
-      Label dummy_slow_path;
-      Label dummy_continuation;
-      Label dummy_guard;
-      Label* slow_path = &dummy_slow_path;
-      Label* continuation = &dummy_continuation;
-      Label* guard = &dummy_guard;
-      if (!Compile::current()->output()->in_scratch_emit_size()) {
-        // Use real labels from actual stub when not emitting code for purpose of measuring its size
-        C2EntryBarrierStub* stub = new (Compile::current()->comp_arena()) C2EntryBarrierStub();
-        Compile::current()->output()->add_stub(stub);
-        slow_path = &stub->entry();
-        continuation = &stub->continuation();
-        guard = &stub->guard();
-      }
-      // In the C2 code, we move the non-hot part of nmethod entry barriers out-of-line to a stub.
-      bs->nmethod_entry_barrier(masm, slow_path, continuation, guard);
+    // Dummy labels for just measuring the code size
+    Label dummy_slow_path;
+    Label dummy_continuation;
+    Label dummy_guard;
+    Label* slow_path = &dummy_slow_path;
+    Label* continuation = &dummy_continuation;
+    Label* guard = &dummy_guard;
+    if (!Compile::current()->output()->in_scratch_emit_size()) {
+      // Use real labels from actual stub when not emitting code for purpose of measuring its size
+      C2EntryBarrierStub* stub = new (Compile::current()->comp_arena()) C2EntryBarrierStub();
+      Compile::current()->output()->add_stub(stub);
+      slow_path = &stub->entry();
+      continuation = &stub->continuation();
+      guard = &stub->guard();
     }
+    // In the C2 code, we move the non-hot part of nmethod entry barriers out-of-line to a stub.
+    bs->nmethod_entry_barrier(masm, slow_path, continuation, guard);
   }
 
   C->output()->set_frame_complete(__ offset());

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -5812,10 +5812,7 @@ static const int64_t right_3_bits = right_n_bits(3);
     // arraycopy stubs used by compilers
     generate_arraycopy_stubs();
 
-    BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
-    if (bs_nm != nullptr) {
-      StubRoutines::_method_entry_barrier = generate_method_entry_barrier();
-    }
+    StubRoutines::_method_entry_barrier = generate_method_entry_barrier();
 
 #ifdef COMPILER2
     if (UseSecondarySupersTable) {

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -2113,9 +2113,9 @@ address TemplateInterpreterGenerator::generate_trace_code(TosState state) {
 
 void TemplateInterpreterGenerator::count_bytecode() {
   __ li(T8, (long)&BytecodeCounter::_counter_value);
-  __ ld_w(AT, T8, 0);
+  __ ld_d(AT, T8, 0);
   __ addi_d(AT, AT, 1);
-  __ st_w(AT, T8, 0);
+  __ st_d(AT, T8, 0);
 }
 
 void TemplateInterpreterGenerator::histogram_bytecode(Template* t) {


### PR DESCRIPTION
35824: LA port of 8351700: Remove code conditional on BarrierSetNMethod being null
35823: LA port of 8350642: Interpreter: Upgrade CountBytecodes to 64 bit on 64 bit platforms
35822: LA port of 8343468: GenShen: Enable relocation of remembered set card tables
35821: LA port of 8343840: Rewrite the ObjectMonitor lists