### PR TITLE
Update (2026.06.23, 2nd)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
@@ -42,7 +42,6 @@ define_pd_global(bool, TieredCompilation,            false);
 define_pd_global(intx, CompileThreshold,             1500 );
 
 define_pd_global(intx, OnStackReplacePercentage,     933  );
-define_pd_global(intx, NewSizeThreadIncrease,        4*K  );
 define_pd_global(size_t, InitialCodeCacheSize,       160*K);
 define_pd_global(size_t, ReservedCodeCacheSize,      32*M );
 define_pd_global(size_t, NonProfiledCodeHeapSize,    13*M );

--- a/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
@@ -49,7 +49,6 @@ define_pd_global(intx, ConditionalMoveLimit,         3);
 define_pd_global(intx, FreqInlineSize,               325);
 define_pd_global(intx, MinJumpTableSize,             10);
 define_pd_global(intx, InteriorEntryAlignment,       16);
-define_pd_global(intx, NewSizeThreadIncrease, ScaleForWordSize(4*K));
 define_pd_global(intx, LoopUnrollLimit,              60);
 define_pd_global(intx, LoopPercentProfileLimit,      10);
 // InitialCodeCacheSize derived from specjbb2000 run.

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1191,10 +1191,9 @@ const RegMask& Matcher::divL_proj_mask() {
 const RegMask& Matcher::modL_proj_mask() {
   return T2_LONG_REG_mask();
 }
-// Return whether or not this register is ever used as an argument.  This
-// function is used on startup to build the trampoline stubs in generateOptoStub.
-// Registers not mentioned will be killed by the VM call in the trampoline, and
-// arguments in those registers not be available to the callee.
+
+#ifdef ASSERT
+// Return whether or not this register is ever used as an argument.
 bool Matcher::can_be_java_arg( int reg ) {
   // Refer to: [sharedRuntime_loongarch_64.cpp] SharedRuntime::java_calling_convention()
   if (    reg == T0_num || reg == T0_H_num
@@ -1220,10 +1219,7 @@ bool Matcher::can_be_java_arg( int reg ) {
 
   return false;
 }
-
-bool Matcher::is_spillable_arg( int reg ) {
-  return can_be_java_arg(reg);
-}
+#endif
 
 uint Matcher::int_pressure_limit()
 {
@@ -2531,12 +2527,6 @@ frame %{
   sync_stack_slots(2);
 
   frame_pointer(SP);
-
-  // Interpreter stores its frame pointer in a register which is
-  // stored to the stack by I2CAdaptors.
-  // I2CAdaptors convert from interpreted java to compiled java.
-
-  interpreter_frame_pointer(FP);
 
   // generate Matcher::stack_alignment
   stack_alignment(StackAlignmentInBytes);  //wordSize = sizeof(char*);


### PR DESCRIPTION
37390: LA port of 8378744: Obsolete NewSizeThreadIncrease flag
37389: LA port of 8377148: Remove obsolete functions Matcher::is_spillable_arg() and Matcher::interpreter_frame_pointer_reg()