### PR TITLE
Update (2026.03.09, 3rd)

### DIFF
--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -711,23 +711,21 @@ void SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm,
 
   // Class initialization barrier for static methods
   entry_address[AdapterBlob::C2I_No_Clinit_Check] = nullptr;
-  if (VM_Version::supports_fast_class_init_checks()) {
-    Label L_skip_barrier;
-    address handle_wrong_method = SharedRuntime::get_handle_wrong_method_stub();
+  assert(VM_Version::supports_fast_class_init_checks(), "sanity");
+  Label L_skip_barrier;
+  address handle_wrong_method = SharedRuntime::get_handle_wrong_method_stub();
 
-    { // Bypass the barrier for non-static methods
-      __ ld_hu(AT, Address(Rmethod, Method::access_flags_offset()));
-      __ test_bit(AT, AT, exact_log2(JVM_ACC_STATIC));
-      __ beqz(AT, L_skip_barrier); // non-static
-    }
+  // Bypass the barrier for non-static methods
+  __ ld_hu(AT, Address(Rmethod, Method::access_flags_offset()));
+  __ test_bit(AT, AT, exact_log2(JVM_ACC_STATIC));
+  __ beqz(AT, L_skip_barrier); // non-static
 
-    __ load_method_holder(T4, Rmethod);
-    __ clinit_barrier(T4, AT, &L_skip_barrier);
-    __ jmp(handle_wrong_method, relocInfo::runtime_call_type);
+  __ load_method_holder(T4, Rmethod);
+  __ clinit_barrier(T4, AT, &L_skip_barrier);
+  __ jmp(handle_wrong_method, relocInfo::runtime_call_type);
 
-    __ bind(L_skip_barrier);
-    entry_address[AdapterBlob::C2I_No_Clinit_Check] = __ pc();
-  }
+  __ bind(L_skip_barrier);
+  entry_address[AdapterBlob::C2I_No_Clinit_Check] = __ pc();
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   __ block_comment("c2i_entry_barrier");
@@ -1488,7 +1486,8 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   int vep_offset = ((intptr_t)__ pc()) - start;
 
-  if (VM_Version::supports_fast_class_init_checks() && method->needs_clinit_barrier()) {
+  if (method->needs_clinit_barrier()) {
+    assert(VM_Version::supports_fast_class_init_checks(), "sanity");
     Label L_skip_barrier;
     address handle_wrong_method = SharedRuntime::get_handle_wrong_method_stub();
     __ mov_metadata(T4, method->method_holder()); // InstanceKlass*

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -2208,7 +2208,8 @@ void TemplateTable::resolve_cache_and_index_for_method(int byte_no,
   __ addi_d(temp, temp, -i);
 
   // Class initialization barrier for static methods
-  if (VM_Version::supports_fast_class_init_checks() && bytecode() == Bytecodes::_invokestatic) {
+  if (bytecode() == Bytecodes::_invokestatic) {
+    assert(VM_Version::supports_fast_class_init_checks(), "sanity");
     __ bnez(temp, L_clinit_barrier_slow);  // have we resolved this bytecode?
     __ ld_d(temp, Address(Rcache, in_bytes(ResolvedMethodEntry::method_offset())));
     __ load_method_holder(temp, temp);
@@ -2259,8 +2260,8 @@ void TemplateTable::resolve_cache_and_index_for_field(int byte_no,
   __ li(AT, (int) code);  // have we resolved this bytecode?
 
   // Class initialization barrier for static fields
-  if (VM_Version::supports_fast_class_init_checks() &&
-      (bytecode() == Bytecodes::_getstatic || bytecode() == Bytecodes::_putstatic)) {
+  if (bytecode() == Bytecodes::_getstatic || bytecode() == Bytecodes::_putstatic) {
+    assert(VM_Version::supports_fast_class_init_checks(), "sanity");
     const Register field_holder = temp;
 
     __ bne(temp, AT, L_clinit_barrier_slow);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2410,9 +2410,10 @@ bool os::Linux::query_accurate_process_memory_info(os::Linux::accurate_meminfo_t
 
 int os::Linux::sched_active_processor_count() {
   if (OSContainer::is_containerized()) {
-    int count = -1;
-    OSContainer::active_processor_count(count);
-    return count;
+    double cpu_quota = -1.0;
+    OSContainer::active_processor_count(cpu_quota);
+    int active_cpus = ceil(cpu_quota);
+    return active_cpus;
   }
   return os::Linux::active_processor_count();
 }


### PR DESCRIPTION
37165: Fix os::Linux::sched_active_processor_count after 8367319
37164: LA port of 8370112: Remove VM_Version::supports_fast_class_init_checks() in platform-specific code