### PR TITLE
Update (2025.07.15)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/z/zAddress_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/z/zAddress_loongarch.cpp
@@ -36,9 +36,11 @@
 #include <sys/mman.h>
 #endif // LINUX
 
-// Default value if probing is not implemented for a certain platform: 128TB
-static const size_t DEFAULT_MAX_ADDRESS_BIT = 47;
-// Minimum value returned, if probing fails: 64GB
+// Default value if probing is not implemented for a certain platform
+// Max address bit is restricted by implicit assumptions in the code, for instance
+// the bit layout of ZForwardingEntry or Partial array entry (see ZMarkStackEntry) in mark stack
+static const size_t DEFAULT_MAX_ADDRESS_BIT = 46;
+// Minimum value returned, if probing fail
 static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;
 
 static size_t probe_valid_max_address_bit() {


### PR DESCRIPTION
36153: LA port of 8358310: ZGC: riscv, ppc ZPlatformAddressOffsetBits may return a too large value