### PR TITLE
Update (2026.04.28)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch.hpp
@@ -46,8 +46,8 @@ friend class ArrayCopyStub;
   Address stack_slot_address(int index, uint shift, int adjust = 0);
 
   // Record the type of the receiver in ReceiverTypeData
-  void type_profile_helper(Register mdo, ciMethodData *md, ciProfileData *data,
-                           Register recv, Label* update_done);
+  void type_profile_helper(Register mdo, ciMethodData *md,
+                           ciProfileData *data, Register recv);
   void add_debug_info_for_branch(address adr, CodeEmitInfo* info);
 
   void casw(Register addr, Register newval, Register cmpval, Register result, bool sign);

--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -1205,36 +1205,10 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
   __ bind(*op->stub()->continuation());
 }
 
-void LIR_Assembler::type_profile_helper(Register mdo, ciMethodData *md, ciProfileData *data,
-                                        Register recv, Label* update_done) {
-  for (uint i = 0; i < ReceiverTypeData::row_limit(); i++) {
-    Label next_test;
-    // See if the receiver is receiver[n].
-    __ lea(SCR2, Address(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_offset(i))));
-    __ ld_d(SCR1, Address(SCR2));
-    __ bne(recv, SCR1, next_test);
-    Address data_addr(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_count_offset(i)));
-    __ ld_d(SCR2, data_addr);
-    __ addi_d(SCR2, SCR2, DataLayout::counter_increment);
-    __ st_d(SCR2, data_addr);
-    __ b(*update_done);
-    __ bind(next_test);
-  }
-
-  // Didn't find receiver; find next empty slot and fill it in
-  for (uint i = 0; i < ReceiverTypeData::row_limit(); i++) {
-    Label next_test;
-    __ lea(SCR2, Address(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_offset(i))));
-    Address recv_addr(SCR2);
-    __ ld_d(SCR1, recv_addr);
-    __ bnez(SCR1, next_test);
-    __ st_d(recv, recv_addr);
-    __ li(SCR1, DataLayout::counter_increment);
-    __ lea(SCR2, Address(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_count_offset(i))));
-    __ st_d(SCR1, Address(SCR2));
-    __ b(*update_done);
-    __ bind(next_test);
-  }
+void LIR_Assembler::type_profile_helper(Register mdo, ciMethodData *md,
+                                        ciProfileData *data, Register recv) {
+  int mdp_offset = md->byte_offset_of_slot(data, in_ByteSize(0));
+  __ profile_receiver_type(recv, mdo, mdp_offset);
 }
 
 void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success,
@@ -1295,15 +1269,9 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success,
     __ b(*obj_is_null);
     __ bind(not_null);
 
-    Label update_done;
     Register recv = k_RInfo;
     __ load_klass(recv, obj);
-    type_profile_helper(mdo, md, data, recv, &update_done);
-    Address counter_addr(mdo, md->byte_offset_of_slot(data, CounterData::count_offset()));
-    __ ld_d(SCR2, counter_addr);
-    __ addi_d(SCR2, SCR2, DataLayout::counter_increment);
-    __ st_d(SCR2, counter_addr);
-    __ bind(update_done);
+    type_profile_helper(mdo, md, data, recv);
   } else {
     __ beqz(obj, *obj_is_null);
   }
@@ -1409,15 +1377,9 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
       __ b(done);
       __ bind(not_null);
 
-      Label update_done;
       Register recv = k_RInfo;
       __ load_klass(recv, value);
-      type_profile_helper(mdo, md, data, recv, &update_done);
-      Address counter_addr(mdo, md->byte_offset_of_slot(data, CounterData::count_offset()));
-      __ ld_d(SCR2, counter_addr);
-      __ addi_d(SCR2, SCR2, DataLayout::counter_increment);
-      __ st_d(SCR2, counter_addr);
-      __ bind(update_done);
+      type_profile_helper(mdo, md, data, recv);
     } else {
       __ beqz(value, done);
     }
