### PR TITLE
Update (2026.03.09)

### DIFF
--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -164,7 +164,7 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
 
   ifeq ($(USE_EXTERNAL_LIBPNG), false)
     LIBSPLASHSCREEN_HEADER_DIRS += libsplashscreen/libpng
-    LIBSPLASHSCREEN_CFLAGS += -DPNG_NO_MMX_CODE -DPNG_ARM_NEON_OPT=0
+    LIBSPLASHSCREEN_CFLAGS += -DPNG_NO_MMX_CODE -DPNG_ARM_NEON_OPT=0 \
       -DPNG_ARM_NEON_IMPLEMENTATION=0 -DPNG_LOONGARCH_LSX_OPT=0
 
     ifeq ($(call isTargetOs, linux)+$(call isTargetCpuArch, ppc), true+true)

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1086,6 +1086,10 @@ bool Matcher::is_reg2reg_move(MachNode* m) {
   return false;
 }
 
+bool Matcher::is_register_biasing_candidate(const MachNode* mdef, int oper_index) {
+  return false;
+}
+
 bool Matcher::is_generic_vector(MachOper* opnd)  {
   return opnd->opcode() == VREG;
 }

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -3364,7 +3364,7 @@ class StubGenerator: public StubCodeGenerator {
   // Inputs:
   //   A0        - source byte array address
   //   A1        - destination byte array address
-  //   A2        - K (key) in little endian int array
+  //   A2        - sessionKe (key) in little endian int array
   //   A3        - r vector byte array address
   //   A4        - input length
   //
@@ -3668,7 +3668,7 @@ class StubGenerator: public StubCodeGenerator {
   // Inputs:
   //   A0        - source byte array address
   //   A1        - destination byte array address
-  //   A2        - K (key) in little endian int array
+  //   A2        - sessionKd (key) in little endian int array
   //   A3        - r vector byte array address
   //   A4        - input length
   //

--- a/src/hotspot/os_cpu/linux_loongarch/atomicAccess_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/atomicAccess_linux_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,6 +233,9 @@ inline D AtomicAccess::PlatformAdd<8>::fetch_then_add(D volatile* dest, I add_va
 
   return old_value;
 }
+
+template<>
+struct AtomicAccess::PlatformXchg<1> : AtomicAccess::XchgUsingCmpxchg<1> {};
 
 template<>
 template<typename T>

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
@@ -24,8 +24,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2022, These
- * modifications are Copyright (c) 2019, 2022, Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2026, These
+ * modifications are Copyright (c) 2019, 2026, Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -96,11 +96,13 @@ class LinuxCDebugger implements CDebugger {
        return LinuxAMD64CFrame.getTopFrame(dbg, sp, pc, context);
     } else if (cpu.equals("loongarch64")) {
        LOONGARCH64ThreadContext context = (LOONGARCH64ThreadContext) thread.getContext();
+       Address sp = context.getRegisterAsAddress(LOONGARCH64ThreadContext.SP);
+       if (sp == null) return null;
        Address fp = context.getRegisterAsAddress(LOONGARCH64ThreadContext.FP);
        if (fp == null) return null;
        Address pc  = context.getRegisterAsAddress(LOONGARCH64ThreadContext.PC);
        if (pc == null) return null;
-       return new LinuxLOONGARCH64CFrame(dbg, fp, pc);
+       return new LinuxLOONGARCH64CFrame(dbg, sp, fp, pc);
     }  else if (cpu.equals("ppc64")) {
         PPC64ThreadContext context = (PPC64ThreadContext) thread.getContext();
         Address sp = context.getRegisterAsAddress(PPC64ThreadContext.SP);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/loongarch64/LinuxLOONGARCH64CFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/loongarch64/LinuxLOONGARCH64CFrame.java
@@ -30,11 +30,14 @@ import sun.jvm.hotspot.debugger.linux.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
 import sun.jvm.hotspot.debugger.cdbg.basic.*;
 import sun.jvm.hotspot.debugger.loongarch64.*;
+import sun.jvm.hotspot.runtime.*;
+import sun.jvm.hotspot.runtime.loongarch64.*;
 
 final public class LinuxLOONGARCH64CFrame extends BasicCFrame {
    // package/class internals only
-   public LinuxLOONGARCH64CFrame(LinuxDebugger dbg, Address fp, Address pc) {
+   public LinuxLOONGARCH64CFrame(LinuxDebugger dbg, Address sp, Address fp, Address pc) {
       super(dbg.getCDebugger());
+      this.sp = sp;
       this.fp = fp;
       this.pc = pc;
       this.dbg = dbg;
@@ -56,11 +59,11 @@ final public class LinuxLOONGARCH64CFrame extends BasicCFrame {
 
    @Override
    public CFrame sender(ThreadProxy thread) {
-      return sender(thread, null, null);
+      return sender(thread, null, null, null);
    }
 
    @Override
-   public CFrame sender(ThreadProxy thread, Address nextFP, Address nextPC) {
+   public CFrame sender(ThreadProxy thread, Address nextSP, Address nextFP, Address nextPC) {
       // Check fp
       // Skip if both nextFP and nextPC are given - do not need to load from fp.
       if (nextFP == null && nextPC == null) {
@@ -72,6 +75,13 @@ final public class LinuxLOONGARCH64CFrame extends BasicCFrame {
         if (dbg.getAddressValue(fp) % (2 * ADDRESS_SIZE) != 0) {
           return null;
         }
+      }
+
+      if (nextSP == null) {
+        nextSP = fp.getAddressAt(0 * ADDRESS_SIZE);
+      }
+      if (nextSP == null) {
+        return null;
       }
 
       if (nextFP == null) {
@@ -88,11 +98,17 @@ final public class LinuxLOONGARCH64CFrame extends BasicCFrame {
         return null;
       }
 
-      return new LinuxLOONGARCH64CFrame(dbg, nextFP, nextPC);
+      return new LinuxLOONGARCH64CFrame(dbg, nextSP, nextFP, nextPC);
+   }
+
+   @Override
+   public Frame toFrame() {
+      return new LOONGARCH64Frame(sp, fp, pc);
    }
 
    private static final int ADDRESS_SIZE = 8;
    private Address pc;
+   private Address sp;
    private Address fp;
    private LinuxDebugger dbg;
 }


### PR DESCRIPTION
36983: 8374321: Fix undefined reference to 'png_init_filter_functions_lsx' after 8371914
36949: LA port of 8371820: Further AES performance improvements for key schedule generation
36948: LA port of 8371194: serviceability/sa/TestJhsdbJstackMixedWithXComp.java failing
36947: LA port of 8372528: Unify atomic exchange and compare exchange
36946: LA port of 8351016: RA support for EVEX to REX/REX2 demotion to optimize NDD instructions