### PR TITLE
Update (2026.06.23, 3rd)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c1_globals_loongarch.hpp
@@ -51,7 +51,6 @@ define_pd_global(bool, ProfileInterpreter,           false);
 define_pd_global(size_t, CodeCacheExpansionSize,     32*K );
 define_pd_global(size_t, CodeCacheMinBlockLength,    1);
 define_pd_global(size_t, CodeCacheMinimumUseSpace,   400*K);
-define_pd_global(bool, NeverActAsServerClassMachine, true );
 define_pd_global(bool, CICompileOSR,                 true );
 #endif // !COMPILER2
 define_pd_global(bool, UseTypeProfile,               false);

--- a/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/c2_globals_loongarch.hpp
@@ -78,7 +78,4 @@ define_pd_global(size_t, CodeCacheMinimumUseSpace,   400*K);
 
 define_pd_global(bool,  TrapBasedRangeChecks,        false);
 
-// Ergonomics related flags
-define_pd_global(bool, NeverActAsServerClassMachine, false);
-
 #endif // CPU_LOONGARCH_C2_GLOBALS_LOONGARCH_HPP

--- a/src/hotspot/cpu/loongarch/downcallLinker_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/downcallLinker_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,10 +142,10 @@ void DowncallLinker::StubGenerator::generate() {
 
   bool should_save_return_value = !_needs_return_buffer;
   RegSpiller out_reg_spiller(_output_registers);
-  int spill_offset = -1;
+  int out_spill_offset = -1;
 
   if (should_save_return_value) {
-    spill_offset = 0;
+    out_spill_offset = 0;
     // spill area can be shared with shadow space and out args,
     // since they are only used before the call,
     // and spill area is only used after.
@@ -170,6 +170,9 @@ void DowncallLinker::StubGenerator::generate() {
   // FP-> |                     |
   //      |---------------------| = frame_bottom_offset = frame_size
   //      | (optional)          |
+  //      | in_reg_spiller area |
+  //      |---------------------|
+  //      | (optional)          |
   //      | capture state buf   |
   //      |---------------------| = StubLocations::CAPTURED_STATE_BUFFER
   //      | (optional)          |
@@ -182,6 +185,18 @@ void DowncallLinker::StubGenerator::generate() {
   VMStorage shuffle_reg = as_VMStorage(S0);
   GrowableArray<VMStorage> out_regs = ForeignGlobals::replace_place_holders(_input_registers, locs);
   ArgumentShuffle arg_shuffle(filtered_java_regs, out_regs, shuffle_reg);
+
+  // Need to spill for state capturing runtime call.
+  // The area spilled into is distinct from the capture state buffer.
+  RegSpiller in_reg_spiller(out_regs);
+  int in_spill_offset = -1;
+  if (_captured_state_mask != 0) {
+    // The spill area cannot be shared with the out_spill since
+    // spilling needs to happen before the call. Allocate a new
+    // region in the stack for this spill space.
+    in_spill_offset = allocated_frame_size;
+    allocated_frame_size += in_reg_spiller.spill_size_bytes();
+  }
 
 #ifndef PRODUCT
   LogTarget(Trace, foreign, downcall) lt;
@@ -231,6 +246,20 @@ void DowncallLinker::StubGenerator::generate() {
   arg_shuffle.generate(_masm, shuffle_reg, 0, _abi._shadow_space_bytes);
   __ block_comment("} argument shuffle");
 
+  if (_captured_state_mask != 0) {
+    assert(in_spill_offset != -1, "must be");
+    __ block_comment("{ load initial thread local");
+    in_reg_spiller.generate_spill(_masm, in_spill_offset);
+
+    // Copy the contents of the capture state buffer into thread local
+    __ ld_d(c_rarg0, Address(SP, locs.data_offset(StubLocations::CAPTURED_STATE_BUFFER)));
+    __ li(c_rarg1, _captured_state_mask);
+    __ call(CAST_FROM_FN_PTR(address, DowncallLinker::capture_state_pre), relocInfo::runtime_call_type);
+
+    in_reg_spiller.generate_fill(_masm, in_spill_offset);
+    __ block_comment("} load initial thread local");
+  }
+
   __ jalr(as_Register(locs.get(StubLocations::TARGET_ADDRESS)));
   // this call is assumed not to have killed rthread
 
@@ -257,15 +286,15 @@ void DowncallLinker::StubGenerator::generate() {
     __ block_comment("{ save thread local");
 
     if (should_save_return_value) {
-      out_reg_spiller.generate_spill(_masm, spill_offset);
+      out_reg_spiller.generate_spill(_masm, out_spill_offset);
     }
 
     __ ld_d(c_rarg0, Address(SP, locs.data_offset(StubLocations::CAPTURED_STATE_BUFFER)));
     __ li(c_rarg1, _captured_state_mask);
-    __ call(CAST_FROM_FN_PTR(address, DowncallLinker::capture_state), relocInfo::runtime_call_type);
+    __ call(CAST_FROM_FN_PTR(address, DowncallLinker::capture_state_post), relocInfo::runtime_call_type);
 
     if (should_save_return_value) {
-      out_reg_spiller.generate_fill(_masm, spill_offset);
+      out_reg_spiller.generate_fill(_masm, out_spill_offset);
     }
 
     __ block_comment("} save thread local");
@@ -329,7 +358,7 @@ void DowncallLinker::StubGenerator::generate() {
 
     if (should_save_return_value) {
       // Need to save the native result registers around any runtime calls.
-      out_reg_spiller.generate_spill(_masm, spill_offset);
+      out_reg_spiller.generate_spill(_masm, out_spill_offset);
     }
 
     __ move(c_rarg0, TREG);
@@ -337,7 +366,7 @@ void DowncallLinker::StubGenerator::generate() {
     __ call(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans), relocInfo::runtime_call_type);
 
     if (should_save_return_value) {
-      out_reg_spiller.generate_fill(_masm, spill_offset);
+      out_reg_spiller.generate_fill(_masm, out_spill_offset);
     }
 
     __ b(L_after_safepoint_poll);
@@ -349,13 +378,13 @@ void DowncallLinker::StubGenerator::generate() {
     __ bind(L_reguard);
 
     if (should_save_return_value) {
-      out_reg_spiller.generate_spill(_masm, spill_offset);
+      out_reg_spiller.generate_spill(_masm, out_spill_offset);
     }
 
     __ call(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages),relocInfo::runtime_call_type);
 
     if (should_save_return_value) {
-      out_reg_spiller.generate_fill(_masm, spill_offset);
+      out_reg_spiller.generate_fill(_masm, out_spill_offset);
     }
 
     __ b(L_after_reguard);

--- a/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,8 +233,8 @@ inline bool frame::equal(frame other) const {
 
 // Return unique id for this frame. The id must have a value where we can distinguish
 // identity and younger/older relationship. null represents an invalid (incomparable)
-// frame.
-inline intptr_t* frame::id(void) const { return unextended_sp(); }
+// frame. Should not be called for heap frames.
+inline intptr_t* frame::id(void) const { return real_fp(); }
 
 // Return true if the frame is older (less recent activation) than the frame represented by id
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "nullptr frame id");
@@ -394,6 +394,9 @@ frame frame::sender(RegisterMap* map) const {
   if (map->process_frames() && !map->in_cont()) {
     StackWatermarkSet::on_iteration(map->thread(), result);
   }
+
+  // Calling frame::id() is currently not supported for heap frames.
+  assert(result._on_heap || this->_on_heap || result.is_older(this->id()), "Must be");
 
   return result;
 }

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -5906,6 +5906,20 @@ instruct membar_release_lock()
   ins_pipe( empty );
 %}
 
+instruct membar_storeload() %{
+  match(MemBarStoreLoad);
+  ins_cost(400);
+
+  format %{ "MEMBAR-storeload" %}
+
+  ins_encode %{
+    __ block_comment("membar_storeload");
+    __ membar(__ StoreLoad);
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
 instruct unnecessary_membar_volatile() %{
   predicate(unnecessary_volatile(n));
   match(MemBarVolatile);
@@ -5965,6 +5979,18 @@ instruct unnecessary_same_addr_load_fence() %{
     __ block_comment("MEMBAR @ same_addr_load_fence (elided)");
   %}
   ins_pipe( empty );
+%}
+
+instruct membar_full() %{
+  match(MemBarFull);
+  ins_cost(400);
+
+  format %{ "MEMBAR-full" %}
+  ins_encode %{
+    __ block_comment("membar_full");
+    __ membar(__ AnyAny);
+  %}
+  ins_pipe(pipe_serial);
 %}
 
 //----------Move Instructions--------------------------------------------------

--- a/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 #ifndef OS_CPU_LINUX_LOONGARCH_ORDERACCESS_LINUX_LOONGARCH_HPP
 #define OS_CPU_LINUX_LOONGARCH_ORDERACCESS_LINUX_LOONGARCH_HPP
-
-#include "runtime/os.hpp"
 
 // Included in orderAccess.hpp header file.
 


### PR DESCRIPTION
37452: LA port of 8379665: Obsolete AlwaysActAsServerClassMachine and NeverActAsServerClassMachine
37392: LA port of 8294152: AArch64: frame::id() and frame::is_older() broken for interpreted frames with large max_stack
37431: LA port of 8379027: Convert utilities/exceptions to use Atomic<T>
37440: LA port of 8379260: C2: Separate volatile barrier and full barrier
37432: LA port of 8378559: Add setting of captured states like errno