@@ -2820,12 +2782,8 @@ void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {
       // We know the type that will be seen at this call site; we can
       // statically update the MethodData* rather than needing to do
       // dynamic tests on the receiver type
-
-      // NOTE: we should probably put a lock around this search to
-      // avoid collisions by concurrent compilations
       ciVirtualCallData* vc_data = (ciVirtualCallData*) data;
-      uint i;
-      for (i = 0; i < VirtualCallData::row_limit(); i++) {
+      for (uint i = 0; i < VirtualCallData::row_limit(); i++) {
         ciKlass* receiver = vc_data->receiver(i);
         if (known_klass->equals(receiver)) {
           Address data_addr(mdo, md->byte_offset_of_slot(data, VirtualCallData::receiver_count_offset(i)));
@@ -2835,38 +2793,13 @@ void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {
           return;
         }
       }
-
-      // Receiver type not found in profile data; select an empty slot
-
-      // Note that this is less efficient than it should be because it
-      // always does a write to the receiver part of the
-      // VirtualCallData rather than just the first time
-      for (i = 0; i < VirtualCallData::row_limit(); i++) {
-        ciKlass* receiver = vc_data->receiver(i);
-        if (receiver == nullptr) {
-          Address recv_addr(mdo, md->byte_offset_of_slot(data, VirtualCallData::receiver_offset(i)));
-          __ mov_metadata(SCR2, known_klass->constant_encoding());
-          __ lea(SCR1, recv_addr);
-          __ st_d(SCR2, SCR1, 0);
-          Address data_addr(mdo, md->byte_offset_of_slot(data, VirtualCallData::receiver_count_offset(i)));
-          __ ld_d(SCR2, data_addr);
-          __ addi_d(SCR2, SCR1, DataLayout::counter_increment);
-          __ st_d(SCR2, data_addr);
-          return;
-        }
-      }
+      // Receiver type is not found in profile data.
+      // Fall back to runtime helper to handle the rest at runtime.
+      __ mov_metadata(recv, known_klass->constant_encoding());
     } else {
       __ load_klass(recv, recv);
-      Label update_done;
-      type_profile_helper(mdo, md, data, recv, &update_done);
-      // Receiver did not match any saved receiver and there is no empty row for it.
-      // Increment total counter to indicate polymorphic case.
-      __ ld_d(SCR2, counter_addr);
-      __ addi_d(SCR2, SCR2, DataLayout::counter_increment);
-      __ st_d(SCR2, counter_addr);
-
-      __ bind(update_done);
     }
+    type_profile_helper(mdo, md, data, recv);
   } else {
     // Static call
     __ ld_d(SCR2, counter_addr);

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -1735,52 +1735,60 @@ void C2_MacroAssembler::reduce_ins_v(FloatRegister vec1, FloatRegister vec2, Flo
   switch (type) {
     case T_BYTE:
       switch (opcode) {
-        case Op_AddReductionVI: vadd_b(vec1, vec2, vec3); break;
-        case Op_MulReductionVI: vmul_b(vec1, vec2, vec3); break;
-        case Op_MaxReductionV:  vmax_b(vec1, vec2, vec3); break;
-        case Op_MinReductionV:  vmin_b(vec1, vec2, vec3); break;
-        case Op_AndReductionV:  vand_v(vec1, vec2, vec3); break;
-        case Op_OrReductionV:    vor_v(vec1, vec2, vec3); break;
-        case Op_XorReductionV:  vxor_v(vec1, vec2, vec3); break;
+        case Op_AddReductionVI:  vadd_b(vec1, vec2, vec3); break;
+        case Op_MulReductionVI:  vmul_b(vec1, vec2, vec3); break;
+        case Op_MaxReductionV:   vmax_b(vec1, vec2, vec3); break;
+        case Op_MinReductionV:   vmin_b(vec1, vec2, vec3); break;
+        case Op_UMaxReductionV: vmax_bu(vec1, vec2, vec3); break;
+        case Op_UMinReductionV: vmin_bu(vec1, vec2, vec3); break;
+        case Op_AndReductionV:   vand_v(vec1, vec2, vec3); break;
+        case Op_OrReductionV:     vor_v(vec1, vec2, vec3); break;
+        case Op_XorReductionV:   vxor_v(vec1, vec2, vec3); break;
         default:
           ShouldNotReachHere();
       }
       break;
     case T_SHORT:
       switch (opcode) {
-        case Op_AddReductionVI: vadd_h(vec1, vec2, vec3); break;
-        case Op_MulReductionVI: vmul_h(vec1, vec2, vec3); break;
-        case Op_MaxReductionV:  vmax_h(vec1, vec2, vec3); break;
-        case Op_MinReductionV:  vmin_h(vec1, vec2, vec3); break;
-        case Op_AndReductionV:  vand_v(vec1, vec2, vec3); break;
-        case Op_OrReductionV:    vor_v(vec1, vec2, vec3); break;
-        case Op_XorReductionV:  vxor_v(vec1, vec2, vec3); break;
+        case Op_AddReductionVI:  vadd_h(vec1, vec2, vec3); break;
+        case Op_MulReductionVI:  vmul_h(vec1, vec2, vec3); break;
+        case Op_MaxReductionV:   vmax_h(vec1, vec2, vec3); break;
+        case Op_MinReductionV:   vmin_h(vec1, vec2, vec3); break;
+        case Op_UMaxReductionV: vmax_hu(vec1, vec2, vec3); break;
+        case Op_UMinReductionV: vmin_hu(vec1, vec2, vec3); break;
+        case Op_AndReductionV:   vand_v(vec1, vec2, vec3); break;
+        case Op_OrReductionV:     vor_v(vec1, vec2, vec3); break;
+        case Op_XorReductionV:   vxor_v(vec1, vec2, vec3); break;
         default:
           ShouldNotReachHere();
       }
       break;
     case T_INT:
       switch (opcode) {
-        case Op_AddReductionVI: vadd_w(vec1, vec2, vec3); break;
-        case Op_MulReductionVI: vmul_w(vec1, vec2, vec3); break;
-        case Op_MaxReductionV:  vmax_w(vec1, vec2, vec3); break;
-        case Op_MinReductionV:  vmin_w(vec1, vec2, vec3); break;
-        case Op_AndReductionV:  vand_v(vec1, vec2, vec3); break;
-        case Op_OrReductionV:    vor_v(vec1, vec2, vec3); break;
-        case Op_XorReductionV:  vxor_v(vec1, vec2, vec3); break;
+        case Op_AddReductionVI:  vadd_w(vec1, vec2, vec3); break;
+        case Op_MulReductionVI:  vmul_w(vec1, vec2, vec3); break;
+        case Op_MaxReductionV:   vmax_w(vec1, vec2, vec3); break;
+        case Op_MinReductionV:   vmin_w(vec1, vec2, vec3); break;
+        case Op_UMaxReductionV: vmax_wu(vec1, vec2, vec3); break;
+        case Op_UMinReductionV: vmin_wu(vec1, vec2, vec3); break;
+        case Op_AndReductionV:   vand_v(vec1, vec2, vec3); break;
+        case Op_OrReductionV:     vor_v(vec1, vec2, vec3); break;
+        case Op_XorReductionV:   vxor_v(vec1, vec2, vec3); break;
         default:
           ShouldNotReachHere();
       }
       break;
     case T_LONG:
       switch (opcode) {
-        case Op_AddReductionVL: vadd_d(vec1, vec2, vec3); break;
-        case Op_MulReductionVL: vmul_d(vec1, vec2, vec3); break;
-        case Op_MaxReductionV:  vmax_d(vec1, vec2, vec3); break;
-        case Op_MinReductionV:  vmin_d(vec1, vec2, vec3); break;
-        case Op_AndReductionV:  vand_v(vec1, vec2, vec3); break;
-        case Op_OrReductionV:    vor_v(vec1, vec2, vec3); break;
-        case Op_XorReductionV:  vxor_v(vec1, vec2, vec3); break;
+        case Op_AddReductionVL:  vadd_d(vec1, vec2, vec3); break;
+        case Op_MulReductionVL:  vmul_d(vec1, vec2, vec3); break;
+        case Op_MaxReductionV:   vmax_d(vec1, vec2, vec3); break;
+        case Op_MinReductionV:   vmin_d(vec1, vec2, vec3); break;
+        case Op_UMaxReductionV: vmax_du(vec1, vec2, vec3); break;
+        case Op_UMinReductionV: vmin_du(vec1, vec2, vec3); break;
+        case Op_AndReductionV:   vand_v(vec1, vec2, vec3); break;
+        case Op_OrReductionV:     vor_v(vec1, vec2, vec3); break;
+        case Op_XorReductionV:   vxor_v(vec1, vec2, vec3); break;
         default:
           ShouldNotReachHere();
       }
@@ -1880,32 +1888,41 @@ void C2_MacroAssembler::reduce(Register dst, Register src, FloatRegister vsrc, F
     }
   }
 
-  switch (type) {
-    case T_BYTE:  vpickve2gr_b(dst, tmp1, 0); break;
-    case T_SHORT: vpickve2gr_h(dst, tmp1, 0); break;
-    case T_INT:   vpickve2gr_w(dst, tmp1, 0); break;
-    case T_LONG:  vpickve2gr_d(dst, tmp1, 0); break;
-    default:
-      ShouldNotReachHere();
+  if (opcode != Op_UMaxReductionV && opcode != Op_UMinReductionV) {
+    switch (type) {
+      case T_BYTE:  vpickve2gr_b(dst, tmp1, 0); break;
+      case T_SHORT: vpickve2gr_h(dst, tmp1, 0); break;
+      case T_INT:   vpickve2gr_w(dst, tmp1, 0); break;
+      case T_LONG:  vpickve2gr_d(dst, tmp1, 0); break;
+      default:
+        ShouldNotReachHere();
+    }
+  } else {
+    switch (type) {
+      case T_BYTE:  vpickve2gr_bu(dst, tmp1, 0); break;
+      case T_SHORT: vpickve2gr_hu(dst, tmp1, 0); break;
+      case T_INT:   vpickve2gr_wu(dst, tmp1, 0); break;
+      case T_LONG:  vpickve2gr_du(dst, tmp1, 0); break;
+      default:
+        ShouldNotReachHere();
+    }
   }
-  if (opcode == Op_MaxReductionV) {
-    slt(AT, dst, src);
-    masknez(dst, dst, AT);
-    maskeqz(AT, src, AT);
-    orr(dst, dst, AT);
-  } else if (opcode == Op_MinReductionV) {
-    slt(AT, src, dst);
+
+  if (opcode == Op_MaxReductionV || opcode == Op_UMaxReductionV ||
+      opcode == Op_MinReductionV || opcode == Op_UMinReductionV) {
+    switch (opcode) {
+      case Op_MaxReductionV:   slt(AT, dst, src); break;
+      case Op_MinReductionV:   slt(AT, src, dst); break;
+      case Op_UMaxReductionV: sltu(AT, dst, src); break;
+      case Op_UMinReductionV: sltu(AT, src, dst); break;
+      default:
+        ShouldNotReachHere();
+    }
     masknez(dst, dst, AT);
     maskeqz(AT, src, AT);
     orr(dst, dst, AT);
   } else {
     reduce_ins_r(dst, dst, src, type, opcode);
-  }
-  switch (type) {
-    case T_BYTE:  ext_w_b(dst, dst); break;
-    case T_SHORT: ext_w_h(dst, dst); break;
-    default:
-      break;
   }
 }
 

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
@@ -247,15 +247,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
                         Register test_value_out,
                         Label& not_equal_continue);
 
-  void record_klass_in_profile(Register receiver, Register mdp,
-                               Register reg2);
-  void record_klass_in_profile_helper(Register receiver, Register mdp,
-                                      Register reg2, int start_row,
-                                      Label& done);
-  void record_item_in_profile_helper(Register item, Register mdp,
-                                     Register reg2, int start_row, Label& done, int total_rows,
-                                     OffsetFunction item_offset_fn, OffsetFunction item_count_offset_fn);
-
   void update_mdp_by_offset(Register mdp_in, int offset_of_offset);
   void update_mdp_by_offset(Register mdp_in, Register reg, int offset_of_disp);
   void update_mdp_by_constant(Register mdp_in, int constant);
@@ -266,11 +257,10 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void profile_call(Register mdp);
   void profile_final_call(Register mdp);
   void profile_virtual_call(Register receiver, Register mdp,
-                            Register scratch2,
                             bool receiver_can_be_null = false);
   void profile_ret(Register return_bci, Register mdp);
   void profile_null_seen(Register mdp);
-  void profile_typecheck(Register mdp, Register klass, Register scratch);
+  void profile_typecheck(Register mdp, Register klass);
   void profile_typecheck_failed(Register mdp);
   void profile_switch_default(Register mdp);
   void profile_switch_case(Register index_in_scratch, Register mdp,

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -463,10 +463,8 @@ void InterpreterMacroAssembler::gen_subtype_check( Register Rsup_klass, Register
 
   assert( Rsub_klass != Rsup_klass, "Rsup_klass holds superklass" );
   assert( Rsub_klass != T1, "T1 holds 2ndary super array length" );
-  assert( Rsub_klass != T0, "T0 holds 2ndary super array scan ptr" );
   // Profile the not-null value's klass.
-  // Here T4 and T1 are used as temporary registers.
-  profile_typecheck(T4, Rsub_klass, T1); // blows T4, reloads T1
+  profile_typecheck(T1, Rsub_klass); // blows T1
 
   // Do the check.
   check_klass_subtype(Rsub_klass, Rsup_klass, T1, ok_is_subtype); // blows T1
@@ -1235,7 +1233,6 @@ void InterpreterMacroAssembler::profile_final_call(Register mdp) {
 
 void InterpreterMacroAssembler::profile_virtual_call(Register receiver,
                                                      Register mdp,
-                                                     Register reg2,
                                                      bool receiver_can_be_null) {
   if (ProfileInterpreter) {
     Label profile_continue;
@@ -1254,7 +1251,7 @@ void InterpreterMacroAssembler::profile_virtual_call(Register receiver,
     }
 
     // Record the receiver type.
-    record_klass_in_profile(receiver, mdp, reg2);
+    profile_receiver_type(receiver, mdp, 0);
     bind(skip_receiver_profile);
 
     // The method data pointer needs to be updated to reflect the new target.
@@ -1263,131 +1260,6 @@ void InterpreterMacroAssembler::profile_virtual_call(Register receiver,
                                     virtual_call_data_size()));
     bind(profile_continue);
   }
-}
-
-// This routine creates a state machine for updating the multi-row
-// type profile at a virtual call site (or other type-sensitive bytecode).
-// The machine visits each row (of receiver/count) until the receiver type
-// is found, or until it runs out of rows.  At the same time, it remembers
-// the location of the first empty row.  (An empty row records null for its
-// receiver, and can be allocated for a newly-observed receiver type.)
-// Because there are two degrees of freedom in the state, a simple linear
-// search will not work; it must be a decision tree.  Hence this helper
-// function is recursive, to generate the required tree structured code.
-// It's the interpreter, so we are trading off code space for speed.
-// See below for example code.
-void InterpreterMacroAssembler::record_klass_in_profile_helper(
-                                        Register receiver, Register mdp,
-                                        Register reg2, int start_row,
-                                        Label& done) {
-  if (TypeProfileWidth == 0) {
-    increment_mdp_data_at(mdp, in_bytes(CounterData::count_offset()));
-  } else {
-    record_item_in_profile_helper(receiver, mdp, reg2, 0, done, TypeProfileWidth,
-        &VirtualCallData::receiver_offset, &VirtualCallData::receiver_count_offset);
-  }
-}
-
-void InterpreterMacroAssembler::record_item_in_profile_helper(Register item, Register mdp,
-                                        Register reg2, int start_row, Label& done, int total_rows,
-                                        OffsetFunction item_offset_fn, OffsetFunction item_count_offset_fn) {
-  int last_row = total_rows - 1;
-  assert(start_row <= last_row, "must be work left to do");
-  // Test this row for both the item and for null.
-  // Take any of three different outcomes:
-  //   1. found item => increment count and goto done
-  //   2. found null => keep looking for case 1, maybe allocate this cell
-  //   3. found something else => keep looking for cases 1 and 2
-  // Case 3 is handled by a recursive call.
-  for (int row = start_row; row <= last_row; row++) {
-    Label next_test;
-    bool test_for_null_also = (row == start_row);
-
-    // See if the receiver is item[n].
-    int item_offset = in_bytes(item_offset_fn(row));
-    test_mdp_data_at(mdp, item_offset, item,
-                     (test_for_null_also ? reg2 : noreg),
-                     next_test);
-    // (Reg2 now contains the item from the CallData.)
-
-    // The receiver is item[n].  Increment count[n].
-    int count_offset = in_bytes(item_count_offset_fn(row));
-    increment_mdp_data_at(mdp, count_offset);
-    b(done);
-    bind(next_test);
-
-    if (test_for_null_also) {
-      Label found_null;
-      // Failed the equality check on item[n]...  Test for null.
-      if (start_row == last_row) {
-        // The only thing left to do is handle the null case.
-        beqz(reg2, found_null);
-        // Item did not match any saved item and there is no empty row for it.
-        // Increment total counter to indicate polymorphic case.
-        increment_mdp_data_at(mdp, in_bytes(CounterData::count_offset()));
-        b(done);
-        bind(found_null);
-        break;
-      }
-      // Since null is rare, make it be the branch-taken case.
-      beqz(reg2, found_null);
-
-      // Put all the "Case 3" tests here.
-      record_item_in_profile_helper(item, mdp, reg2, start_row + 1, done, total_rows,
-        item_offset_fn, item_count_offset_fn);
-
-      // Found a null.  Keep searching for a matching item,
-      // but remember that this is an empty (unused) slot.
-      bind(found_null);
-    }
-  }
-
-  // In the fall-through case, we found no matching item, but we
-  // observed the item[start_row] is null.
-
-  // Fill in the item field and increment the count.
-  int item_offset = in_bytes(item_offset_fn(start_row));
-  set_mdp_data_at(mdp, item_offset, item);
-  int count_offset = in_bytes(item_count_offset_fn(start_row));
-  li(reg2, DataLayout::counter_increment);
-  set_mdp_data_at(mdp, count_offset, reg2);
-  if (start_row > 0) {
-    b(done);
-  }
-}
-
-// Example state machine code for three profile rows:
-//   // main copy of decision tree, rooted at row[1]
-//   if (row[0].rec == rec) { row[0].incr(); goto done; }
-//   if (row[0].rec != nullptr) {
-//     // inner copy of decision tree, rooted at row[1]
-//     if (row[1].rec == rec) { row[1].incr(); goto done; }
-//     if (row[1].rec != nullptr) {
-//       // degenerate decision tree, rooted at row[2]
-//       if (row[2].rec == rec) { row[2].incr(); goto done; }
-//       if (row[2].rec != nullptr) { goto done; } // overflow
-//       row[2].init(rec); goto done;
-//     } else {
-//       // remember row[1] is empty
-//       if (row[2].rec == rec) { row[2].incr(); goto done; }
-//       row[1].init(rec); goto done;
-//     }
-//   } else {
-//     // remember row[0] is empty
-//     if (row[1].rec == rec) { row[1].incr(); goto done; }
-//     if (row[2].rec == rec) { row[2].incr(); goto done; }
-//     row[0].init(rec); goto done;
-//   }
-//   done:
-
-void InterpreterMacroAssembler::record_klass_in_profile(Register receiver,
-                                                        Register mdp, Register reg2) {
-  assert(ProfileInterpreter, "must be profiling");
-  Label done;
-
-  record_klass_in_profile_helper(receiver, mdp, reg2, 0, done);
-
-  bind (done);
 }
 
 void InterpreterMacroAssembler::profile_ret(Register return_bci,
@@ -1448,7 +1320,7 @@ void InterpreterMacroAssembler::profile_null_seen(Register mdp) {
   }
 }
 
-void InterpreterMacroAssembler::profile_typecheck(Register mdp, Register klass, Register reg2) {
+void InterpreterMacroAssembler::profile_typecheck(Register mdp, Register klass) {
   if (ProfileInterpreter) {
     Label profile_continue;
 
@@ -1461,7 +1333,7 @@ void InterpreterMacroAssembler::profile_typecheck(Register mdp, Register klass, 
       mdp_delta = in_bytes(VirtualCallData::virtual_call_data_size());
 
       // Record the object type.
-      record_klass_in_profile(klass, mdp, reg2);
+      profile_receiver_type(klass, mdp, 0);
     }
     update_mdp_by_constant(mdp, mdp_delta);
 

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -14090,6 +14090,8 @@ instruct reduceV(mRegI dst, mRegI src, vReg vsrc, vReg tmp1, vReg tmp2) %{
   match(Set dst (MulReductionVI src vsrc));
   match(Set dst (MaxReductionV  src vsrc));
   match(Set dst (MinReductionV  src vsrc));
+  match(Set dst (UMaxReductionV src vsrc));
+  match(Set dst (UMinReductionV src vsrc));
   match(Set dst (AndReductionV  src vsrc));
   match(Set dst (OrReductionV   src vsrc));
   match(Set dst (XorReductionV  src vsrc));
@@ -14107,6 +14109,8 @@ instruct reduceVL(mRegL dst, mRegL src, vReg vsrc, vReg tmp1, vReg tmp2) %{
   match(Set dst (MulReductionVL src vsrc));
   match(Set dst (MaxReductionV  src vsrc));
   match(Set dst (MinReductionV  src vsrc));
+  match(Set dst (UMaxReductionV src vsrc));
+  match(Set dst (UMinReductionV src vsrc));
   match(Set dst (AndReductionV  src vsrc));
   match(Set dst (OrReductionV   src vsrc));
   match(Set dst (XorReductionV  src vsrc));

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -434,6 +434,162 @@ void MacroAssembler::reserved_stack_check() {
   bind(no_reserved_zone_enabling);
 }
 
+// Handle the receiver type profile update given the "recv" klass.
+//
+// Normally updates the ReceiverData (RD) that starts at "mdp" + "mdp_offset".
+// If there are no matching or claimable receiver entries in RD, updates
+// the polymorphic counter.
+//
+// This code expected to run by either the interpreter or JIT-ed code, without
+// extra synchronization. For safety, receiver cells are claimed atomically, which
+// avoids grossly misrepresenting the profiles under concurrent updates. For speed,
+// counter updates are not atomic.
+//
+void MacroAssembler::profile_receiver_type(Register recv, Register mdp, int mdp_offset) {
+  assert_different_registers(recv, mdp, SCR1, SCR2);
+
+  int base_receiver_offset   = in_bytes(ReceiverTypeData::receiver_offset(0));
+  int end_receiver_offset    = in_bytes(ReceiverTypeData::receiver_offset(ReceiverTypeData::row_limit()));
+  int poly_count_offset      = in_bytes(CounterData::count_offset());
+  int receiver_step          = in_bytes(ReceiverTypeData::receiver_offset(1)) - base_receiver_offset;
+  int receiver_to_count_step = in_bytes(ReceiverTypeData::receiver_count_offset(0)) - base_receiver_offset;
+
+  // Adjust for MDP offsets. Slots are pointer-sized, so is the global offset.
+  base_receiver_offset += mdp_offset;
+  end_receiver_offset  += mdp_offset;
+  poly_count_offset    += mdp_offset;
+
+#ifdef ASSERT
+  // We are about to walk the MDO slots without asking for offsets.
+  // Check that our math hits all the right spots.
+  for (uint c = 0; c < ReceiverTypeData::row_limit(); c++) {
+    int real_recv_offset  = mdp_offset + in_bytes(ReceiverTypeData::receiver_offset(c));
+    int real_count_offset = mdp_offset + in_bytes(ReceiverTypeData::receiver_count_offset(c));
+    int offset = base_receiver_offset + receiver_step*c;
+    int count_offset = offset + receiver_to_count_step;
+    assert(offset == real_recv_offset, "receiver slot math");
+    assert(count_offset  == real_count_offset, "receiver count math");
+  }
+  int real_poly_count_offset = mdp_offset + in_bytes(CounterData::count_offset());
+  assert(poly_count_offset == real_poly_count_offset, "poly counter math");
+#endif
+
+  // Corner case: no profile table. Increment poly counter and exit.
+  if (ReceiverTypeData::row_limit() == 0) {
+    increment(Address(mdp, poly_count_offset), DataLayout::counter_increment);
+    return;
+  }
+
+  Register offset = SCR2;
+
+  Label L_loop_search_receiver, L_loop_search_empty;
+  Label L_restart, L_found_recv, L_found_empty, L_polymorphic, L_count_update;
+
+  // The code here recognizes three major cases:
+  //   A. Fastest: receiver found in the table
+  //   B. Fast: no receiver in the table, and the table is full
+  //   C. Slow: no receiver in the table, free slots in the table
+  //
+  // The case A performance is most important, as perfectly-behaved code would end up
+  // there, especially with larger TypeProfileWidth. The case B performance is
+  // important as well, this is where bulk of code would land for normally megamorphic
+  // cases. The case C performance is not essential, its job is to deal with installation
+  // races, we optimize for code density instead. Case C needs to make sure that receiver
+  // rows are only claimed once. This makes sure we never overwrite a row for another
+  // receiver and never duplicate the receivers in the list, making profile type-accurate.
+  //
+  // It is very tempting to handle these cases in a single loop, and claim the first slot
+  // without checking the rest of the table. But, profiling code should tolerate free slots
+  // in the table, as class unloading can clear them. After such cleanup, the receiver
+  // we need might be _after_ the free slot. Therefore, we need to let at least full scan
+  // to complete, before trying to install new slots. Splitting the code in several tight
+  // loops also helpfully optimizes for cases A and B.
+  //
+  // This code is effectively:
+  //
+  // restart:
+  //   // Fastest: receiver is already installed
+  //   for (i = 0; i < receiver_count(); i++) {
+  //     if (receiver(i) == recv) goto found_recv(i);
+  //   }
+  //
+  //   // Fast: no receiver, but profile is full
+  //   for (i = 0; i < receiver_count(); i++) {
+  //     if (receiver(i) == null) goto found_null(i);
+  //   }
+  //   goto polymorphic
+  //
+  //   // Slow: try to install receiver
+  // found_null(i):
+  //   CAS(&receiver(i), null, recv);
+  //   goto restart
+  //
+  // polymorphic:
+  //   count++;
+  //   return
+  //
+  // found_recv(i):
+  //   *receiver_count(i)++
+  //
+
+  bind(L_restart);
+
+  // Fastest: receiver is already installed
+  li(offset, base_receiver_offset);
+  bind(L_loop_search_receiver);
+    ldx_d(SCR1, mdp, offset);
+    beq(recv, SCR1, L_found_recv);
+  addi_d(offset, offset, receiver_step);
+  li(SCR1, end_receiver_offset);
+  sub_d(SCR1, offset, SCR1);
+  bnez(SCR1, L_loop_search_receiver);
+
+  // Fast: no receiver, but profile is full
+  li(offset, base_receiver_offset);
+  bind(L_loop_search_empty);
+    ldx_d(SCR1, mdp, offset);
+    beqz(SCR1, L_found_empty);
+  addi_d(offset, offset, receiver_step);
+  li(SCR1, end_receiver_offset);
+  sub_d(SCR1, offset, SCR1);
+  bnez(SCR1, L_loop_search_empty);
+  b(L_polymorphic);
+
+  // Slow: try to install receiver
+  bind(L_found_empty);
+
+  // Atomically swing receiver slot: null -> recv.
+  //
+  // The update uses CAS, which clobbers SCR1. Therefore, SCR2
+  // is used to hold the destination address. This is safe because the
+  // offset is no longer needed after the address is computed.
+  add_d(SCR2, mdp, offset);
+  Address addr_tmp(SCR2);
+  cmpxchg(/*addr*/ addr_tmp, /*oldval*/ R0, /*newval*/ recv,
+          /*resflag*/ SCR1, /*retold*/ false, /*acquire*/ false,
+          /*weak*/ true, /*exchange*/ false);
+
+  // CAS success means the slot now has the receiver we want. CAS failure means
+  // something had claimed the slot concurrently: it can be the same receiver we want,
+  // or something else. Since this is a slow path, we can optimize for code density,
+  // and just restart the search from the beginning.
+  b(L_restart);
+
+  // Counter updates:
+  // Increment polymorphic counter instead of receiver slot.
+  bind(L_polymorphic);
+  li(offset, poly_count_offset);
+  b(L_count_update);
+
+  // Found a receiver, convert its slot offset to corresponding count offset.
+  bind(L_found_recv);
+  addi_d(offset, offset, receiver_to_count_step);
+
+  bind(L_count_update);
+  add_d(SCR2, mdp, offset);
+  increment(Address(SCR2), DataLayout::counter_increment);
+}
+
 // the stack pointer adjustment is needed. see InterpreterMacroAssembler::super_call_VM_leaf
 // this method will handle the stack problem, you need not to preserve the stack space for the argument now
 void MacroAssembler::call_VM_leaf_base(address entry_point, int number_of_arguments) {

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -677,6 +677,7 @@ class MacroAssembler: public Assembler {
   // method handles (JSR 292)
   Address argument_address(RegisterOrConstant arg_slot, int extra_slot_offset = 0);
 
+  void profile_receiver_type(Register recv, Register mdp, int mdp_offset);
 
   // LA added:
   void jr  (Register reg)        { jirl(R0, reg, 0); }

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -3320,7 +3320,7 @@ void TemplateTable::invokevirtual_helper(Register index,
   __ load_klass(T2, recv);
 
   // profile this call
-  __ profile_virtual_call(T2, T0, T1);
+  __ profile_virtual_call(T2, T0);
 
   // get target Method & entry point
   __ lookup_virtual_method(T2, index, method);
@@ -3475,7 +3475,7 @@ void TemplateTable::invokeinterface(int byte_no) {
 
   // profile this call
   __ restore_bcp();
-  __ profile_virtual_call(T1, T0, FSR);
+  __ profile_virtual_call(T1, T0);
 
   // Get declaring interface class from method, and itable index
   __ load_method_holder(T2, Rmethod);

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -277,24 +277,49 @@ void VM_Version::get_processor_features() {
   assert(!is_la32(), "Should Not Reach Here, what is the cpu type?");
   assert( is_la64(), "Should be LoongArch64");
 
-  if (FLAG_IS_DEFAULT(AllocatePrefetchStyle)) {
-    FLAG_SET_DEFAULT(AllocatePrefetchStyle, 1);
-  }
+  int dcache_line = 1 << _cpuid_info.cpucfg_info_id12.bits.LINESIZELOG2;
 
-  if (FLAG_IS_DEFAULT(AllocatePrefetchLines)) {
-    FLAG_SET_DEFAULT(AllocatePrefetchLines, 3);
+  // Limit AllocatePrefetchDistance so that it does not exceed the
+  // static constraint of 512 defined in runtime/globals.hpp.
+  if (FLAG_IS_DEFAULT(AllocatePrefetchDistance)) {
+    // Based on RawAllocationRate results.
+    FLAG_SET_DEFAULT(AllocatePrefetchDistance, MIN2(512, 3*dcache_line));
   }
 
   if (FLAG_IS_DEFAULT(AllocatePrefetchStepSize)) {
-    FLAG_SET_DEFAULT(AllocatePrefetchStepSize, 64);
+    FLAG_SET_DEFAULT(AllocatePrefetchStepSize, dcache_line);
   }
 
-  if (FLAG_IS_DEFAULT(AllocatePrefetchDistance)) {
-    FLAG_SET_DEFAULT(AllocatePrefetchDistance, 192);
+  // Prefetch tuning based on SPECjbb2015 results.
+  //
+  // Mechanism:
+  // - SCAN: Hides memory read latency during object iteration.
+  // - COPY: Hides RFO write latency during object evacuation.
+  // Reducing these latencies directly shortens STW pauses, significantly
+  // boosting Critical-jOPS.
+  //
+  // 1. Single-NUMA Architectures:
+  //    - 192 bytes (3 cache lines) is the performance peak, delivering
+  //      an approximate 40% Critical-jOPS boost over the baseline,
+  //      most notably in adaptive young generation heap scenarios.
+  //    - 256 bytes is a close second.
+  //    - 576 bytes causes a ~6.7% regression compared to 192 due to
+  //      cache pollution, though it still outperforms the baseline.
+  //
+  // 2. Multi-NUMA Architectures:
+  //    Larger intervals (e.g., 576 bytes) help mitigate the higher
+  //    latency associated with cross-node memory access.
+  //
+  // Trade-off:
+  // We prioritize single-NUMA peak performance. The 192-byte setting
+  // offers the maximum uplift for mainstream single-node configurations
+  // while remaining performant on multi-NUMA systems.
+  if (FLAG_IS_DEFAULT(PrefetchCopyIntervalInBytes)) {
+    FLAG_SET_DEFAULT(PrefetchCopyIntervalInBytes, 3*dcache_line);
   }
 
-  if (FLAG_IS_DEFAULT(AllocateInstancePrefetchLines)) {
-    FLAG_SET_DEFAULT(AllocateInstancePrefetchLines, 1);
+  if (FLAG_IS_DEFAULT(PrefetchScanIntervalInBytes)) {
+    FLAG_SET_DEFAULT(PrefetchScanIntervalInBytes, 3*dcache_line);
   }
 
   // Basic instructions are used to implement SHA Intrinsics on LA, so sha

--- a/src/hotspot/os_cpu/linux_loongarch/prefetch_linux_loongarch.inline.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/prefetch_linux_loongarch.inline.hpp
@@ -28,30 +28,24 @@
 
 // Included in runtime/prefetch.inline.hpp
 
-inline void Prefetch::read (const void *loc, intx interval) {
-// According to previous and present SPECjbb2015 score,
-// comment prefetch is better than if (interval >= 0) prefetch branch.
-// So choose comment prefetch as the base line.
-#if 0
-  __asm__ __volatile__ (
-                        "       preld  0, %[__loc] \n"
-                        :
-                        : [__loc] "m"( *((address)loc + interval) )
-                        : "memory"
-                        );
-#endif
+inline void Prefetch::read(const void *loc, intx interval) {
+  if (interval >= 0) {
+    __asm__ __volatile__ (
+      "preld 0, %0"
+      :
+      : "m"(((const_address)loc)[interval])
+    );
+  }
 }
 
 inline void Prefetch::write(void *loc, intx interval) {
-// Ditto
-#if 0
-  __asm__ __volatile__ (
-                        "       preld  8, %[__loc] \n"
-                        :
-                        : [__loc] "m"( *((address)loc + interval) )
-                        : "memory"
-                        );
-#endif
+  if (interval >= 0) {
+    __asm__ __volatile__ (
+      "preld 8, %0"
+      :
+      : "m"(((const_address)loc)[interval])
+    );
+  }
 }
 
 #endif // OS_CPU_LINUX_LOONGARCH_PREFETCH_LINUX_LOONGARCH_INLINE_HPP

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorUMinMaxReductionTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorUMinMaxReductionTest.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2026. These
+ * modifications are Copyright (c) 2026, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 package compiler.vectorapi;
 
 import compiler.lib.generators.*;
@@ -140,7 +146,7 @@ public class VectorUMinMaxReductionTest {
 
     @Test
     @IR(counts = {IRNode.UMIN_REDUCTION_V, "= 1"},
-        applyIfCPUFeature = {"asimd", "true"})
+        applyIfCPUFeatureOr = {"asimd", "true","lsx", "true"})
     public static void testByteUMin() {
         byte got = ByteVector.fromArray(B_SPECIES, ba, 0).reduceLanes(VectorOperators.UMIN);
         verifyByte(B_SPECIES, got, BYTE_UMIN_IDENTITY, VectorMath::minUnsigned, false);
@@ -148,7 +154,7 @@ public class VectorUMinMaxReductionTest {
 
     @Test
     @IR(counts = {IRNode.UMAX_REDUCTION_V, "= 1"},
-        applyIfCPUFeature = {"asimd", "true"})
+        applyIfCPUFeatureOr = {"asimd", "true","lsx", "true"})
     public static void testByteUMax() {
         byte got = ByteVector.fromArray(B_SPECIES, ba, 0).reduceLanes(VectorOperators.UMAX);
         verifyByte(B_SPECIES, got, BYTE_UMAX_IDENTITY, VectorMath::maxUnsigned, false);
@@ -178,7 +184,7 @@ public class VectorUMinMaxReductionTest {
 
     @Test
     @IR(counts = {IRNode.UMIN_REDUCTION_V, "= 1"},
-        applyIfCPUFeature = {"asimd", "true"})
+        applyIfCPUFeatureOr = {"asimd", "true","lsx", "true"})
     public static void testShortUMin() {
         short got = ShortVector.fromArray(S_SPECIES, sa, 0).reduceLanes(VectorOperators.UMIN);
         verifyShort(S_SPECIES, got, SHORT_UMIN_IDENTITY, VectorMath::minUnsigned, false);
@@ -186,7 +192,7 @@ public class VectorUMinMaxReductionTest {
 
     @Test
     @IR(counts = {IRNode.UMAX_REDUCTION_V, "= 1"},
-        applyIfCPUFeature = {"asimd", "true"})
+        applyIfCPUFeatureOr = {"asimd", "true","lsx", "true"})
     public static void testShortUMax() {
         short got = ShortVector.fromArray(S_SPECIES, sa, 0).reduceLanes(VectorOperators.UMAX);
         verifyShort(S_SPECIES, got, SHORT_UMAX_IDENTITY, VectorMath::maxUnsigned, false);
@@ -216,7 +222,7 @@ public class VectorUMinMaxReductionTest {
 
     @Test
     @IR(counts = {IRNode.UMIN_REDUCTION_V, "= 1"},
-        applyIfCPUFeature = {"asimd", "true"})
+        applyIfCPUFeatureOr = {"asimd", "true","lsx", "true"})
     public static void testIntUMin() {
         int got = IntVector.fromArray(I_SPECIES, ia, 0).reduceLanes(VectorOperators.UMIN);
         verifyInt(I_SPECIES, got, INT_UMIN_IDENTITY, VectorMath::minUnsigned, false);
@@ -224,7 +230,7 @@ public class VectorUMinMaxReductionTest {
 
     @Test
     @IR(counts = {IRNode.UMAX_REDUCTION_V, "= 1"},
-        applyIfCPUFeature = {"asimd", "true"})
+        applyIfCPUFeatureOr = {"asimd", "true","lsx", "true"})
     public static void testIntUMax() {
         int got = IntVector.fromArray(I_SPECIES, ia, 0).reduceLanes(VectorOperators.UMAX);
         verifyInt(I_SPECIES, got, INT_UMAX_IDENTITY, VectorMath::maxUnsigned, false);
@@ -254,7 +260,7 @@ public class VectorUMinMaxReductionTest {
 
     @Test
     @IR(counts = {IRNode.UMIN_REDUCTION_V, "= 1"},
-        applyIfCPUFeature = {"asimd", "true"})
+        applyIfCPUFeatureOr = {"asimd", "true","lsx", "true"})
     public static void testLongUMin() {
         long got = LongVector.fromArray(L_SPECIES, la, 0).reduceLanes(VectorOperators.UMIN);
         verifyLong(L_SPECIES, got, LONG_UMIN_IDENTITY, VectorMath::minUnsigned, false);
@@ -262,7 +268,7 @@ public class VectorUMinMaxReductionTest {
 
     @Test
     @IR(counts = {IRNode.UMAX_REDUCTION_V, "= 1"},
-        applyIfCPUFeature = {"asimd", "true"})
+        applyIfCPUFeatureOr = {"asimd", "true","lsx", "true"})
     public static void testLongUMax() {
         long got = LongVector.fromArray(L_SPECIES, la, 0).reduceLanes(VectorOperators.UMAX);
         verifyLong(L_SPECIES, got, LONG_UMAX_IDENTITY, VectorMath::maxUnsigned, false);


### PR DESCRIPTION
37245: Double Critical-jOPS via Architectural Prefetch Revitalization
37356: Add intrinsic support for unsigned min/max reduction operations
37302: LA: Improve receiver type profiling reliability