### PR TITLE
Update (2025.05.21)

### DIFF
--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -11167,7 +11167,8 @@ instruct ShouldNotReachHere( )
   format %{ "stop; #@ShouldNotReachHere" %}
   ins_encode %{
     if (is_reachable()) {
-      __ stop(_halt_reason);
+      const char* str = __ code_string(_halt_reason);
+      __ stop(str);
     }
   %}
 


### PR DESCRIPTION
35924: LA port of 8349479: C2: when a Type node becomes dead, make CFG path that uses it unreachable