### PR TITLE
Update (2026.03.05)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,6 @@ define_pd_global(size_t, CodeCacheExpansionSize,     32*K );
 define_pd_global(size_t, CodeCacheMinBlockLength,    1);
 define_pd_global(size_t, CodeCacheMinimumUseSpace,   400*K);
 define_pd_global(bool, NeverActAsServerClassMachine, true );
-define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
 define_pd_global(bool, CICompileOSR,                 true );
 #endif // !COMPILER2
 define_pd_global(bool, UseTypeProfile,               false);

--- a/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,6 @@ define_pd_global(size_t, InitialCodeCacheSize,       2496*K); // Integral multip
 define_pd_global(size_t, CodeCacheExpansionSize,     64*K);
 
 // Ergonomics related flags
-define_pd_global(uint64_t,MaxRAM,                    128ULL*G);
 define_pd_global(intx, RegisterCostAreaRatio,        16000);
 
 // Peephole and CISC spilling both break the graph, and so makes the

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+// Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -3727,6 +3727,7 @@ opclass memory_exclusive(indOffset16, indirect);
 
 opclass mRegLorI2L(mRegI2L, mRegL);
 opclass mRegIorL2I(mRegI, mRegL2I);
+opclass mRegIorN(mRegI, mRegN);
 opclass mRegLorP(mRegL, mRegP);
 
 //----------PIPELINE-----------------------------------------------------------
@@ -7732,6 +7733,28 @@ instruct cmovD_cmpF_reg_reg(regD dst, regD src, regF tmp1, regF tmp2, cmpOp cop 
   ins_pipe( pipe_slow );
 %}
 
