### PR TITLE
Update (2026.03.05)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -425,7 +425,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
 
   code_stub->set_safepoint_offset(__ offset());
   __ relocate(relocInfo::poll_return_type);
-  __ safepoint_poll(*code_stub->entry(), TREG, true /* at_return */, false /* acquire */, true /* in_nmethod */);
+  __ safepoint_poll(*code_stub->entry(), TREG, true /* at_return */, true /* in_nmethod */);
 
   __ jr(RA);
 }

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -307,18 +307,20 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register box, Regi
 
     bind(not_recursive);
 
-    const Register tmp2_owner_addr = tmp2;
-
-    // Compute owner address.
-    lea(tmp2_owner_addr, Address(tmp1_monitor, ObjectMonitor::owner_offset()));
-
     // Set owner to null.
-    // Release to satisfy the JMM
-    membar(Assembler::Membar_mask_bits(MacroAssembler::LoadStore | MacroAssembler::StoreStore));
-    st_d(R0, tmp2_owner_addr, 0);
-    // We need a full fence after clearing owner to avoid stranding.
-    // StoreLoad achieves this.
-    membar(MacroAssembler::StoreLoad);
+    if (UseAMOForOrderingStore) {
+      move(AT, R0); // avoid swapping R0 with R0
+      addi_d(tmp2, tmp1_monitor, in_bytes(ObjectMonitor::owner_offset()));
+      amswap_db_d(R0, AT, tmp2); // as Release and StoreLoad
+    } else {
+      // Release to satisfy the JMM
+      membar(Assembler::Membar_mask_bits(MacroAssembler::LoadStore |
+                                         MacroAssembler::StoreStore));
+      st_d(R0, Address(tmp1_monitor, ObjectMonitor::owner_offset()));
+      // We need a full fence after clearing owner to avoid stranding.
+      // StoreLoad achieves this.
+      membar(MacroAssembler::StoreLoad);
+    }
 
     // Check if the entry_list is empty.
     ld_d(AT, Address(tmp1_monitor, ObjectMonitor::entry_list_offset()));

