### PR TITLE
Update (2025.07.15)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
@@ -95,6 +95,7 @@ instruct zLoadP(mRegP dst, memory mem, mRegP tmp)
   match(Set dst (LoadP mem));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(125);//must be equal loadP in loongarch_64.ad
+  ins_is_late_expanded_null_check_candidate(true);
 
   predicate(UseZGC && n->as_Load()->barrier_data() != 0);
 

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -2632,6 +2632,10 @@ ins_attrib ins_alignment(4);    // Required alignment attribute (must be a power
                                 // necessarily the start) requires.  If > 1, a compute_padding()
                                 // function must be provided for the instruction
 
+// Whether this node is expanded during code emission into a sequence of
+// instructions and the first instruction can perform an implicit null check.
+ins_attrib ins_is_late_expanded_null_check_candidate(false);
+
 //----------OPERANDS-----------------------------------------------------------
 // Operand definitions must precede instruction definitions for correct parsing
 // in the ADLC because operands constitute user defined types which are used in


### PR DESCRIPTION
36185: LA port of 8345067: C2: enable implicit null checks for ZGC reads