### PR TITLE
Update (2026.03.10)

### DIFF
--- a/src/hotspot/cpu/loongarch/compiledIC_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/compiledIC_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,9 +107,7 @@ void CompiledDirectCall::set_stub_to_clean(static_stub_Relocation* static_stub) 
 void CompiledDirectCall::verify() {
   // Verify call.
   _call->verify();
-  if (os::is_MP()) {
-    _call->verify_alignment();
-  }
+  _call->verify_alignment();
 
   // Verify stub.
   address stub = find_stub();

--- a/src/hotspot/cpu/loongarch/globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globals_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,9 +78,6 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
                    product,                                                 \
                    range,                                                   \
                    constraint)                                              \
-                                                                            \
-  product(bool, UseCodeCacheAllocOpt, true,                                 \
-                "Allocate code cache within 32-bit memory address space")   \
                                                                             \
   product(bool, UseLSX, false,                                              \
                 "Use LSX 128-bit vector instructions")                      \

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -5936,9 +5936,7 @@ instruct membar_volatile() %{
 
   format %{ "MEMBAR-volatile" %}
   ins_encode %{
-    if( !os::is_MP() ) return;     // Not needed on single CPU
     __ membar(__ StoreLoad);
-
   %}
   ins_pipe( pipe_serial );
 %}

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1047,6 +1047,10 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   __ addi_d(LVP, LVP, (-1) * wordSize);
   __ add_d(LVP, LVP, SP);
 
+  // Padding between locals and fixed part of activation frame to ensure
+  // SP is always 16-byte aligned.
+  assert(StackAlignmentInBytes == 16, "must be");
+  __ bstrins_d(SP, R0, 3, 0);
 
   // add 2 zero-initialized slots for native calls
   // 1 slot for native oop temp offset (setup via runtime)
@@ -1688,6 +1692,11 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
 
     __ bind(exit);
   }
+
+  // Padding between locals and fixed part of activation frame to ensure
+  // SP is always 16-byte aligned.
+  assert(StackAlignmentInBytes == 16, "must be");
+  __ bstrins_d(SP, R0, 3, 0);
 
   // And the base dispatch table
   __ get_dispatch();

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -300,9 +300,7 @@ void TemplateTable::ldc(LdcType type) {
   // get type
   __ add_d(AT, T1, T2);
   __ ld_b(T1, AT, tags_offset);
-  if(os::is_MP()) {
-    __ membar(Assembler::Membar_mask_bits(__ LoadLoad|__ LoadStore));
-  }
+  __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
   //now T1 is the tag
 
   // unresolved class - get the resolved class
@@ -3620,9 +3618,7 @@ void TemplateTable::_new() {
   const int tags_offset = Array<u1>::base_offset_in_bytes();
   __ add_d(T1, T1, A2);
   __ ld_b(AT, T1, tags_offset);
-  if(os::is_MP()) {
-    __ membar(Assembler::Membar_mask_bits(__ LoadLoad|__ LoadStore));
-  }
+  __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
   __ addi_d(AT, AT, -(int)JVM_CONSTANT_Class);
   __ bnez(AT, slow_case);
 
@@ -3746,9 +3742,7 @@ void TemplateTable::checkcast() {
   // See if bytecode has already been quicked
   __ add_d(AT, T1, T2);
   __ ld_b(AT, AT, Array<u1>::base_offset_in_bytes());
-  if(os::is_MP()) {
-    __ membar(Assembler::Membar_mask_bits(__ LoadLoad|__ LoadStore));
-  }
+  __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
   __ addi_d(AT, AT, - (int)JVM_CONSTANT_Class);
   __ beq(AT, R0, quicked);
 
@@ -3810,9 +3804,7 @@ void TemplateTable::instanceof() {
   // quicked
   __ add_d(AT, T1, T2);
   __ ld_b(AT, AT, Array<u1>::base_offset_in_bytes());
-  if(os::is_MP()) {
-    __ membar(Assembler::Membar_mask_bits(__ LoadLoad|__ LoadStore));
-  }
+  __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
   __ addi_d(AT, AT, - (int)JVM_CONSTANT_Class);
   __ beq(AT, R0, quicked);
 

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,61 +60,53 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
 
     address start = __ pc();
 
-    __ enter();
-    __ push(AT);
-    __ push(T5);
+    __ cpucfg(AT, R0);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id0_offset()));
 
-    __ li(AT, (long)0);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id0_offset()));
+    __ li(AT, 0x1);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id1_offset()));
 
