### PR TITLE
Update (2025.11.07)

### DIFF
--- a/src/hotspot/cpu/loongarch/assembler_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 #ifndef CPU_LOONGARCH_ASSEMBLER_LOONGARCH_INLINE_HPP
 #define CPU_LOONGARCH_ASSEMBLER_LOONGARCH_INLINE_HPP
 
-#include "asm/assembler.inline.hpp"
+#include "asm/assembler.hpp"
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.cpp
@@ -308,7 +308,7 @@ address BarrierSetAssembler::patching_epoch_addr() {
 }
 
 void BarrierSetAssembler::increment_patching_epoch() {
-  Atomic::inc(&_patching_epoch);
+  AtomicAccess::inc(&_patching_epoch);
 }
 
 void BarrierSetAssembler::clear_patching_epoch() {

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetNMethod_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetNMethod_loongarch.cpp
@@ -106,22 +106,22 @@ public:
   }
 
   int get_value() {
-    return Atomic::load_acquire(guard_addr());
+    return AtomicAccess::load_acquire(guard_addr());
   }
 
   void set_value(int value, int bit_mask) {
     if (bit_mask == ~0) {
-      Atomic::release_store(guard_addr(), value);
+      AtomicAccess::release_store(guard_addr(), value);
       return;
     }
     assert((value & ~bit_mask) == 0, "trying to set bits outside the mask");
     value &= bit_mask;
-    int old_value = Atomic::load(guard_addr());
+    int old_value = AtomicAccess::load(guard_addr());
     while (true) {
       // Only bits in the mask are changed
       int new_value = value | (old_value & ~bit_mask);
       if (new_value == old_value) break;
-      int v = Atomic::cmpxchg(guard_addr(), old_value, new_value, memory_order_release);
+      int v = AtomicAccess::cmpxchg(guard_addr(), old_value, new_value, memory_order_release);
       if (v == old_value) break;
       old_value = v;
     }

--- a/src/hotspot/os_cpu/linux_loongarch/atomicAccess_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/atomicAccess_linux_loongarch.hpp
@@ -23,12 +23,12 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_LOONGARCH_ATOMIC_LINUX_LOONGARCH_HPP
-#define OS_CPU_LINUX_LOONGARCH_ATOMIC_LINUX_LOONGARCH_HPP
+#ifndef OS_CPU_LINUX_LOONGARCH_ATOMICACCESS_LINUX_LOONGARCH_HPP
+#define OS_CPU_LINUX_LOONGARCH_ATOMICACCESS_LINUX_LOONGARCH_HPP
 
 #include "runtime/vm_version.hpp"
 
-// Implementation of class atomic
+// Implementation of class AtomicAccess
 
 #define AMCAS_MACRO asm volatile (                                          \
       ".ifndef _ASM_ASMMACRO_                                         \n\t" \
@@ -522,4 +522,4 @@ struct AtomicAccess::PlatformOrderedStore<8, RELEASE_X_FENCE>
   void operator()(volatile T* p, T v) const { xchg(p, v, memory_order_conservative); }
 };
 
-#endif // OS_CPU_LINUX_LOONGARCH_ATOMIC_LINUX_LOONGARCH_HPP
+#endif // OS_CPU_LINUX_LOONGARCH_ATOMICACCESS_LINUX_LOONGARCH_HPP

--- a/src/hotspot/os_cpu/linux_loongarch/atomic_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/atomic_linux_loongarch.hpp
@@ -168,7 +168,7 @@
      );
 
 template<size_t byte_size>
