### PR TITLE
Update (2025.11.07)

### DIFF
--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -887,10 +887,10 @@ RegMask _NO_FP_REG_mask;
 RegMask _PTR_HAS_S6_REG_mask;
 
 void reg_mask_init() {
-  _ANY_REG32_mask = _ALL_REG32_mask;
-  _ANY_REG_mask = _ALL_REG_mask;
-  _PTR_REG_mask = _ALL_REG_mask;
-  _PTR_HAS_S6_REG_mask = _ALL_REG_mask;
+  _ANY_REG32_mask.assignFrom(_ALL_REG32_mask);
+  _ANY_REG_mask.assignFrom(_ALL_REG_mask);
+  _PTR_REG_mask.assignFrom(_ALL_REG_mask);
+  _PTR_HAS_S6_REG_mask.assignFrom(_ALL_REG_mask);
 
   if (UseCompressedOops && (CompressedOops::base() != nullptr)) {
     _ANY_REG32_mask.remove(OptoReg::as_OptoReg(r28->as_VMReg()));
@@ -913,10 +913,10 @@ void reg_mask_init() {
   }
 #endif
 
-  _NO_CR_REG_mask = _PTR_REG_mask;
+  _NO_CR_REG_mask.assignFrom(_PTR_REG_mask);
   _NO_CR_REG_mask.subtract(_T0_LONG_REG_mask);
 
-  _NO_FP_REG_mask = _PTR_REG_mask;
+  _NO_FP_REG_mask.assignFrom(_PTR_REG_mask);
   _NO_FP_REG_mask.remove(OptoReg::as_OptoReg(r22->as_VMReg()));
 
   _PTR_HAS_S6_REG_mask.or_with(_S6_LONG_REG_mask);
@@ -1195,21 +1195,21 @@ int Matcher::min_vector_size(const BasicType bt) {
 }
 
 // Register for DIVI projection of divmodI
-RegMask Matcher::divI_proj_mask() {
+const RegMask& Matcher::divI_proj_mask() {
   return T1_REG_mask();
 }
 
 // Register for MODI projection of divmodI
-RegMask Matcher::modI_proj_mask() {
+const RegMask& Matcher::modI_proj_mask() {
   return T2_REG_mask();
 }
 
 // Register for DIVL projection of divmodL
-RegMask Matcher::divL_proj_mask() {
+const RegMask& Matcher::divL_proj_mask() {
   return T1_LONG_REG_mask();
 }
 
-RegMask Matcher::modL_proj_mask() {
+const RegMask& Matcher::modL_proj_mask() {
   return T2_LONG_REG_mask();
 }
 // Return whether or not this register is ever used as an argument.  This

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -893,33 +893,33 @@ void reg_mask_init() {
   _PTR_HAS_S6_REG_mask = _ALL_REG_mask;
 
   if (UseCompressedOops && (CompressedOops::base() != nullptr)) {
-    _ANY_REG32_mask.Remove(OptoReg::as_OptoReg(r28->as_VMReg()));
-    _ANY_REG_mask.SUBTRACT(_S5_LONG_REG_mask);
-    _PTR_REG_mask.SUBTRACT(_S5_LONG_REG_mask);
+    _ANY_REG32_mask.remove(OptoReg::as_OptoReg(r28->as_VMReg()));
+    _ANY_REG_mask.subtract(_S5_LONG_REG_mask);
+    _PTR_REG_mask.subtract(_S5_LONG_REG_mask);
   }
 
   // FP(r22) is not allocatable when PreserveFramePointer is on
   if (PreserveFramePointer) {
-    _ANY_REG32_mask.Remove(OptoReg::as_OptoReg(r22->as_VMReg()));
-    _ANY_REG_mask.SUBTRACT(_FP_REG_mask);
-    _PTR_REG_mask.SUBTRACT(_FP_REG_mask);
+    _ANY_REG32_mask.remove(OptoReg::as_OptoReg(r22->as_VMReg()));
+    _ANY_REG_mask.subtract(_FP_REG_mask);
+    _PTR_REG_mask.subtract(_FP_REG_mask);
   }
 
 #if INCLUDE_ZGC || INCLUDE_SHENANDOAHGC
   if (UseZGC || UseShenandoahGC) {
-    _ANY_REG32_mask.Remove(OptoReg::as_OptoReg(r16->as_VMReg()));
-    _ANY_REG_mask.SUBTRACT(_T4_LONG_REG_mask);
-    _PTR_REG_mask.SUBTRACT(_T4_LONG_REG_mask);
+    _ANY_REG32_mask.remove(OptoReg::as_OptoReg(r16->as_VMReg()));
+    _ANY_REG_mask.subtract(_T4_LONG_REG_mask);
+    _PTR_REG_mask.subtract(_T4_LONG_REG_mask);
   }
 #endif
 
   _NO_CR_REG_mask = _PTR_REG_mask;
-  _NO_CR_REG_mask.SUBTRACT(_T0_LONG_REG_mask);
+  _NO_CR_REG_mask.subtract(_T0_LONG_REG_mask);
 
   _NO_FP_REG_mask = _PTR_REG_mask;
-  _NO_FP_REG_mask.Remove(OptoReg::as_OptoReg(r22->as_VMReg()));
+  _NO_FP_REG_mask.remove(OptoReg::as_OptoReg(r22->as_VMReg()));
 
-  _PTR_HAS_S6_REG_mask.OR(_S6_LONG_REG_mask);
+  _PTR_HAS_S6_REG_mask.or_with(_S6_LONG_REG_mask);
 }
 
 void PhaseOutput::pd_perform_mach_node_analysis() {
@@ -1248,7 +1248,7 @@ bool Matcher::is_spillable_arg( int reg ) {
 
 uint Matcher::int_pressure_limit()
 {
-  uint default_intpresssure = _ANY_REG32_mask.Size() - 1;
+  uint default_intpresssure = _ANY_REG32_mask.size() - 1;
 
   if (!PreserveFramePointer) {
     default_intpresssure--;
@@ -1258,7 +1258,7 @@ uint Matcher::int_pressure_limit()
 
 uint Matcher::float_pressure_limit()
 {
-  return (FLOATPRESSURE == -1) ? _FLT_REG_mask.Size() : FLOATPRESSURE;
+  return (FLOATPRESSURE == -1) ? _FLT_REG_mask.size() : FLOATPRESSURE;
 }
 
 bool Matcher::use_asm_for_ldiv_by_con( jlong divisor ) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/loongarch64/LOONGARCH64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/loongarch64/LOONGARCH64Frame.java
@@ -243,7 +243,13 @@ public class LOONGARCH64Frame extends Frame {
     }
 
     if (cb != null) {
-      return cb.isUpcallStub() ? senderForUpcallStub(map, (UpcallStub)cb) : senderForCompiledFrame(map, cb);
+      if (cb.isUpcallStub()) {
+        return senderForUpcallStub(map, (UpcallStub)cb);
+      } else if (cb.isContinuationStub()) {
+        return senderForContinuationStub(map, cb);
+      } else {
+        return senderForCompiledFrame(map, cb);
+      }
     }
 
     // Must be native-compiled frame, i.e. the marshaling code for native
@@ -327,6 +333,16 @@ public class LOONGARCH64Frame extends Frame {
 
   private void updateMapWithSavedLink(RegisterMap map, Address savedFPAddr) {
     map.setLocation(fp, savedFPAddr);
+  }
+
+  private Frame senderForContinuationStub(LOONGARCH64RegisterMap map, CodeBlob cb) {
+    var contEntry = map.getThread().getContEntry();
+
+    Address senderSP = contEntry.getEntrySP();
+    Address senderPC = contEntry.getEntryPC();
+    Address senderFP = contEntry.getEntryFP();
+
+    return new LOONGARCH64Frame(senderSP, senderFP, senderPC);
   }
 
   private Frame senderForCompiledFrame(LOONGARCH64RegisterMap map, CodeBlob cb) {


### PR DESCRIPTION
36721: LA port of 8370031: Make RegMask copy constructor explicit and replace RegMask operator= with named function
36720: LA port of 8369569: Rename methods in regmask.hpp to conform with HotSpot coding style
36719: LA port of 8369505: jhsdb jstack cannot handle continuation stub