### PR TITLE
Update (2026.03.05)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1103,11 +1103,11 @@ void LIRGenerator::do_Convert(Convert* x) {
   switch (x->op()) {
     case Bytecodes::_f2i:
     case Bytecodes::_f2l:
-      __ convert(x->op(), conv_input, conv_result, nullptr, new_register(T_FLOAT));
+      __ convert(x->op(), conv_input, conv_result, new_register(T_FLOAT));
       break;
     case Bytecodes::_d2i:
     case Bytecodes::_d2l:
-      __ convert(x->op(), conv_input, conv_result, nullptr, new_register(T_DOUBLE));
+      __ convert(x->op(), conv_input, conv_result, new_register(T_DOUBLE));
       break;
     default:
       __ convert(x->op(), conv_input, conv_result);

--- a/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register basic_lo
 
   null_check_offset = offset();
 
-  lightweight_lock(basic_lock, obj, hdr, SCR1, SCR2, slow_case);
+  fast_lock(basic_lock, obj, hdr, SCR1, SCR2, slow_case);
 
   return null_check_offset;
 }
@@ -59,7 +59,7 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register basic
   ld_d(obj, Address(basic_lock, BasicObjectLock::obj_offset()));
   verify_oop(obj);
 
-  lightweight_unlock(obj, hdr, SCR1, SCR2, slow_case);
+  fast_unlock(obj, hdr, SCR1, SCR2, slow_case);
 }
 
 // Defines obj, preserves var_size_in_bytes

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,10 @@
 #define BLOCK_COMMENT(str) block_comment(str)
 #endif
 
-void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box,
-                                              Register flag, Register tmp1,
-                                              Register tmp2, Register tmp3,
-                                              Register tmp4) {
+void C2_MacroAssembler::fast_lock(Register obj, Register box,
+                                  Register flag, Register tmp1,
+                                  Register tmp2, Register tmp3,
+                                  Register tmp4) {
   assert_different_registers(obj, box, flag, tmp1, tmp2, tmp3, tmp4);
 
   // Handle inflated monitor.
@@ -69,7 +69,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box,
   const Register tmp1_mark = tmp1;
   const Register tmp3_t = tmp3;
 
-  { // Lightweight locking
+  { // Fast locking
 
     // Push lock to the lock stack and finish successfully. MUST branch to with flag != 0
     Label push;
@@ -198,7 +198,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box,
   // C2 uses the value of flag (0 vs !0) to determine the continuation.
 }
 
-void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register box, Register flag, Register tmp1, Register tmp2, Register tmp3) {
+void C2_MacroAssembler::fast_unlock(Register obj, Register box, Register flag, Register tmp1, Register tmp2, Register tmp3) {
   assert_different_registers(obj, box, tmp1, tmp2, tmp3, flag, AT);
 
   // Handle inflated monitor.
@@ -213,7 +213,7 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register box, Regi
   const Register tmp3_t = tmp3;
 
   move(flag, R0);
-  { // Lightweight unlock
+  { // Fast unlock
     Label push_and_slow_path;
 
     // Check if obj is top of lock-stack.

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,13 +33,13 @@ public:
   void cmp_branch_long(int flag, Register op1, Register op2, Label* L, bool is_signed);
   void cmp_branchEqNe_off21(int flag, Register op1, Label& L);
 
-  // Code used by cmpFastLockLightweight and cmpFastUnlockLightweight mach instructions in .ad file.
-  void fast_lock_lightweight(Register object, Register box,
-                             Register flag, Register tmp1,
-                             Register tmp2, Register tmp3,
-                             Register tmp4);
-  void fast_unlock_lightweight(Register object, Register box, Register flag,
-                               Register tmp1, Register tmp2, Register tmp3);
+  // Code used by cmpFastLock and cmpFastUnlock mach instructions in .ad file.
+  void fast_lock(Register object, Register box,
+                 Register flag, Register tmp1,
+                 Register tmp2, Register tmp3,
+                 Register tmp4);
+  void fast_unlock(Register object, Register box, Register flag,
+                   Register tmp1, Register tmp2, Register tmp3);
 
   // Compare strings.
   void string_compareL(Register str1, Register str2,

--- a/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.cpp
@@ -90,8 +90,7 @@ void G1BarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* mas
                                                              DecoratorSet decorators,
                                                              Register start,
                                                              Register count,
-                                                             Register tmp,
-                                                             RegSet saved_regs) {
+                                                             Register tmp) {
   assert_different_registers(start, count, tmp);
 
   Label loop, next, done;

--- a/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/g1/g1BarrierSetAssembler_loongarch.hpp
@@ -37,7 +37,7 @@ class G1PreBarrierStubC2;
 class G1BarrierSetAssembler: public CardTableBarrierSetAssembler {
  protected:
   virtual void gen_write_ref_array_pre_barrier(MacroAssembler* masm, DecoratorSet decorators, Register addr, Register count, RegSet saved_regs);
-  virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators, Register addr, Register count, Register tmp, RegSet saved_regs);
+  virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators, Register addr, Register count, Register tmp);
 
   void g1_write_barrier_pre(MacroAssembler* masm,
                             Register obj,

--- a/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/barrierSetAssembler_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2018, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
                                   Register src, Register dst, Register count, RegSet saved_regs) {}
   virtual void arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
-                                  Register dst, Register count, Register scratch, RegSet saved_regs) {}
+                                  Register dst, Register count, Register scratch) {}
 
   virtual void copy_load_at(MacroAssembler* masm,
                             DecoratorSet decorators,

--- a/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.cpp
@@ -49,10 +49,9 @@ void CardTableBarrierSetAssembler::arraycopy_prologue(MacroAssembler* masm, Deco
 }
 
 void CardTableBarrierSetAssembler::arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
-                                                      Register start, Register count, Register tmp,
-                                                      RegSet saved_regs) {
+                                                      Register start, Register count, Register tmp) {
   if (is_oop) {
-    gen_write_ref_array_post_barrier(masm, decorators, start, count, tmp, saved_regs);
+    gen_write_ref_array_post_barrier(masm, decorators, start, count, tmp);
   }
 }
 
@@ -66,8 +65,7 @@ void CardTableBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet d
 }
 
 void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators,
-                                                                    Register addr, Register count, Register tmp,
-                                                                    RegSet saved_regs) {
+                                                                    Register addr, Register count, Register tmp) {
   BarrierSet *bs = BarrierSet::barrier_set();
   CardTableBarrierSet* ctbs = barrier_set_cast<CardTableBarrierSet>(bs);
   CardTable* ct = ctbs->card_table();

--- a/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.hpp
@@ -37,8 +37,7 @@ protected:
                                                Register addr, Register count, RegSet saved_regs) {}
 
   virtual void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators,
-                                                Register addr, Register count, Register tmp,
-                                                RegSet saved_regs);
+                                                Register addr, Register count, Register tmp);
 
   virtual void oop_store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                             Address dst, Register val, Register tmp1, Register tmp2, Register tmp3);
