### PR TITLE
Update (2025.08.27)

### DIFF
--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -5793,8 +5793,6 @@ static const int64_t right_3_bits = right_n_bits(3);
     }
 
     if (UseCRC32Intrinsics) {
-      // set table address before stub generation which use it
-      StubRoutines::_crc_table_adr = (address)StubRoutines::la::_crc_table;
       StubRoutines::_updateBytesCRC32 = generate_updateBytesCRC32();
     }
 

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
@@ -47,6 +47,7 @@ enum platform_dependent_constants {
 
 class la {
   friend class StubGenerator;
+  friend class StubRoutines;
   friend class VMStructs;
 #if INCLUDE_JVMCI
   friend class JVMCIVMStructs;

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
@@ -46,6 +46,10 @@ STUBGEN_ARCH_ENTRIES_DO(DEFINE_ARCH_ENTRY, DEFINE_ARCH_ENTRY_INIT)
 /**
  *  crc_table[] from jdk/src/share/native/java/util/zip/zlib-1.2.5/crc32.h
  */
+
+address StubRoutines::crc_table_addr()    { return (address)StubRoutines::la::_crc_table; }
+address StubRoutines::crc32c_table_addr() { ShouldNotCallThis(); return nullptr; }
+
 juint StubRoutines::la::_crc_table[] =
 {
     0x00000000UL, 0x77073096UL, 0xee0e612cUL, 0x990951baUL, 0x076dc419UL,


### PR DESCRIPTION
36392: LA port of 8363837: Make StubRoutines::crc_table_adr() into platform-specific method