### PR TITLE
Update (2025.07.15)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,15 +43,15 @@ define_pd_global(intx, CompileThreshold,             1500 );
 
 define_pd_global(intx, OnStackReplacePercentage,     933  );
 define_pd_global(intx, NewSizeThreadIncrease,        4*K  );
-define_pd_global(intx, InitialCodeCacheSize,         160*K);
-define_pd_global(intx, ReservedCodeCacheSize,        32*M );
-define_pd_global(intx, NonProfiledCodeHeapSize,      13*M );
-define_pd_global(intx, ProfiledCodeHeapSize,         14*M );
-define_pd_global(intx, NonNMethodCodeHeapSize,       5*M  );
+define_pd_global(size_t, InitialCodeCacheSize,       160*K);
+define_pd_global(size_t, ReservedCodeCacheSize,      32*M );
+define_pd_global(size_t, NonProfiledCodeHeapSize,    13*M );
+define_pd_global(size_t, ProfiledCodeHeapSize,       14*M );
+define_pd_global(size_t, NonNMethodCodeHeapSize,     5*M  );
 define_pd_global(bool, ProfileInterpreter,           false);
-define_pd_global(intx, CodeCacheExpansionSize,       32*K );
-define_pd_global(uintx, CodeCacheMinBlockLength,     1);
-define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
+define_pd_global(size_t, CodeCacheExpansionSize,     32*K );
+define_pd_global(size_t, CodeCacheMinBlockLength,    1);
+define_pd_global(size_t, CodeCacheMinimumUseSpace,   400*K);
 define_pd_global(bool, NeverActAsServerClassMachine, true );
 define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
 define_pd_global(bool, CICompileOSR,                 true );

--- a/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
@@ -53,8 +53,8 @@ define_pd_global(intx, NewSizeThreadIncrease, ScaleForWordSize(4*K));
 define_pd_global(intx, LoopUnrollLimit,              60);
 define_pd_global(intx, LoopPercentProfileLimit,      10);
 // InitialCodeCacheSize derived from specjbb2000 run.
-define_pd_global(intx, InitialCodeCacheSize,         2496*K); // Integral multiple of CodeCacheExpansionSize
-define_pd_global(intx, CodeCacheExpansionSize,       64*K);
+define_pd_global(size_t, InitialCodeCacheSize,       2496*K); // Integral multiple of CodeCacheExpansionSize
+define_pd_global(size_t, CodeCacheExpansionSize,     64*K);
 
 // Ergonomics related flags
 define_pd_global(uint64_t,MaxRAM,                    128ULL*G);
@@ -71,12 +71,12 @@ define_pd_global(bool, SuperWordLoopUnrollAnalysis,  true);
 define_pd_global(uint, SuperWordStoreToLoadForwardingFailureDetection, 16);
 define_pd_global(bool, IdealizeClearArrayNode,       true);
 
-define_pd_global(intx, ReservedCodeCacheSize,        48*M);
-define_pd_global(intx, NonProfiledCodeHeapSize,      21*M);
-define_pd_global(intx, ProfiledCodeHeapSize,         22*M);
-define_pd_global(intx, NonNMethodCodeHeapSize,       5*M );
-define_pd_global(uintx, CodeCacheMinBlockLength,     4);
-define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
+define_pd_global(size_t, ReservedCodeCacheSize,      48*M);
+define_pd_global(size_t, NonProfiledCodeHeapSize,    21*M);
+define_pd_global(size_t, ProfiledCodeHeapSize,       22*M);
+define_pd_global(size_t, NonNMethodCodeHeapSize,     5*M );
+define_pd_global(size_t, CodeCacheMinBlockLength,    4);
+define_pd_global(size_t, CodeCacheMinimumUseSpace,   400*K);
 
 define_pd_global(bool,  TrapBasedRangeChecks,        false);
 

--- a/src/hotspot/cpu/loongarch/globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globals_loongarch.hpp
@@ -38,7 +38,7 @@ define_pd_global(bool, UncommonNullCast,         true);  // Uncommon-trap nulls 
 
 define_pd_global(bool, DelayCompilerStubsGeneration, COMPILER2_OR_JVMCI);
 
-define_pd_global(uintx, CodeCacheSegmentSize,    64 COMPILER1_AND_COMPILER2_PRESENT(+64)); // Tiered compilation has large code-entry alignment.
+define_pd_global(size_t, CodeCacheSegmentSize,   64 COMPILER1_AND_COMPILER2_PRESENT(+64)); // Tiered compilation has large code-entry alignment.
 
 // Ideally, this should be cache line size,
 // which keeps code end data on separate lines.

--- a/src/hotspot/cpu/loongarch/stubDeclarations_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/stubDeclarations_loongarch.hpp
@@ -26,6 +26,13 @@
 #ifndef CPU_LOONGARCH_STUBDECLARATIONS_HPP
 #define CPU_LOONGARCH_STUBDECLARATIONS_HPP
 
+#define STUBGEN_PREUNIVERSE_BLOBS_ARCH_DO(do_stub,                      \
+                                          do_arch_blob,                 \
+                                          do_arch_entry,                \
+                                          do_arch_entry_init)           \
+  do_arch_blob(preuniverse, 0)                                          \
+
+
 #define STUBGEN_INITIAL_BLOBS_ARCH_DO(do_stub,                          \
                                       do_arch_blob,                     \
                                       do_arch_entry,                    \

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -5766,6 +5766,10 @@ static const int64_t right_3_bits = right_n_bits(3);
     // }
   };
 
+  void generate_preuniverse_stubs() {
+    // preuniverse stubs are not needed for loongarch64
+  }
+
   // Initialization
   void generate_initial_stubs() {
     // Generates all stubs and initializes the entry points
@@ -5908,6 +5912,9 @@ static const int64_t right_3_bits = right_n_bits(3);
  public:
   StubGenerator(CodeBuffer* code, StubGenBlobId blob_id) : StubCodeGenerator(code, blob_id) {
     switch(blob_id) {
+      case preuniverse_id:
+        generate_preuniverse_stubs();
+        break;
       case initial_id:
         generate_initial_stubs();
         break;


### PR DESCRIPTION
36207: LA port of 8359227: Code cache/heap size options should be size_t
36206: LA port of 8359373: Split stubgen initial blob into pre and post-universe blobs