@@ -48,7 +47,7 @@ public:
                                   Register src, Register dst, Register count, RegSet saved_regs);
 
   virtual void arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
-                                  Register start, Register count, Register tmp, RegSet saved_regs);
+                                  Register start, Register count, Register tmp);
 
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         Address dst, Register val, Register tmp1, Register tmp2, Register tmp3);

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2021, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2022, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,9 +78,9 @@ void ShenandoahBarrierSetAssembler::arraycopy_prologue(MacroAssembler* masm, Dec
 }
 
 void ShenandoahBarrierSetAssembler::arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
-                                                       Register start, Register count, Register tmp, RegSet saved_regs) {
+                                                       Register start, Register count, Register tmp) {
   if (ShenandoahCardBarrier && is_oop) {
-    gen_write_ref_array_post_barrier(masm, decorators, start, count, tmp, saved_regs);
+    gen_write_ref_array_post_barrier(masm, decorators, start, count, tmp);
   }
 }
 
@@ -631,7 +631,7 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
 }
 
 void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators,
-                                                                     Register start, Register count, Register tmp, RegSet saved_regs) {
+                                                                     Register start, Register count, Register tmp) {
   assert(ShenandoahCardBarrier, "Did you mean to enable ShenandoahCardBarrier?");
 
   Label L_loop, L_done;

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoahBarrierSetAssembler_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2021, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2022, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ private:
 
   void gen_write_ref_array_post_barrier(MacroAssembler* masm, DecoratorSet decorators,
                                         Register start, Register count,
-                                        Register tmp, RegSet saved_regs);
+                                        Register tmp);
 
 public:
   virtual NMethodPatchingType nmethod_patching_type() { return NMethodPatchingType::conc_instruction_and_data_patch; }
