### PR TITLE
Update (2025.07.24)

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2593,6 +2593,8 @@ static bool can_subword_truncate(Node* in, const Type* type) {
   case Op_ReverseI:
   case Op_CountLeadingZerosI:
   case Op_CountTrailingZerosI:
+  case Op_IsFiniteF:
+  case Op_IsFiniteD:
   case Op_IsInfiniteF:
   case Op_IsInfiniteD:
   case Op_ExtractS:


### PR DESCRIPTION
36331: 8362972: C2 fails with unexpected node in SuperWord truncation: IsFiniteF, IsFiniteD