### PR TITLE
Update (2026.03.09)

### DIFF
--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -29,6 +29,7 @@
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "code/vtableStubs.hpp"
+#include "cppstdlib/cstdlib.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/allocation.inline.hpp"
 #include "os_linux.hpp"
@@ -59,7 +60,6 @@
 # include <signal.h>
 # include <errno.h>
 # include <dlfcn.h>
-# include <stdlib.h>
 # include <stdio.h>
 # include <unistd.h>
 # include <sys/resource.h>

--- a/src/hotspot/os_cpu/linux_loongarch/prefetch_linux_loongarch.inline.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/prefetch_linux_loongarch.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #ifndef OS_CPU_LINUX_LOONGARCH_PREFETCH_LINUX_LOONGARCH_INLINE_HPP
 #define OS_CPU_LINUX_LOONGARCH_PREFETCH_LINUX_LOONGARCH_INLINE_HPP
 
+// Included in runtime/prefetch.inline.hpp
 
 inline void Prefetch::read (const void *loc, intx interval) {
 // According to previous and present SPECjbb2015 score,


### PR DESCRIPTION
37128: LA port of 8372040: Remove Prefetch header vs inline header separation
37127: LA port of 8372754: Add wrapper for <cstdlib> 8369205: AIX build break in forbiddenFunctions.hpp