@@ -79,7 +79,7 @@ public:
   virtual void arraycopy_prologue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
                                   Register src, Register dst, Register count, RegSet saved_regs);
   virtual void arraycopy_epilogue(MacroAssembler* masm, DecoratorSet decorators, bool is_oop,
-                                  Register start, Register count, Register tmp, RegSet saved_regs);
+                                  Register start, Register count, Register tmp);
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register dst, Address src, Register tmp1, Register tmp2);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -925,7 +925,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
   // Load object pointer into scr_reg
   ld_d(scr_reg, Address(lock_reg, BasicObjectLock::obj_offset()));
 
-  lightweight_lock(lock_reg, scr_reg, tmp_reg, SCR1, SCR2, slow_case);
+  fast_lock(lock_reg, scr_reg, tmp_reg, SCR1, SCR2, slow_case);
   b(done);
 
   bind(slow_case);
@@ -965,7 +965,7 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
   // free entry
   st_d(R0, Address(lock_reg, BasicObjectLock::obj_offset()));
 
-  lightweight_unlock(scr_reg, hdr_reg, tmp_reg, SCR1, slow_case);
+  fast_unlock(scr_reg, hdr_reg, tmp_reg, SCR1, slow_case);
   b(done);
 
   bind(slow_case);

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -11166,32 +11166,32 @@ instruct storeSSD(stackSlotD dst, regD src)
   ins_pipe( fpu_store );
 %}
 
-instruct cmpFastLockLightweight(FlagsReg cr, no_CR_mRegP object, no_CR_mRegP box,
-                                no_CR_mRegP tmp1, no_CR_mRegP tmp2,
-                                no_CR_mRegP tmp3, no_CR_mRegP tmp4) %{
+instruct cmpFastLock(FlagsReg cr, no_CR_mRegP object, no_CR_mRegP box,
+                     no_CR_mRegP tmp1, no_CR_mRegP tmp2,
+                     no_CR_mRegP tmp3, no_CR_mRegP tmp4) %{
   match(Set cr (FastLock object box));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4);
 
-  format %{ "FASTLOCK $cr <-- $object, $box, $tmp1, $tmp2, $tmp3, $tmp4 #@ cmpFastLockLightweight" %}
+  format %{ "FASTLOCK $cr <-- $object, $box, $tmp1, $tmp2, $tmp3, $tmp4 #@ cmpFastLock" %}
 
   ins_encode %{
-    __ fast_lock_lightweight($object$$Register, $box$$Register,
-                             $cr$$Register, $tmp1$$Register,
-                             $tmp2$$Register, $tmp3$$Register,
-                             $tmp4$$Register);
+    __ fast_lock($object$$Register, $box$$Register,
+                 $cr$$Register, $tmp1$$Register,
+                 $tmp2$$Register, $tmp3$$Register,
+                 $tmp4$$Register);
   %}
 
   ins_pipe( pipe_slow );
 %}
 
