### PR TITLE
Update (2025.05.22)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_CodeStubs_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_CodeStubs_loongarch_64.cpp
@@ -68,7 +68,7 @@ void RangeCheckStub::emit_code(LIR_Assembler* ce) {
     __ call(a, relocInfo::runtime_call_type);
     ce->add_call_info_here(_info);
     ce->verify_oop_map(_info);
-    debug_only(__ should_not_reach_here());
+    DEBUG_ONLY(__ should_not_reach_here());
     return;
   }
 
@@ -88,7 +88,7 @@ void RangeCheckStub::emit_code(LIR_Assembler* ce) {
   __ call(Runtime1::entry_for(stub_id), relocInfo::runtime_call_type);
   ce->add_call_info_here(_info);
   ce->verify_oop_map(_info);
-  debug_only(__ should_not_reach_here());
+  DEBUG_ONLY(__ should_not_reach_here());
 }
 
 PredicateFailedStub::PredicateFailedStub(CodeEmitInfo* info) {
@@ -101,7 +101,7 @@ void PredicateFailedStub::emit_code(LIR_Assembler* ce) {
   __ call(a, relocInfo::runtime_call_type);
   ce->add_call_info_here(_info);
   ce->verify_oop_map(_info);
-  debug_only(__ should_not_reach_here());
+  DEBUG_ONLY(__ should_not_reach_here());
 }
 
 void DivByZeroStub::emit_code(LIR_Assembler* ce) {
@@ -261,7 +261,7 @@ void ImplicitNullCheckStub::emit_code(LIR_Assembler* ce) {
   __ call(a, relocInfo::runtime_call_type);
   ce->add_call_info_here(_info);
   ce->verify_oop_map(_info);
-  debug_only(__ should_not_reach_here());
+  DEBUG_ONLY(__ should_not_reach_here());
 }
 
 void SimpleExceptionStub::emit_code(LIR_Assembler* ce) {
@@ -275,7 +275,7 @@ void SimpleExceptionStub::emit_code(LIR_Assembler* ce) {
   }
   __ call(Runtime1::entry_for(_stub), relocInfo::runtime_call_type);
   ce->add_call_info_here(_info);
-  debug_only(__ should_not_reach_here());
+  DEBUG_ONLY(__ should_not_reach_here());
 }
 
 void ArrayCopyStub::emit_code(LIR_Assembler* ce) {

--- a/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
@@ -420,7 +420,7 @@ class NativeJump: public NativeInstruction {
 
 inline NativeJump* nativeJump_at(address address) {
   NativeJump* jump = (NativeJump*)(address - NativeJump::instruction_offset);
-  debug_only(jump->verify();)
+  DEBUG_ONLY(jump->verify();)
   return jump;
 }
 
@@ -436,7 +436,7 @@ class NativeGeneralJump: public NativeJump {
 
 inline NativeGeneralJump* nativeGeneralJump_at(address address) {
   NativeGeneralJump* jump = (NativeGeneralJump*)(address);
-  debug_only(jump->verify();)
+  DEBUG_ONLY(jump->verify();)
   return jump;
 }
 

--- a/src/hotspot/cpu/loongarch/runtime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/runtime_loongarch_64.cpp
@@ -45,6 +45,9 @@ UncommonTrapBlob* OptoRuntime::generate_uncommon_trap_blob() {
   // Setup code generation tools
   const char* name = OptoRuntime::stub_name(OptoStubId::uncommon_trap_id);
   CodeBuffer buffer(name, 2048, 1024);
+  if (buffer.blob() == nullptr) {
+    return nullptr;
+  }
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
   enum frame_layout {
@@ -253,6 +256,9 @@ ExceptionBlob* OptoRuntime::generate_exception_blob() {
   // Setup code generation tools
   const char* name = OptoRuntime::stub_name(OptoStubId::exception_id);
   CodeBuffer buffer(name, 2048, 1024);
+  if (buffer.blob() == nullptr) {
+    return nullptr;
+  }
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
   address start = __ pc();

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -238,8 +238,8 @@ void VM_Version::get_processor_features() {
 
   char buf[256];
 
-  // A note on the _features_string format:
-  //   There are jtreg tests checking the _features_string for various properties.
+  // A note on the _cpu_info_string format:
+  //   There are jtreg tests checking the _cpu_info_string for various properties.
   //   For some strange reason, these tests require the string to contain
   //   only _lowercase_ characters. Keep that in mind when being surprised
   //   about the unusual notation of features - and when adding new ones.
@@ -270,7 +270,7 @@ void VM_Version::get_processor_features() {
     _cpuid_info.cpucfg_info_id0.bits.PRID,
     _cpuid_info.cpucfg_info_id2.bits.FP_VER,
     _cpuid_info.cpucfg_info_id2.bits.LVZ_VER);
-  _features_string = os::strdup(buf);
+  _cpu_info_string = os::strdup(buf);
 
   assert(!is_la32(), "Should Not Reach Here, what is the cpu type?");
   assert( is_la64(), "Should be LoongArch64");
@@ -499,7 +499,7 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_threads = _no_of_cores;
   _no_of_sockets = _no_of_cores;
   snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "LoongArch");
-  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "LoongArch %s", features_string());
+  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "LoongArch %s", cpu_info_string());
   _initialized = true;
 }
 


### PR DESCRIPTION
36034: LA port of 8355617: Remove historical debug_only macro in favor of DEBUG_ONLY
36033: LA port of 8354119: Missing C2 proper allocation failure handling during initialization (during generate_uncommon_trap_blob)
36032: LA port of 8353786: Migrate Vector API math library support to FFM API