--- a/src/hotspot/cpu/loongarch/downcallLinker_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/downcallLinker_loongarch_64.cpp
@@ -214,11 +214,12 @@ void DowncallLinker::StubGenerator::generate() {
 
     // State transition
     __ li(tmp1, _thread_in_native);
-    if (os::is_MP()) {
+    if (UseAMOForOrderingStore) {
       __ addi_d(tmp2, TREG, in_bytes(JavaThread::thread_state_offset()));
-      __ amswap_db_w(R0, tmp1, tmp2);
+      __ amswap_db_w(R0, tmp1, tmp2); // as Release
     } else {
-      __ st_w(tmp1, TREG, in_bytes(JavaThread::thread_state_offset()));
+      __ membar(Assembler::Membar_mask_bits(__ LoadStore|__ StoreStore));
+      __ st_w(tmp1, Address(TREG, JavaThread::thread_state_offset()));
     }
   }
 
@@ -279,12 +280,16 @@ void DowncallLinker::StubGenerator::generate() {
   if (_needs_transition) {
     __ li(tmp1, _thread_in_native_trans);
 
-    // Force this write out before the read below
-    if (os::is_MP() && !UseSystemMemoryBarrier) {
+    if (UseAMOForOrderingStore) {
       __ addi_d(tmp2, TREG, in_bytes(JavaThread::thread_state_offset()));
-      __ amswap_db_w(R0, tmp1, tmp2); // AnyAny
+      __ amswap_db_w(R0, tmp1, tmp2); // as AnyAny
     } else {
-      __ st_w(tmp1, TREG, in_bytes(JavaThread::thread_state_offset()));
+      __ st_w(tmp1, Address(TREG, JavaThread::thread_state_offset()));
+
+      // Force this write out before the read below
+      if (!UseSystemMemoryBarrier) {
+        __ membar(__ AnyAny);
+      }
     }
 
     __ safepoint_poll(L_safepoint_poll_slow_path, TREG, true /* at_return */, true /* acquire */, false /* in_nmethod */);
@@ -296,11 +301,12 @@ void DowncallLinker::StubGenerator::generate() {
 
     // change thread state
     __ li(tmp1, _thread_in_Java);
-    if (os::is_MP()) {
+    if (UseAMOForOrderingStore) {
       __ addi_d(tmp2, TREG, in_bytes(JavaThread::thread_state_offset()));
-      __ amswap_db_w(R0, tmp1, tmp2);
+      __ amswap_db_w(R0, tmp1, tmp2); // as Release
     } else {
-      __ st_w(tmp1, TREG, in_bytes(JavaThread::thread_state_offset()));
+      __ membar(Assembler::Membar_mask_bits(__ LoadStore|__ StoreStore));
+      __ st_w(tmp1, Address(TREG, JavaThread::thread_state_offset()));
     }
 
     __ block_comment("reguard stack check");

--- a/src/hotspot/cpu/loongarch/downcallLinker_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/downcallLinker_loongarch_64.cpp
@@ -292,7 +292,7 @@ void DowncallLinker::StubGenerator::generate() {
       }
     }
 
-    __ safepoint_poll(L_safepoint_poll_slow_path, TREG, true /* at_return */, true /* acquire */, false /* in_nmethod */);
+    __ safepoint_poll(L_safepoint_poll_slow_path, TREG, true /* at_return */, false /* in_nmethod */);
 
     __ ld_w(tmp1, TREG, in_bytes(JavaThread::suspend_flags_offset()));
     __ bnez(tmp1, L_safepoint_poll_slow_path);

--- a/src/hotspot/cpu/loongarch/gc/g1/g1_loongarch.ad
+++ b/src/hotspot/cpu/loongarch/gc/g1/g1_loongarch.ad
@@ -113,7 +113,7 @@ instruct g1StorePVolatile(indirect mem, mRegP src, mRegP tmp1, mRegP tmp2, mRegP
                       $tmp2$$Register /* tmp1 */,
                       $tmp3$$Register /* tmp2 */,
                       RegSet::of($mem$$Register, $src$$Register) /* preserve */);
-    __ amswap_db_d(R0, $src$$Register, as_Register($mem$$base));
+    __ amswap_db_d(R0, $src$$Register, as_Register($mem$$base)); // as Release
     write_barrier_post(masm, this,
                        $mem$$Register /* store_addr */,
                        $src$$Register /* new_val */,
@@ -169,7 +169,7 @@ instruct g1StoreNVolatile(indirect mem, mRegN src, mRegP tmp1, mRegP tmp2, mRegP
                       $tmp2$$Register /* tmp1 */,
                       $tmp3$$Register /* tmp2 */,
                       RegSet::of($mem$$Register, $src$$Register) /* preserve */);
-    __ amswap_db_w(R0, $src$$Register, as_Register($mem$$base));
+    __ amswap_db_w(R0, $src$$Register, as_Register($mem$$base)); // as Release
     if ((barrier_data() & G1C2BarrierPost) != 0) {
       if ((barrier_data() & G1C2BarrierPostNotNull) == 0) {
         __ decode_heap_oop($tmp1$$Register, $src$$Register);

--- a/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/z/z_loongarch_64.ad
@@ -141,7 +141,7 @@ instruct zStorePVolatile(indirect mem, mRegP src, mRegP tmp1, mRegP tmp2)
     Address ref_addr = Address($mem$$Register);
     __ block_comment("zStorePVolatile");
     z_store_barrier(masm, this, ref_addr, $src$$Register, $tmp1$$Register, $tmp2$$Register, false /* is_atomic */);
-    __ amswap_db_d(R0, $tmp1$$Register, as_Register($mem$$base));
+    __ amswap_db_d(R0, $tmp1$$Register, as_Register($mem$$base)); // as Release
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/loongarch/globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globals_loongarch.hpp
@@ -100,6 +100,9 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
   product(bool, UseAMCAS, false,                                            \
                 "Use AMCAS{_DB}.{B/H/W/D} instructions")                    \
                                                                             \
+  product(bool, UseAMOForOrderingStore, true,                               \
+                "Use AMSWAP_DB instead of DBAR and STORE sequence")         \
+                                                                            \
   product(bool, UseBarriersForVolatile, false,                              \
           "Use memory barriers to implement volatile accesses")             \
                                                                             \

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
@@ -127,6 +127,8 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void load_field_entry(Register cache, Register index, int bcp_offset = 1);
   void load_method_entry(Register cache, Register index, int bcp_offset = 1);
 
+  void verify_field_offset(Register reg) NOT_DEBUG_RETURN;
+
   // load cpool->resolved_references(index);
   void load_resolved_reference_at_index(Register result, Register index, Register tmp);
 

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -353,6 +353,17 @@ void InterpreterMacroAssembler::load_method_entry(Register cache, Register index
   add_d(cache, cache, index);
 }
 
+#ifdef ASSERT
+void InterpreterMacroAssembler::verify_field_offset(Register reg) {
+  // Verify the field offset is not in the header, implicitly checks for 0
+  Label L;
+  li(AT, oopDesc::base_offset_in_bytes());
+  bge(reg, AT, L);
+  stop("bad field offset");
+  bind(L);
+}
+#endif
+
 // Load object from cpool->resolved_references(index)
 void InterpreterMacroAssembler::load_resolved_reference_at_index(
                                            Register result, Register index, Register tmp) {

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -748,7 +748,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
   // the stack, will call InterpreterRuntime::at_unwind.
   Label slow_path;
   Label fast_path;
-  safepoint_poll(slow_path, TREG, true /* at_return */, false /* acquire */, false /* in_nmethod */);
+  safepoint_poll(slow_path, TREG, true /* at_return */, false /* in_nmethod */);
   b(fast_path);
 
   bind(slow_path);

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1951,7 +1951,7 @@ void MachEpilogNode::emit(C2_MacroAssembler *masm, PhaseRegAlloc *ra_) const {
       code_stub = &stub->entry();
     }
     __ relocate(relocInfo::poll_return_type);
-    __ safepoint_poll(*code_stub, TREG, true /* at_return */, false /* acquire */, true /* in_nmethod */);
+    __ safepoint_poll(*code_stub, TREG, true /* at_return */, true /* in_nmethod */);
   }
 }
 

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -2257,7 +2257,7 @@ bool use_AMO(int opcode)
   case Op_StoreP:
   case Op_StoreN:
   case Op_StoreNKlass:
-    return true;
+    return UseAMOForOrderingStore;
   default:
     return false;
   }
@@ -2351,6 +2351,11 @@ bool needs_releasing_store(const Node *n)
   // assert n->is_Store();
   if (UseBarriersForVolatile) {
     // we use a normal store and dbar combination
+    return false;
+  }
+
+  if (!UseAMOForOrderingStore) {
+    // prevent AMO node generation
     return false;
   }
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -1054,13 +1054,8 @@ void MacroAssembler::reset_last_Java_frame(bool clear_fp) {
   st_d(R0, TREG, in_bytes(JavaThread::last_Java_pc_offset()));
 }
 
-void MacroAssembler::safepoint_poll(Label& slow_path, Register thread_reg, bool at_return, bool acquire, bool in_nmethod) {
-  if (acquire) {
-    ld_d(AT, thread_reg, in_bytes(JavaThread::polling_word_offset()));
-    membar(Assembler::Membar_mask_bits(LoadLoad|LoadStore));
-  } else {
-    ld_d(AT, thread_reg, in_bytes(JavaThread::polling_word_offset()));
-  }
+void MacroAssembler::safepoint_poll(Label& slow_path, Register thread_reg, bool at_return, bool in_nmethod) {
+  ld_d(AT, thread_reg, in_bytes(JavaThread::polling_word_offset()));
   if (at_return) {
     // Note that when in_nmethod is set, the stack pointer is incremented before the poll. Therefore,
     // we may safely use the sp instead to perform the stack watermark check.

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -518,7 +518,7 @@ class MacroAssembler: public Assembler {
   // Check for reserved stack access in method being exited (for JIT)
   void reserved_stack_check();
 
-  void safepoint_poll(Label& slow_path, Register thread_reg, bool at_return, bool acquire, bool in_nmethod);
+  void safepoint_poll(Label& slow_path, Register thread_reg, bool at_return, bool in_nmethod);
 
   void verify_tlab(Register t1, Register t2);
 

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1738,12 +1738,13 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   __ addi_d(A0, TREG, in_bytes(JavaThread::jni_environment_offset()));
 
   // Now set thread in native
-  __ addi_d(AT, R0, _thread_in_native);
-  if (os::is_MP()) {
+  __ li(AT, _thread_in_native);
+  if (UseAMOForOrderingStore) {
     __ addi_d(T4, TREG, in_bytes(JavaThread::thread_state_offset()));
-    __ amswap_db_w(R0, AT, T4);
+    __ amswap_db_w(R0, AT, T4); // as Release
   } else {
-    __ st_w(AT, TREG, in_bytes(JavaThread::thread_state_offset()));
+    __ membar(Assembler::Membar_mask_bits(__ LoadStore|__ StoreStore));
+    __ st_w(AT, Address(TREG, JavaThread::thread_state_offset()));
   }
 
   // do the call
@@ -1766,14 +1767,18 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   //     VM thread changes sync state to synchronizing and suspends threads for GC.
   //     Thread A is resumed to finish this native method, but doesn't block here since it
   //     didn't see any synchronization is progress, and escapes.
-  __ addi_d(AT, R0, _thread_in_native_trans);
+  __ li(AT, _thread_in_native_trans);
 
-  // Force this write out before the read below
-  if (os::is_MP() && UseSystemMemoryBarrier) {
+  if (UseAMOForOrderingStore) {
     __ addi_d(T4, TREG, in_bytes(JavaThread::thread_state_offset()));
-    __ amswap_db_w(R0, AT, T4); // AnyAny
+    __ amswap_db_w(R0, AT, T4); // as AnyAny
   } else {
-    __ st_w(AT, TREG, in_bytes(JavaThread::thread_state_offset()));
+    __ st_w(AT, Address(TREG, JavaThread::thread_state_offset()));
+
+    // Force this write out before the read below
+    if (!UseSystemMemoryBarrier) {
+      __ membar(__ AnyAny);
+    }
   }
 
   // check for safepoint operation in progress and/or pending suspend requests
@@ -1816,12 +1821,13 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
 
   // change thread state
-  __ addi_d(AT, R0, _thread_in_Java);
-  if (os::is_MP()) {
+  __ li(AT, _thread_in_Java);
+  if (UseAMOForOrderingStore) {
     __ addi_d(T4, TREG, in_bytes(JavaThread::thread_state_offset()));
-    __ amswap_db_w(R0, AT, T4);
+    __ amswap_db_w(R0, AT, T4); // as Release
   } else {
-    __ st_w(AT, TREG, in_bytes(JavaThread::thread_state_offset()));
+    __ membar(Assembler::Membar_mask_bits(__ LoadStore|__ StoreStore));
+    __ st_w(AT, Address(TREG, JavaThread::thread_state_offset()));
   }
 
   if (method->is_object_wait0()) {

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1786,16 +1786,8 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     Label Continue;
     Label slow_path;
 
-    // We need an acquire here to ensure that any subsequent load of the
-    // global SafepointSynchronize::_state flag is ordered after this load
-    // of the thread-local polling word.  We don't want this poll to
-    // return false (i.e. not safepointing) and a later poll of the global
-    // SafepointSynchronize::_state spuriously to return true.
-    //
-    // This is to avoid a race when we're in a native->Java transition
-    // racing the code which wakes up from a safepoint.
-
-    __ safepoint_poll(slow_path, TREG, true /* at_return */, true /* acquire */, false /* in_nmethod */);
+    // No need for acquire as Java threads always disarm themselves.
+    __ safepoint_poll(slow_path, TREG, true /* at_return */, false /* in_nmethod */);
     __ ld_w(AT, TREG, in_bytes(JavaThread::suspend_flags_offset()));
     __ beq(AT, R0, Continue);
     __ bind(slow_path);

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -4451,6 +4451,280 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  /**
+   *  void j.u.Base64.Encoder.encodeBlock(byte[] src, int sp, int sl, byte[] dst, int dp, boolean isURL)
+   *
+   *  Input arguments:
+   *  c_rarg0   - src, source array
+   *  c_rarg1   - sp, src start offset
+   *  c_rarg2   - sl, src end offset
+   *  c_rarg3   - dst, dest array
+   *  c_rarg4   - dp, dst start offset
+   *  c_rarg5   - isURL, Base64 or URL character set
+   */
+  address generate_base64_encodeBlock() {
+    alignas(64) static const char toBase64[64] = {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+      'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+      'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+      'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+    };
+
+    alignas(64) static const char toBase64URL[64] = {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+      'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+      'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+      'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
+    };
+
+    __ align(CodeEntryAlignment);
+    StubId stub_id = StubId::stubgen_base64_encodeBlock_id;
+    StubCodeMark mark(this, stub_id);
+    address start = __ pc();
+    __ enter();
+
+    Register src    = c_rarg0;
+    Register soff   = c_rarg1;
+    Register send   = c_rarg2;
+    Register dst    = c_rarg3;
+    Register doff   = c_rarg4;
+    Register isURL  = c_rarg5;
+
+    Register codec  = c_rarg6;
+    Register length = c_rarg7; // total length of src data in bytes
+
+    Label ProcessData, Exit;
+
+    // length should be multiple of 3
+    __ sub_d(length, send, soff);
+    // real src/dst to process data
+    __ add_d(src, src, soff);
+    __ add_d(dst, dst, doff);
+
+    // load the codec base address
+    __ li(codec, (jlong) toBase64);
+    __ beqz(isURL, ProcessData);
+    __ li(codec, (jlong) toBase64URL);
+    __ BIND(ProcessData);
+
+    // scalar version
+    {
+      Register byte1 = soff, byte0 = send, byte2 = doff;
+      Register combined24Bits = isURL;
+
+      __ beqz(length, Exit);
+
+      Label ScalarLoop;
+      __ BIND(ScalarLoop);
+      {
+        // plain:   [byte0[7:0] : byte1[7:0] : byte2[7:0]] =>
+        // encoded: [byte0[7:2] : byte0[1:0]+byte1[7:4] : byte1[3:0]+byte2[7:6] : byte2[5:0]]
+
+        // load 3 bytes src data
+        __ ld_bu(byte0, Address(src, 0));
+        __ ld_bu(byte1, Address(src, 1));
+        __ ld_bu(byte2, Address(src, 2));
+        __ addi_d(src, src, 3);
+
+        // construct 24 bits from 3 bytes
+        __ slli_w(byte0, byte0, 16);
+        __ slli_w(byte1, byte1, 8);
+        __ orr(combined24Bits, byte0, byte1);
+        __ orr(combined24Bits, combined24Bits, byte2);
+
+        // get codec index and encode(ie. load from codec by index)
+        __ slli_w(byte0, combined24Bits, 8);
+        __ srli_w(byte0, byte0, 26);
+        __ add_d(byte0, codec, byte0);
+        __ ld_bu(byte0, byte0);
+
+        __ slli_w(byte1, combined24Bits, 14);
+        __ srli_w(byte1, byte1, 26);
+        __ add_d(byte1, codec, byte1);
+        __ ld_bu(byte1, byte1);
+
+        __ slli_w(byte2, combined24Bits, 20);
+        __ srli_w(byte2, byte2, 26);
+        __ add_d(byte2, codec, byte2);
+        __ ld_bu(byte2, byte2);
+
+        __ andi(combined24Bits, combined24Bits, 0x3f);
+        __ add_d(combined24Bits, codec, combined24Bits);
+        __ ld_bu(combined24Bits, combined24Bits);
+
+        // store 4 bytes encoded data
+        __ st_b(byte0, Address(dst, 0));
+        __ st_b(byte1, Address(dst, 1));
+        __ st_b(byte2, Address(dst, 2));
+        __ st_b(combined24Bits, Address(dst, 3));
+
+        __ addi_d(length, length, -3);
+        __ addi_d(dst, dst, 4);
+        // loop back
+        __ bnez(length, ScalarLoop);
+      }
+    }
+
+    __ BIND(Exit);
+
+    __ leave();
+    __ jr(RA);
+
+    return (address) start;
+  }
+
+  /**
+   * int j.u.Base64.Decoder.decodeBlock(byte[] src, int sp, int sl, byte[] dst, int dp, boolean isURL, boolean isMIME)
+   *
+   *  Input arguments:
+   *  c_rarg0   - src, source array
+   *  c_rarg1   - sp, src start offset
+   *  c_rarg2   - sl, src end offset
+   *  c_rarg3   - dst, dest array
+   *  c_rarg4   - dp, dst start offset
+   *  c_rarg5   - isURL, Base64 or URL character set
+   *  c_rarg6   - isMIME, Decoding MIME block
+   */
+  address generate_base64_decodeBlock() {
+
+    static const uint8_t fromBase64[256] = {
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,  62u, 255u, 255u, 255u,  63u,
+        52u,  53u,  54u,  55u,  56u,  57u,  58u,  59u,  60u,  61u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u,   0u,   1u,   2u,   3u,   4u,   5u,   6u,   7u,   8u,   9u,  10u,  11u,  12u,  13u,  14u,
+        15u,  16u,  17u,  18u,  19u,  20u,  21u,  22u,  23u,  24u,  25u, 255u, 255u, 255u, 255u, 255u,
+        255u,  26u,  27u,  28u,  29u,  30u,  31u,  32u,  33u,  34u,  35u,  36u,  37u,  38u,  39u,  40u,
+        41u,  42u,  43u,  44u,  45u,  46u,  47u,  48u,  49u,  50u,  51u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    };
+
+    static const uint8_t fromBase64URL[256] = {
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,  62u, 255u, 255u,
+        52u,  53u,  54u,  55u,  56u,  57u,  58u,  59u,  60u,  61u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u,   0u,   1u,   2u,   3u,   4u,   5u,   6u,   7u,   8u,   9u,  10u,  11u,  12u,  13u,  14u,
+        15u,  16u,  17u,  18u,  19u,  20u,  21u,  22u,  23u,  24u,  25u, 255u, 255u, 255u, 255u,  63u,
+        255u,  26u,  27u,  28u,  29u,  30u,  31u,  32u,  33u,  34u,  35u,  36u,  37u,  38u,  39u,  40u,
+        41u,  42u,  43u,  44u,  45u,  46u,  47u,  48u,  49u,  50u,  51u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    };
+
+    __ align(CodeEntryAlignment);
+    StubId stub_id = StubId::stubgen_base64_decodeBlock_id;
+    StubCodeMark mark(this, stub_id);
+    address start = __ pc();
+    __ enter();
+
+    Register src    = c_rarg0;
+    Register soff   = c_rarg1;
+    Register send   = c_rarg2;
+    Register dst    = c_rarg3;
+    Register doff   = c_rarg4;
+    Register isURL  = c_rarg5;
+    Register isMIME = c_rarg6;
+
+    Register codec     = c_rarg7;
+    Register dstBackup = SCR1;
+    Register length    = SCR2;     // total length of src data in bytes
+
+    Label ProcessData, Exit;
+    Label ScalarLoop;
+
+    // passed in length (send - soff) is guaranteed to be > 4,
+    // and in this intrinsic we only process data of length in multiple of 4,
+    // it's not guaranteed to be multiple of 4 by java level, so do it explicitly
+    __ sub_d(length, send, soff);
+    __ bstrins_d(length, R0, 1, 0);
+    // real src/dst to process data
+    __ add_d(src, src, soff);
+    __ add_d(dst, dst, doff);
+    // backup of dst, used to calculate the return value at exit
+    __ move(dstBackup, dst);
+
+    // load the codec base address
+    __ li(codec, (jlong) fromBase64);
+    __ beqz(isURL, ProcessData);
+    __ li(codec, (jlong) fromBase64URL);
+    __ BIND(ProcessData);
+
+    // scalar version
+    {
+      Register byte0 = soff, byte1 = send, byte2 = doff, byte3 = isURL;
+      Register combined32Bits = isMIME;
+
+      // encoded:   [byte0[5:0] : byte1[5:0] : byte2[5:0]] : byte3[5:0]] =>
+      // plain:     [byte0[5:0]+byte1[5:4] : byte1[3:0]+byte2[5:2] : byte2[1:0]+byte3[5:0]]
+      __ BIND(ScalarLoop);
+
+      // load 4 bytes encoded src data
+      __ ld_bu(byte0, Address(src, 0));
+      __ ld_bu(byte1, Address(src, 1));
+      __ ld_bu(byte2, Address(src, 2));
+      __ ld_bu(byte3, Address(src, 3));
+      __ addi_d(src, src, 4);
+
+      // get codec index and decode (ie. load from codec by index)
+      __ add_d(byte0, codec, byte0);
+      __ add_d(byte1, codec, byte1);
+      __ ld_b(byte0, Address(byte0, 0));
+      __ ld_b(byte1, Address(byte1, 0));
+      __ add_d(byte2, codec, byte2);
+      __ add_d(byte3, codec, byte3);
+      __ ld_b(byte2, Address(byte2, 0));
+      __ ld_b(byte3, Address(byte3, 0));
+      __ slli_w(byte0, byte0, 18);
+      __ slli_w(byte1, byte1, 12);
+      __ orr(byte0, byte0, byte1);
+      __ orr(byte0, byte0, byte3);
+      __ slli_w(byte2, byte2, 6);
+      // For performance consideration, `combined32Bits` is constructed for 2 purposes at the same time,
+      //  1. error check below
+      //  2. decode below
+      __ orr(combined32Bits, byte0, byte2);
+
+      // error check
+      __ blt(combined32Bits, R0, Exit);
+
+      // store 3 bytes decoded data
+      __ srai_w(byte0, combined32Bits, 16);
+      __ srai_w(byte1, combined32Bits, 8);
+      __ st_b(byte0, Address(dst, 0));
+      __ st_b(byte1, Address(dst, 1));
+      __ st_b(combined32Bits, Address(dst, 2));
+
+      __ addi_d(length, length, -4);
+      __ addi_d(dst, dst, 3);
+      // loop back
+      __ bnez(length, ScalarLoop);
+    }
+
+    __ BIND(Exit);
+    __ sub_d(c_rarg0, dst, dstBackup);
+
+    __ leave();
+    __ jr(RA);
+
+    return (address) start;
+  }
+
   // ChaCha20 block function.  This version parallelizes by loading
   // individual 32-bit state elements into vectors for four blocks
   //
@@ -5932,6 +6206,11 @@ static const int64_t right_3_bits = right_n_bits(3);
     if (UseSHA256Intrinsics) {
       StubRoutines::_sha256_implCompress   = generate_sha256_implCompress(false);
       StubRoutines::_sha256_implCompressMB = generate_sha256_implCompress(true);
+    }
+
+    if (UseBASE64Intrinsics) {
+      StubRoutines::_base64_encodeBlock = generate_base64_encodeBlock();
+      StubRoutines::_base64_decodeBlock = generate_base64_decodeBlock();
     }
 
     if (UseChaCha20Intrinsics) {

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -1356,11 +1356,12 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 #endif
 
   __ li(t, _thread_in_native);
-  if (os::is_MP()) {
+  if (UseAMOForOrderingStore) {
     __ addi_d(AT, TREG, in_bytes(JavaThread::thread_state_offset()));
-    __ amswap_db_w(R0, t, AT);
+    __ amswap_db_w(R0, t, AT); // as Release
   } else {
-    __ st_w(t, TREG, in_bytes(JavaThread::thread_state_offset()));
+    __ membar(Assembler::Membar_mask_bits(__ LoadStore|__ StoreStore));
+    __ st_w(t, Address(TREG, JavaThread::thread_state_offset()));
   }
 
   __ push_cont_fastpath();
@@ -1384,16 +1385,19 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
   // change thread state
   __ li(t, _thread_in_native_trans);
-  if (os::is_MP()) {
+
+  if (UseAMOForOrderingStore) {
     __ addi_d(AT, TREG, in_bytes(JavaThread::thread_state_offset()));
-    __ amswap_db_w(R0, t, AT); // Release-Store
+    __ amswap_db_w(R0, t, AT); // as Release and AnyAny
+  } else {
+    // Force all preceding writes to be observed prior to thread state change
+    __ membar(Assembler::Membar_mask_bits(__ LoadStore|__ StoreStore));
+    __ st_w(t, Address(TREG, JavaThread::thread_state_offset()));
 
     // Force this write out before the read below
     if (!UseSystemMemoryBarrier) {
       __ membar(__ AnyAny);
     }
-  } else {
-    __ st_w(t, TREG, in_bytes(JavaThread::thread_state_offset()));
   }
 
   // check for safepoint operation in progress and/or pending suspend requests
@@ -1430,11 +1434,12 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
   // change thread state
   __ li(t, _thread_in_Java);
-  if (os::is_MP()) {
+  if (UseAMOForOrderingStore) {
     __ addi_d(AT, TREG, in_bytes(JavaThread::thread_state_offset()));
-    __ amswap_db_w(R0, t, AT);
+    __ amswap_db_w(R0, t, AT); // as Release
   } else {
-    __ st_w(t, TREG, in_bytes(JavaThread::thread_state_offset()));
+    __ membar(Assembler::Membar_mask_bits(__ LoadStore|__ StoreStore));
+    __ st_w(t, Address(TREG, JavaThread::thread_state_offset()));
   }
 
   // Check preemption for Object.wait()

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -138,7 +138,7 @@ address TemplateInterpreterGenerator::generate_CRC32_update_entry() {
 
   Label slow_path;
   // If we need a safepoint check, generate full interpreter entry.
-  __ safepoint_poll(slow_path, TREG, false /* at_return */, false /* acquire */, false /* in_nmethod */);
+  __ safepoint_poll(slow_path, TREG, false /* at_return */, false /* in_nmethod */);
 
   // We don't generate local frame and don't align stack because
   // we call stub code and there is no safepoint on this path.
@@ -181,7 +181,7 @@ address TemplateInterpreterGenerator::generate_CRC32_updateBytes_entry(AbstractI
 
   Label slow_path;
   // If we need a safepoint check, generate full interpreter entry.
-  __ safepoint_poll(slow_path, TREG, false /* at_return */, false /* acquire */, false /* in_nmethod */);
+  __ safepoint_poll(slow_path, TREG, false /* at_return */, false /* in_nmethod */);
 
   // We don't generate local frame and don't align stack because
   // we call stub code and there is no safepoint on this path.
@@ -1411,15 +1411,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     //
     Label slow_path;
 
-    // We need an acquire here to ensure that any subsequent load of the
-    // global SafepointSynchronize::_state flag is ordered after this load
-    // of the thread-local polling word.  We don't want this poll to
-    // return false (i.e. not safepointing) and a later poll of the global
-    // SafepointSynchronize::_state spuriously to return true.
-    //
-    // This is to avoid a race when we're in a native->Java transition
-    // racing the code which wakes up from a safepoint.
-    __ safepoint_poll(slow_path, TREG, true /* at_return */, true /* acquire */, false /* in_nmethod */);
+    // No need for acquire as Java threads always disarm themselves.
+    __ safepoint_poll(slow_path, TREG, true /* at_return */, false /* in_nmethod */);
     __ ld_w(AT, TREG, in_bytes(JavaThread::suspend_flags_offset()));
     __ beq(AT, R0, Continue);
     __ bind(slow_path);
@@ -1556,7 +1549,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
   Label slow_path;
   Label fast_path;
-  __ safepoint_poll(slow_path, TREG, true /* at_return */, false /* acquire */, false /* in_nmethod */);
+  __ safepoint_poll(slow_path, TREG, true /* at_return */, false /* in_nmethod */);
   __ b(fast_path);
 
   __ bind(slow_path);

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -154,7 +154,6 @@ void TemplateTable::patch_bytecode(Bytecodes::Code bc, Register bc_reg,
         __ lea(tmp_reg, Address(tmp_reg, in_bytes(ResolvedFieldEntry::put_code_offset())));
       }
       // Load-acquire the bytecode to match store-release in ResolvedFieldEntry::fill_in()
-      __ membar(MacroAssembler::AnyAny);
       __ ld_bu(tmp_reg, Address(tmp_reg, 0));
       __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
       __ addi_d(bc_reg, R0, bc);
@@ -2197,7 +2196,6 @@ void TemplateTable::resolve_cache_and_index_for_method(int byte_no,
       break;
   }
   // Load-acquire the bytecode to match store-release in InterpreterRuntime
-  __ membar(MacroAssembler::AnyAny);
   __ ld_bu(temp, Address(temp, 0));
   __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
   // is resolved?
@@ -2251,7 +2249,6 @@ void TemplateTable::resolve_cache_and_index_for_field(int byte_no,
     __ lea(temp, Address(Rcache, in_bytes(ResolvedFieldEntry::put_code_offset())));
   }
   // Load-acquire the bytecode to match store-release in ResolvedFieldEntry::fill_in()
-  __ membar(MacroAssembler::AnyAny);
   __ ld_bu(temp, Address(temp, 0));
   __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
   __ li(AT, (int) code);  // have we resolved this bytecode?

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -2546,19 +2546,9 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   const Register flags     = T1;
   const Register tos_state = T0;
 
-  const Register scratch = T8;
-
   resolve_cache_and_index_for_field(byte_no, cache, index);
   jvmti_post_field_access(cache, index, is_static, false);
   load_resolved_field_entry(obj, cache, tos_state, off, flags, is_static);
-
-  {
-    Label notVolatile;
-    __ test_bit(scratch, flags, ResolvedFieldEntry::is_volatile_shift);
-    __ beq(scratch, R0, notVolatile);
-    __ membar(MacroAssembler::AnyAny);
-    __ bind(notVolatile);
-  }
 
   if (!is_static) pop_and_check_object(obj);
 
@@ -2696,12 +2686,11 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
 
   __ bind(Done);
 
-  {
-    Label notVolatile;
-    __ beq(scratch, R0, notVolatile);
-    __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
-    __ bind(notVolatile);
-  }
+  Label notVolatile;
+  __ test_bit(AT, flags, ResolvedFieldEntry::is_volatile_shift);
+  __ beqz(AT, notVolatile);
+  __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
+  __ bind(notVolatile);
 }
 
 void TemplateTable::getfield(int byte_no) {
@@ -3130,9 +3119,6 @@ void TemplateTable::fast_storefield(TosState state) {
 // T2 : index & offset
 void TemplateTable::fast_accessfield(TosState state) {
   transition(atos, state);
-
-  const Register scratch = T8;
-
   // do the JVMTI work here to avoid disturbing the register state below
   if (JvmtiExport::can_post_field_access()) {
     // Check to see if a field access watch has been set before we take
@@ -3160,14 +3146,6 @@ void TemplateTable::fast_accessfield(TosState state) {
   // replace index with field offset from cache entry
   __ load_sized_value(T2, Address(T3, in_bytes(ResolvedFieldEntry::field_offset_offset())), sizeof(int), true /*is_signed*/);
   __ ld_bu(T1, Address(T3, in_bytes(ResolvedFieldEntry::flags_offset())));
-
-  {
-    Label notVolatile;
-    __ test_bit(scratch, T1, ResolvedFieldEntry::is_volatile_shift);
-    __ beqz(scratch, notVolatile);
-    __ membar(MacroAssembler::AnyAny);
-    __ bind(notVolatile);
-  }
 
   // FSR: object
   __ verify_oop(FSR);
@@ -3205,10 +3183,10 @@ void TemplateTable::fast_accessfield(TosState state) {
     default:
       ShouldNotReachHere();
   }
-
   {
     Label notVolatile;
-    __ beq(scratch, R0, notVolatile);
+    __ test_bit(AT, T1, ResolvedFieldEntry::is_volatile_shift);
+    __ beqz(AT, notVolatile);
     __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
     __ bind(notVolatile);
   }
@@ -3223,23 +3201,11 @@ void TemplateTable::fast_accessfield(TosState state) {
 void TemplateTable::fast_xaccess(TosState state) {
   transition(vtos, state);
 
-  const Register scratch = T8;
-
   // get receiver
   __ ld_d(T1, aaddress(0));
   // access constant pool cache
   __ load_field_entry(T3, T2, 2);
   __ load_sized_value(T2, Address(T3, in_bytes(ResolvedFieldEntry::field_offset_offset())), sizeof(int), true /*is_signed*/);
-
-  {
-    __ ld_bu(AT, Address(T3, in_bytes(ResolvedFieldEntry::flags_offset())));
-    __ test_bit(scratch, AT, ResolvedFieldEntry::is_volatile_shift);
-
-    Label notVolatile;
-    __ beq(scratch, R0, notVolatile);
-    __ membar(MacroAssembler::AnyAny);
-    __ bind(notVolatile);
-  }
 
   // make sure exception is reported in correct bcp range (getfield is
   // next instruction)
@@ -3257,14 +3223,17 @@ void TemplateTable::fast_xaccess(TosState state) {
   } else {
     ShouldNotReachHere();
   }
-  __ addi_d(BCP, BCP, -1);
 
   {
     Label notVolatile;
-    __ beq(scratch, R0, notVolatile);
+    __ ld_bu(T2, Address(T3, in_bytes(ResolvedFieldEntry::flags_offset())));
+    __ test_bit(AT, T2, ResolvedFieldEntry::is_volatile_shift);
+    __ beqz(AT, notVolatile);
     __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
     __ bind(notVolatile);
   }
+
+  __ addi_d(BCP, BCP, -1);
 }
 
 

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -126,6 +126,7 @@ static void do_oop_load(InterpreterMacroAssembler* _masm,
 void TemplateTable::patch_bytecode(Bytecodes::Code bc, Register bc_reg,
                                    Register tmp_reg, bool load_bc_into_bc_reg/*=true*/,
                                    int byte_no) {
+  assert_different_registers(bc_reg, tmp_reg);
   if (!RewriteBytecodes)  return;
   Label L_patch_done;
 
@@ -194,7 +195,11 @@ void TemplateTable::patch_bytecode(Bytecodes::Code bc, Register bc_reg,
   __ bind(L_okay);
 #endif
 
-  // patch bytecode
+  // Patch bytecode with release store to coordinate with ResolvedFieldEntry loads
+  // in fast bytecode codelets. load_field_entry has a memory barrier that gains
+  // the needed ordering, together with control dependency on entering the fast codelet
+  // itself.
+  __ membar(Assembler::Membar_mask_bits(__ LoadStore | __ StoreStore));
   __ st_b(bc_reg, at_bcp(0));
   __ bind(L_patch_done);
 }
@@ -3054,6 +3059,7 @@ void TemplateTable::fast_storefield(TosState state) {
   __ load_field_entry(T3, T2);
   // T2: field offset, T3: field holder, T1: flags
   load_resolved_field_entry(T3, T3, noreg, T2, T1);
+  __ verify_field_offset(T2);
 
   Label Done;
   {
@@ -3145,6 +3151,8 @@ void TemplateTable::fast_accessfield(TosState state) {
 
   // replace index with field offset from cache entry
   __ load_sized_value(T2, Address(T3, in_bytes(ResolvedFieldEntry::field_offset_offset())), sizeof(int), true /*is_signed*/);
+  __ verify_field_offset(T2);
+
   __ ld_bu(T1, Address(T3, in_bytes(ResolvedFieldEntry::flags_offset())));
 
   // FSR: object
@@ -3205,7 +3213,9 @@ void TemplateTable::fast_xaccess(TosState state) {
   __ ld_d(T1, aaddress(0));
   // access constant pool cache
   __ load_field_entry(T3, T2, 2);
+
   __ load_sized_value(T2, Address(T3, in_bytes(ResolvedFieldEntry::field_offset_offset())), sizeof(int), true /*is_signed*/);
+  __ verify_field_offset(T2);
 
   // make sure exception is reported in correct bcp range (getfield is
   // next instruction)

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -207,6 +207,13 @@ void VM_Version::get_processor_features() {
     warning("AMCAS{_DB}.{B/H/W/D} instructions are not available on this CPU");
     FLAG_SET_DEFAULT(UseAMCAS, false);
   }
+
+  if (supports_dbarhints()) {
+    if (FLAG_IS_DEFAULT(UseAMOForOrderingStore)) {
+      FLAG_SET_DEFAULT(UseAMOForOrderingStore, false);
+    }
+  }
+
 #ifdef COMPILER2
   int max_vector_size = 0;
   int min_vector_size = 0;

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -386,6 +386,10 @@ void VM_Version::get_processor_features() {
     }
   }
 
+  if (FLAG_IS_DEFAULT(UseBASE64Intrinsics)) {
+    FLAG_SET_DEFAULT(UseBASE64Intrinsics, true);
+  }
+
   if (UseLSX) {
       if (FLAG_IS_DEFAULT(UseChaCha20Intrinsics)) {
           UseChaCha20Intrinsics = true;


### PR DESCRIPTION
36722: Bytecode rewriting causes Java heap corruption on LoongArch
36251: No need for acquire fence in safepoint poll during JNI calls and FFM
36774: An auto-switch for ordering store implementation
36655: Reduce fence within the interp volatile read
36622: Implement Base64 intrinsic
36568: Redundant fence before ldar in the interpreter