-struct Atomic::PlatformAdd {
+struct AtomicAccess::PlatformAdd {
   template<typename D, typename I>
   D fetch_then_add(D volatile* dest, I add_value, atomic_memory_order order) const;
 
@@ -180,7 +180,7 @@ struct Atomic::PlatformAdd {
 
 template<>
 template<typename D, typename I>
-inline D Atomic::PlatformAdd<4>::fetch_then_add(D volatile* dest, I add_value,
+inline D AtomicAccess::PlatformAdd<4>::fetch_then_add(D volatile* dest, I add_value,
                                                atomic_memory_order order) const {
   STATIC_ASSERT(4 == sizeof(I));
   STATIC_ASSERT(4 == sizeof(D));
@@ -208,7 +208,7 @@ inline D Atomic::PlatformAdd<4>::fetch_then_add(D volatile* dest, I add_value,
 
 template<>
 template<typename D, typename I>
-inline D Atomic::PlatformAdd<8>::fetch_then_add(D volatile* dest, I add_value,
+inline D AtomicAccess::PlatformAdd<8>::fetch_then_add(D volatile* dest, I add_value,
                                                atomic_memory_order order) const {
   STATIC_ASSERT(8 == sizeof(I));
   STATIC_ASSERT(8 == sizeof(D));
@@ -236,7 +236,7 @@ inline D Atomic::PlatformAdd<8>::fetch_then_add(D volatile* dest, I add_value,
 
 template<>
 template<typename T>
-inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
+inline T AtomicAccess::PlatformXchg<4>::operator()(T volatile* dest,
                                              T exchange_value,
                                              atomic_memory_order order) const {
   STATIC_ASSERT(4 == sizeof(T));
@@ -264,7 +264,7 @@ inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
 
 template<>
 template<typename T>
-inline T Atomic::PlatformXchg<8>::operator()(T volatile* dest,
+inline T AtomicAccess::PlatformXchg<8>::operator()(T volatile* dest,
                                              T exchange_value,
                                              atomic_memory_order order) const {
   STATIC_ASSERT(8 == sizeof(T));
@@ -291,11 +291,11 @@ inline T Atomic::PlatformXchg<8>::operator()(T volatile* dest,
 }
 
 template<>
-struct Atomic::PlatformCmpxchg<1> : Atomic::CmpxchgByteUsingInt {};
+struct AtomicAccess::PlatformCmpxchg<1> : AtomicAccess::CmpxchgByteUsingInt {};
 
 template<>
 template<typename T>
-inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
+inline T AtomicAccess::PlatformCmpxchg<4>::operator()(T volatile* dest,
                                                 T compare_value,
                                                 T exchange_value,
                                                 atomic_memory_order order) const {
@@ -392,7 +392,7 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
 
 template<>
 template<typename T>
-inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
+inline T AtomicAccess::PlatformCmpxchg<8>::operator()(T volatile* dest,
                                                 T compare_value,
                                                 T exchange_value,
                                                 atomic_memory_order order) const {
@@ -488,35 +488,35 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
 }
 
 template<size_t byte_size>
-struct Atomic::PlatformOrderedLoad<byte_size, X_ACQUIRE>
+struct AtomicAccess::PlatformOrderedLoad<byte_size, X_ACQUIRE>
 {
   template <typename T>
   T operator()(const volatile T* p) const { T data; __atomic_load(const_cast<T*>(p), &data, __ATOMIC_ACQUIRE); return data; }
 };
 
 template<>
-struct Atomic::PlatformOrderedStore<4, RELEASE_X>
+struct AtomicAccess::PlatformOrderedStore<4, RELEASE_X>
 {
   template <typename T>
   void operator()(volatile T* p, T v) const { xchg(p, v, memory_order_release); }
 };
 
 template<>
-struct Atomic::PlatformOrderedStore<8, RELEASE_X>
+struct AtomicAccess::PlatformOrderedStore<8, RELEASE_X>
 {
   template <typename T>
   void operator()(volatile T* p, T v) const { xchg(p, v, memory_order_release); }
 };
 
 template<>
-struct Atomic::PlatformOrderedStore<4, RELEASE_X_FENCE>
+struct AtomicAccess::PlatformOrderedStore<4, RELEASE_X_FENCE>
 {
   template <typename T>
   void operator()(volatile T* p, T v) const { xchg(p, v, memory_order_conservative); }
 };
 
 template<>
-struct Atomic::PlatformOrderedStore<8, RELEASE_X_FENCE>
+struct AtomicAccess::PlatformOrderedStore<8, RELEASE_X_FENCE>
 {
   template <typename T>
   void operator()(volatile T* p, T v) const { xchg(p, v, memory_order_conservative); }


### PR DESCRIPTION
36593: LA port of 8367740: assembler_<cpu>.inline.hpp should not include assembler.inline.hpp
36592: LA port of 8367486: Change prefix for platform-dependent AtomicAccess files
36591: LA port of 8367014: Rename class Atomic to AtomicAccess