### PR TITLE
Update (2026.03.10, 4th)

### DIFF
--- a/src/hotspot/cpu/loongarch/globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globals_loongarch.hpp
@@ -42,7 +42,7 @@ define_pd_global(size_t, CodeCacheSegmentSize,   64 COMPILER1_AND_COMPILER2_PRES
 
 // Ideally, this should be cache line size,
 // which keeps code end data on separate lines.
-define_pd_global(intx, CodeEntryAlignment,       64);
+define_pd_global(uint, CodeEntryAlignment,       64);
 define_pd_global(intx, OptoLoopAlignment,        16);
 define_pd_global(intx, InlineSmallCode,          2000);
 


### PR DESCRIPTION
37243: LA port of 8377172: Change datatype of CodeEntryAlignment to uint