### PR TITLE
Update (2025.05.20)

### DIFF
--- a/src/hotspot/cpu/loongarch/stubDeclarations_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/stubDeclarations_loongarch.hpp
@@ -44,7 +44,7 @@
                                        do_arch_blob,                    \
                                        do_arch_entry,                   \
                                        do_arch_entry_init)              \
-  do_arch_blob(compiler, 66000)                                         \
+  do_arch_blob(compiler, 70000)                                         \
   do_stub(compiler, vector_iota_indices)                                \
   do_arch_entry(la, compiler, vector_iota_indices,                      \
                 vector_iota_indices, vector_iota_indices)               \

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -2113,16 +2113,14 @@ address TemplateInterpreterGenerator::generate_trace_code(TosState state) {
 
 void TemplateInterpreterGenerator::count_bytecode() {
   __ li(T8, (long)&BytecodeCounter::_counter_value);
-  __ ld_d(AT, T8, 0);
-  __ addi_d(AT, AT, 1);
-  __ st_d(AT, T8, 0);
+  __ li(AT, 1);
+  __ amadd_d(R0, AT, T8);
 }
 
 void TemplateInterpreterGenerator::histogram_bytecode(Template* t) {
   __ li(T8, (long)&BytecodeHistogram::_counters[t->bytecode()]);
-  __ ld_w(AT, T8, 0);
-  __ addi_d(AT, AT, 1);
-  __ st_w(AT, T8, 0);
+  __ li(AT, 1);
+  __ amadd_w(R0, AT, T8);
 }
 
 void TemplateInterpreterGenerator::histogram_bytecode_pair(Template* t) {
@@ -2136,9 +2134,8 @@ void TemplateInterpreterGenerator::histogram_bytecode_pair(Template* t) {
   __ slli_d(T4, T4, 2);
   __ li(T8, (long)BytecodePairHistogram::_counters);
   __ add_d(T8, T8, T4);
-  __ ld_w(AT, T8, 0);
-  __ addi_d(AT, AT, 1);
-  __ st_w(AT, T8, 0);
+  __ li(AT, 1);
+  __ amadd_w(R0, AT, T8);
 }
 
 

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -144,6 +144,8 @@ uint32_t VM_Version::get_feature_flags_by_cpucfg() {
     result |= CPU_SCDLY;
   if (_cpuid_info.cpucfg_info_id3.bits.LLEXC != 0)
     result |= CPU_LLEXC;
+  if (_cpuid_info.cpucfg_info_id3.bits.DBARHINTS != 0)
+    result |= CPU_DBARHINTS;
 
   result |= CPU_ULSYNC;
 
@@ -244,7 +246,7 @@ void VM_Version::get_processor_features() {
   //   Features may have one comma at the end.
   //   Furthermore, use one, and only one, separator space between features.
   //   Multiple spaces are considered separate tokens, messing up everything.
-  jio_snprintf(buf, sizeof(buf), "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s, "
+  jio_snprintf(buf, sizeof(buf), "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s, "
     "0x%lx, fp_ver: %d, lvz_ver: %d, ",
     (is_la64()             ?  "la64"  : ""),
     (is_la32()             ?  "la32"  : ""),
@@ -264,6 +266,7 @@ void VM_Version::get_processor_features() {
     (needs_ulsync()        ?  ", needs_ulsync": ""),
     (supports_lam_bh()     ?  ", lam_bh" : ""),
     (supports_lamcas()     ?  ", lamcas" : ""),
+    (supports_dbarhints()  ?  ", dbarhints" : ""),
     _cpuid_info.cpucfg_info_id0.bits.PRID,
     _cpuid_info.cpucfg_info_id2.bits.FP_VER,
     _cpuid_info.cpucfg_info_id2.bits.LVZ_VER);

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2024, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,8 @@ public:
                SPW_HP_HF  : 1,
                RVA        : 1,
                RVAMAXM1   : 4,
-                          : 15;
+               DBARHINTS  : 1,
+                          : 14;
     } bits;
   };
 
@@ -221,6 +222,7 @@ public:
     decl(ULSYNC,        ulsync,          22)    \
     decl(LAM_BH,        lam_bh,          23)    \
     decl(LAMCAS,        lamcas,          24)    \
+    decl(DBARHINTS,     dbarhints,       25)    \
 
   enum Feature_Flag {
 #define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1 << bit),
@@ -294,6 +296,7 @@ public:
   static bool needs_ulsync()        { return 1; }
   static bool supports_lam_bh()     { return _features & CPU_LAM_BH; }
   static bool supports_lamcas()     { return _features & CPU_LAMCAS; }
+  static bool supports_dbarhints()  { return _features & CPU_DBARHINTS; }
 
   // LoongArch64 supports fast class initialization checks
   static bool supports_fast_class_init_checks() { return true; }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2025, These
+ * modifications are Copyright (c) 2025, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "classfile/classLoaderData.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "gc/g1/g1BarrierSet.hpp"
@@ -2596,6 +2602,9 @@ void G1CMTask::attempt_stealing() {
       // And since we're towards the end, let's totally drain the
       // local queue and global stack.
       drain_local_queue(false);
+      // Load of _age._fields._top in drain_local_queue must not pass
+      // the load of _age._fields._top in assert _task_queue->size().
+      LOONGARCH64_ONLY(DEBUG_ONLY(OrderAccess::loadload();))
       drain_global_stack(false);
     } else {
       break;
@@ -2886,6 +2895,9 @@ void G1CMTask::do_marking_step(double time_target_ms,
   // Since we've done everything else, we can now totally drain the
   // local queue and global stack.
   drain_local_queue(false);
+  // Load of _age._fields._top in drain_local_queue must not pass
+  // the load of _age._fields._top in assert _task_queue->size().
+  LOONGARCH64_ONLY(DEBUG_ONLY(OrderAccess::loadload();))
   drain_global_stack(false);
 
   // Attempt at work stealing from other task's queues.

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/LoongArch64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/loongarch64/LoongArch64HotSpotVMConfig.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,5 +75,6 @@ class LoongArch64HotSpotVMConfig extends HotSpotVMConfigAccess {
     final long loongarch64LAM_BH = getConstant("VM_Version::CPU_LAM_BH", Long.class);
     final long loongarch64LAMCAS = getConstant("VM_Version::CPU_LAMCAS", Long.class);
     final long loongarch64UAL = getConstant("VM_Version::CPU_UAL", Long.class);
+    final long loongarch64DBARHINTS = getConstant("VM_Version::CPU_DBARHINTS", Long.class);
     // Checkstyle: resume
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/loongarch64/LoongArch64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/loongarch64/LoongArch64.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, 2024, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,7 +176,8 @@ public class LoongArch64 extends Architecture {
         ULSYNC,
         LAM_BH,
         LAMCAS,
-        UAL
+        UAL,
+        DBARHINTS
     }
 
     private final EnumSet<CPUFeature> features;


### PR DESCRIPTION
35925: Reviving the cpucfg.DBARHINTS for CPUFeature
35917: atomic add of count_bytecode, histogram_bytecode and histogram_bytecode_pair
20405: Fix assert(partially || _task_queue->size() == 0) by preventing loadload reordering
35869: Increase the size of compiler_blob