-    __ li(AT, 1);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id1_offset()));
+    __ li(AT, 0x2);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id2_offset()));
 
-    __ li(AT, 2);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id2_offset()));
+    __ li(AT, 0x3);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id3_offset()));
 
-    __ li(AT, 3);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id3_offset()));
+    __ li(AT, 0x4);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id4_offset()));
 
-    __ li(AT, 4);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id4_offset()));
+    __ li(AT, 0x5);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id5_offset()));
 
-    __ li(AT, 5);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id5_offset()));
+    __ li(AT, 0x6);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id6_offset()));
 
-    __ li(AT, 6);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id6_offset()));
+    __ li(AT, 0x10);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id10_offset()));
 
-    __ li(AT, 10);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id10_offset()));
+    __ li(AT, 0x11);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id11_offset()));
 
-    __ li(AT, 11);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id11_offset()));
+    __ li(AT, 0x12);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id12_offset()));
 
-    __ li(AT, 12);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id12_offset()));
+    __ li(AT, 0x13);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id13_offset()));
 
-    __ li(AT, 13);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id13_offset()));
+    __ li(AT, 0x14);
+    __ cpucfg(AT, AT);
+    __ st_w(AT, Address(c_rarg0, VM_Version::cpucfg_info_id14_offset()));
 
-    __ li(AT, 14);
-    __ cpucfg(T5, AT);
-    __ st_w(T5, A0, in_bytes(VM_Version::Loongson_Cpucfg_id14_offset()));
-
-    __ pop(T5);
-    __ pop(AT);
-    __ leave();
     __ jr(RA);
 #   undef __
     return start;

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.hpp
@@ -261,18 +261,18 @@ protected:
 
 public:
   // Offsets for cpuid asm stub
-  static ByteSize Loongson_Cpucfg_id0_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id0); }
-  static ByteSize Loongson_Cpucfg_id1_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id1); }
-  static ByteSize Loongson_Cpucfg_id2_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id2); }
-  static ByteSize Loongson_Cpucfg_id3_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id3); }
-  static ByteSize Loongson_Cpucfg_id4_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id4); }
-  static ByteSize Loongson_Cpucfg_id5_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id5); }
-  static ByteSize Loongson_Cpucfg_id6_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id6); }
-  static ByteSize Loongson_Cpucfg_id10_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id10); }
-  static ByteSize Loongson_Cpucfg_id11_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id11); }
-  static ByteSize Loongson_Cpucfg_id12_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id12); }
-  static ByteSize Loongson_Cpucfg_id13_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id13); }
-  static ByteSize Loongson_Cpucfg_id14_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id14); }
+  static ByteSize cpucfg_info_id0_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id0); }
+  static ByteSize cpucfg_info_id1_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id1); }
+  static ByteSize cpucfg_info_id2_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id2); }
+  static ByteSize cpucfg_info_id3_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id3); }
+  static ByteSize cpucfg_info_id4_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id4); }
+  static ByteSize cpucfg_info_id5_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id5); }
+  static ByteSize cpucfg_info_id6_offset()  { return byte_offset_of(CpuidInfo, cpucfg_info_id6); }
+  static ByteSize cpucfg_info_id10_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id10); }
+  static ByteSize cpucfg_info_id11_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id11); }
+  static ByteSize cpucfg_info_id12_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id12); }
+  static ByteSize cpucfg_info_id13_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id13); }
+  static ByteSize cpucfg_info_id14_offset() { return byte_offset_of(CpuidInfo, cpucfg_info_id14); }
 
   static void clean_cpuFeatures()   { _features = 0; }
 


### PR DESCRIPTION
37261: removed UseCodeCacheAllocOpt
35654: Padding between locals and fixed frame to ensure SP is 16-bytes aligned
37147: Correct cpucfg register index from decimal to hex
36962: Purge the irrational is_MP() usage