-instruct cmpFastUnlockLightweight(FlagsReg cr, no_CR_mRegP object, no_CR_mRegP box, no_CR_mRegP tmp1, no_CR_mRegP tmp2, no_CR_mRegP tmp3) %{
+instruct cmpFastUnlock(FlagsReg cr, no_CR_mRegP object, no_CR_mRegP box, no_CR_mRegP tmp1, no_CR_mRegP tmp2, no_CR_mRegP tmp3) %{
   match(Set cr (FastUnlock object box));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
 
-  format %{ "FASTUNLOCK $cr <-- $object, $box, $tmp1, $tmp2, $tmp3 #@ cmpFastUnlockLightweight" %}
+  format %{ "FASTUNLOCK $cr <-- $object, $box, $tmp1, $tmp2, $tmp3 #@ cmpFastUnlock" %}
 
   ins_encode %{
-    __ fast_unlock_lightweight($object$$Register, $box$$Register, $cr$$Register, $tmp1$$Register, $tmp2$$Register, $tmp3$$Register);
+    __ fast_unlock($object$$Register, $box$$Register, $cr$$Register, $tmp1$$Register, $tmp2$$Register, $tmp3$$Register);
   %}
 
   ins_pipe( pipe_slow );

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1127,6 +1127,10 @@ bool Matcher::vector_rearrange_requires_load_shuffle(BasicType elem_bt, int vlen
   return false;
 }
 
+bool Matcher::mask_op_prefers_predicate(int opcode, const TypeVect* vt) {
+  return false;
+}
+
 const RegMask* Matcher::predicate_reg_mask(void) {
   return nullptr;
 }

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -4796,12 +4796,12 @@ void MacroAssembler::double_move(VMRegPair src, VMRegPair dst, Register tmp) {
   }
 }
 
-// Implements lightweight-locking.
+// Implements fast-locking.
 //
 //  - obj: the object to be locked
 //  - tmp1, tmp2, tmp3: temporary registers, will be destroyed
 //  - slow: branched to if locking fails
-void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow) {
+void MacroAssembler::fast_lock(Register basic_lock, Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow) {
   assert_different_registers(basic_lock, obj, tmp1, tmp2, tmp3);
 
   Label _push, _tmp;
@@ -4858,12 +4858,12 @@ void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Registe
   st_w(top, Address(TREG, JavaThread::lock_stack_top_offset()));
 }
 
-// Implements lightweight-unlocking.
+// Implements fast-unlocking.
 //
 // - obj: the object to be unlocked
 // - tmp1, tmp2, tmp3: temporary registers
 // - slow: branched to if unlocking fails
-void MacroAssembler::lightweight_unlock(Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow) {
+void MacroAssembler::fast_unlock(Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow) {
   assert_different_registers(obj, tmp1, tmp2, tmp3);
 
 #ifdef ASSERT
@@ -4909,7 +4909,7 @@ void MacroAssembler::lightweight_unlock(Register obj, Register tmp1, Register tm
   Label not_unlocked;
   test_bit(t, mark, exact_log2(markWord::unlocked_value));
   beqz(t, not_unlocked);
-  stop("lightweight_unlock already unlocked");
+  stop("fast_unlock already unlocked");
   bind(not_unlocked);
 #endif
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -818,8 +818,8 @@ class MacroAssembler: public Assembler {
     }
   }
 
-  void lightweight_lock(Register basic_lock, Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow);
-  void lightweight_unlock(Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow);
+  void fast_lock(Register basic_lock, Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow);
+  void fast_unlock(Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow);
 
 #if INCLUDE_ZGC
   void patchable_li16(Register rd, uint16_t value);

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1724,7 +1724,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
     // FIXME
     Register tmp = T1;
-    __ lightweight_lock(lock_reg, obj_reg, swap_reg, tmp, SCR1, slow_path_lock);
+    __ fast_lock(lock_reg, obj_reg, swap_reg, tmp, SCR1, slow_path_lock);
 
     // Slow path will re-enter here
     __ bind(lock_done);
@@ -1859,7 +1859,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       save_native_result(masm, ret_type, stack_slots);
     }
 
-    __ lightweight_unlock(obj_reg, lock_reg, swap_reg, SCR1, slow_path_unlock);
+    __ fast_unlock(obj_reg, lock_reg, swap_reg, SCR1, slow_path_unlock);
 
     // slow path re-enters here
     __ bind(unlock_done);

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2034,7 +2034,7 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(post);
       __ pop(RegSet::of(A1, A2));
 
-      bs->arraycopy_epilogue(_masm, decorators, is_oop, A1, A2, T1, RegSet());
+      bs->arraycopy_epilogue(_masm, decorators, is_oop, A1, A2, T1);
 
       __ pop(RegSet::of(RA));
       __ move(A0, R0);
@@ -2330,7 +2330,6 @@ class StubGenerator: public StubCodeGenerator {
     const Register ckval       = A4; // super_klass
 
     RegSet wb_pre_saved_regs = RegSet::range(A0, A4);
-    RegSet wb_post_saved_regs = RegSet::of(count);
 
     // Registers used as temps (S0, S1, S2, S3 are save-on-entry)
     const Register copied_oop  = S0; // actual oop copied
@@ -2446,7 +2445,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ bind(L_do_card_marks);
 
-    bs->arraycopy_epilogue(_masm, decorators, is_oop, start_to, count_save, tmp2, wb_post_saved_regs);
+    bs->arraycopy_epilogue(_masm, decorators, is_oop, start_to, count_save, tmp2);
 
     __ bind(L_done_pop);
     __ pop(RegSet::of(S0, S1, S2, S3) + RA);

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -307,7 +307,7 @@ public:
   static bool supports_float16() { return UseLSX; }
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
-  constexpr static bool supports_recursive_lightweight_locking() { return true; }
+  constexpr static bool supports_recursive_fast_locking() { return true; }
 
   constexpr static bool supports_secondary_supers_table() { return true; }
 


### PR DESCRIPTION
36828: LA port of 8370878: C1: Clean up unnecessary ConversionStub constructor
36827: LA port of 8367292: VectorAPI: Optimize VectorMask.fromLong/toLong() for SVE
36826: LA port of 8371321: Remove unused last arg of BarrierSetAssembler::arraycopy_epilogue
36825: LA port of 8367982: Unify ObjectSynchronizer and LightweightSynchronizer