+instruct cmovF_cmpNorU_reg_reg(regF dst, regF src, mRegIorN tmp1, mRegIorN tmp2, cmpOp cop) %{
+  match(Set dst (CMoveF (Binary cop (CmpN tmp1 tmp2)) (Binary dst src)));
+  match(Set dst (CMoveF (Binary cop (CmpU tmp1 tmp2)) (Binary dst src)));
+  ins_cost(200);
+  format %{
+             "CMP$cop  $tmp1, $tmp2\t  @cmovF_cmpNorU_reg_reg\n"
+             "\tCMOV  $dst, $src \t @cmovF_cmpNorU_reg_reg"
+         %}
+
+  ins_encode %{
+    Register op1 = $tmp1$$Register;
+    Register op2 = $tmp2$$Register;
+    FloatRegister dst = as_FloatRegister($dst$$reg);
+    FloatRegister src = as_FloatRegister($src$$reg);
+    int     flag = $cop$$cmpcode;
+
+    __ cmp_cmov(op1, op2, dst, src, (MacroAssembler::CMCompare) flag, false /* is_signed */);
+  %}
+
+  ins_pipe( pipe_slow );
+%}
+
 instruct cmovF_cmpI_reg_reg(regF dst, regF src, mRegI tmp1, mRegI tmp2, cmpOp cop) %{
   match(Set dst (CMoveF (Binary cop (CmpI tmp1 tmp2)) (Binary dst src)));
   ins_cost(200);
@@ -7748,6 +7771,28 @@ instruct cmovF_cmpI_reg_reg(regF dst, regF src, mRegI tmp1, mRegI tmp2, cmpOp co
     int     flag = $cop$$cmpcode;
 
     __ cmp_cmov(op1, op2, dst, src, (MacroAssembler::CMCompare) flag);
+  %}
+
+  ins_pipe( pipe_slow );
+%}
+
+instruct cmovF_cmpPorUL_reg_reg(regF dst, regF src, mRegLorP tmp1, mRegLorP tmp2, cmpOp cop) %{
+  match(Set dst (CMoveF (Binary cop (CmpP tmp1 tmp2)) (Binary dst src)));
+  match(Set dst (CMoveF (Binary cop (CmpUL tmp1 tmp2)) (Binary dst src)));
+  ins_cost(200);
+  format %{
+             "CMP$cop  $tmp1, $tmp2\t  @cmovF_cmpPorUL_reg_reg\n"
+             "\tCMOV  $dst, $src \t @cmovF_cmpPorUL_reg_reg"
+         %}
+
+  ins_encode %{
+    Register op1 = $tmp1$$Register;
+    Register op2 = $tmp2$$Register;
+    FloatRegister dst = as_FloatRegister($dst$$reg);
+    FloatRegister src = as_FloatRegister($src$$reg);
+    int     flag = $cop$$cmpcode;
+
+    __ cmp_cmov(op1, op2, dst, src, (MacroAssembler::CMCompare) flag, false /* is_signed */);
   %}
 
   ins_pipe( pipe_slow );
@@ -7774,12 +7819,13 @@ instruct cmovF_cmpL_reg_reg(regF dst, regF src, mRegL tmp1, mRegL tmp2, cmpOp co
   ins_pipe( pipe_slow );
 %}
 
-instruct cmovD_cmpN_reg_reg(regD dst, regD src, mRegN tmp1, mRegN tmp2, cmpOp cop) %{
+instruct cmovD_cmpNorU_reg_reg(regD dst, regD src, mRegIorN tmp1, mRegIorN tmp2, cmpOp cop) %{
   match(Set dst (CMoveD (Binary cop (CmpN tmp1 tmp2)) (Binary dst src)));
+  match(Set dst (CMoveD (Binary cop (CmpU tmp1 tmp2)) (Binary dst src)));
   ins_cost(200);
   format %{
-             "CMP$cop  $tmp1, $tmp2\t  @cmovD_cmpN_reg_reg\n"
-             "\tCMOV  $dst, $src \t @cmovD_cmpN_reg_reg"
+             "CMP$cop  $tmp1, $tmp2\t  @cmovD_cmpNorU_reg_reg\n"
+             "\tCMOV  $dst, $src \t @cmovD_cmpNorU_reg_reg"
          %}
 
   ins_encode %{
@@ -7816,13 +7862,36 @@ instruct cmovD_cmpI_reg_reg(regD dst, regD src, mRegI tmp1, mRegI tmp2, cmpOp co
   ins_pipe( pipe_slow );
 %}
 
-instruct cmovD_cmpLorP_reg_reg(regD dst, regD src, mRegLorP tmp1, mRegLorP tmp2, cmpOp cop) %{
+instruct cmovD_cmpPorUL_reg_reg(regD dst, regD src, mRegLorP tmp1, mRegLorP tmp2, cmpOp cop) %{
   match(Set dst (CMoveD (Binary cop (CmpP tmp1 tmp2)) (Binary dst src)));
+  match(Set dst (CMoveD (Binary cop (CmpUL tmp1 tmp2)) (Binary dst src)));
+  ins_cost(200);
+  format %{
+             "CMP$cop  $tmp1, $tmp2\t  @cmovD_cmpPorUL_reg_reg\n"
+             "\tCMOV  $dst, $src \t @cmovD_cmpPorUL_reg_reg"
+         %}
+
+  ins_encode %{
+    Register op1 = $tmp1$$Register;
+    Register op2 = $tmp2$$Register;
+    FloatRegister dst = as_FloatRegister($dst$$reg);
+    FloatRegister src = as_FloatRegister($src$$reg);
+    int     flag = $cop$$cmpcode;
+
+    // Use signed comparison here, because the most significant bit of the
+    // user-space virtual address must be 0.
+    __ cmp_cmov(op1, op2, dst, src, (MacroAssembler::CMCompare) flag, false /* is_signed */);
+  %}
+
+  ins_pipe( pipe_slow );
+%}
+
+instruct cmovD_cmpL_reg_reg(regD dst, regD src, mRegL tmp1, mRegL tmp2, cmpOp cop) %{
   match(Set dst (CMoveD (Binary cop (CmpL tmp1 tmp2)) (Binary dst src)));
   ins_cost(200);
   format %{
-             "CMP$cop  $tmp1, $tmp2\t  @cmovD_cmpLorP_reg_reg\n"
-             "\tCMOV  $dst, $src \t @cmovD_cmpLorP_reg_reg"
+             "CMP$cop  $tmp1, $tmp2\t  @cmovD_cmpL_reg_reg\n"
+             "\tCMOV  $dst, $src \t @cmovD_cmpL_reg_reg"
          %}
 
   ins_encode %{


### PR DESCRIPTION
36768: Add unsigned comparison for CMoveF/D
36767: LA port of 8369346: Remove default value of and deprecate the MaxRAM flag