### PR TITLE
Update (2026.06.23, 5th)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRAssembler_loongarch_64.cpp
@@ -55,18 +55,6 @@ NEEDS_CLEANUP // remove this definitions?
 #define __ _masm->
 
 static void select_different_registers(Register preserve, Register extra,
-                                       Register &tmp1, Register &tmp2) {
-  if (tmp1 == preserve) {
-    assert_different_registers(tmp1, tmp2, extra);
-    tmp1 = extra;
-  } else if (tmp2 == preserve) {
-    assert_different_registers(tmp1, tmp2, extra);
-    tmp2 = extra;
-  }
-  assert_different_registers(preserve, tmp1, tmp2);
-}
-
-static void select_different_registers(Register preserve, Register extra,
                                        Register &tmp1, Register &tmp2,
                                        Register &tmp3) {
   if (tmp1 == preserve) {
@@ -1247,12 +1235,9 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success,
   } else if (obj == klass_RInfo) {
     klass_RInfo = dst;
   }
-  if (k->is_loaded() && !UseCompressedClassPointers) {
-    select_different_registers(obj, dst, k_RInfo, klass_RInfo);
-  } else {
-    Rtmp1 = op->tmp3()->as_register();
-    select_different_registers(obj, dst, k_RInfo, klass_RInfo, Rtmp1);
-  }
+
+  Rtmp1 = op->tmp3()->as_register();
+  select_different_registers(obj, dst, k_RInfo, klass_RInfo, Rtmp1);
 
   assert_different_registers(obj, k_RInfo, klass_RInfo);
 
@@ -2538,12 +2523,9 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
       if (UseCompactObjectHeaders) {
         __ load_narrow_klass_compact(tmp, src);
         __ load_narrow_klass_compact(SCR1, dst);
-      } else if (UseCompressedClassPointers) {
+      } else {
         __ ld_wu(tmp, src_klass_addr);
         __ ld_wu(SCR1, dst_klass_addr);
-      } else {
-        __ ld_d(tmp, src_klass_addr);
-        __ ld_d(SCR1, dst_klass_addr);
       }
       __ bne_far(tmp, SCR1, *stub->entry());
     } else {
@@ -2676,9 +2658,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
     // but not necessarily exactly of type default_type.
     Label known_ok, halt;
     __ mov_metadata(tmp, default_type->constant_encoding());
-    if (UseCompressedClassPointers) {
-      __ encode_klass_not_null(tmp);
-    }
+    __ encode_klass_not_null(tmp);
 
     if (basic_type != T_OBJECT) {
       __ cmp_klass_compressed(dst, tmp, SCR1, halt, false);

--- a/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
@@ -1287,9 +1287,7 @@ void LIRGenerator::do_CheckCast(CheckCast* x) {
   }
   LIR_Opr reg = rlock_result(x);
   LIR_Opr tmp3 = LIR_OprFact::illegalOpr;
-  if (!x->klass()->is_loaded() || UseCompressedClassPointers) {
-    tmp3 = new_register(objectType);
-  }
+  tmp3 = new_register(objectType);
   __ checkcast(reg, obj.result(), x->klass(),
                new_register(objectType), new_register(objectType), tmp3,
                x->direct_compare(), info_for_exception, patching_info, stub,
@@ -1308,9 +1306,7 @@ void LIRGenerator::do_InstanceOf(InstanceOf* x) {
   }
   obj.load_item();
   LIR_Opr tmp3 = LIR_OprFact::illegalOpr;
-  if (!x->klass()->is_loaded() || UseCompressedClassPointers) {
-    tmp3 = new_register(objectType);
-  }
+  tmp3 = new_register(objectType);
   __ instanceof(reg, obj.result(), x->klass(),
                 new_register(objectType), new_register(objectType), tmp3,
                 x->direct_compare(), patching_info, x->profiled_method(), x->profiled_bci());

--- a/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
@@ -82,12 +82,8 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
   } else {
     li(t1, checked_cast<int32_t>(markWord::prototype().value()));
     st_d(t1, Address(obj, oopDesc::mark_offset_in_bytes()));
-    if (UseCompressedClassPointers) { // Take care not to kill klass
-      encode_klass_not_null(t1, klass);
-      st_w(t1, Address(obj, oopDesc::klass_offset_in_bytes()));
-    } else {
-      st_d(klass, Address(obj, oopDesc::klass_offset_in_bytes()));
-    }
+    encode_klass_not_null(t1, klass);
+    st_w(t1, Address(obj, oopDesc::klass_offset_in_bytes()));
   }
 
   if (len->is_valid()) {
@@ -98,7 +94,7 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
       // Clear gap/first 4 bytes following the length field.
       st_w(R0, Address(obj, base_offset));
     }
-  } else if (UseCompressedClassPointers && !UseCompactObjectHeaders) {
+  } else if (!UseCompactObjectHeaders) {
     store_klass_gap(obj, R0);
   }
 }

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch.hpp
@@ -256,8 +256,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void profile_not_taken_branch(Register mdp);
   void profile_call(Register mdp);
   void profile_final_call(Register mdp);
-  void profile_virtual_call(Register receiver, Register mdp,
-                            bool receiver_can_be_null = false);
+  void profile_virtual_call(Register receiver, Register mdp);
   void profile_ret(Register return_bci, Register mdp);
   void profile_null_seen(Register mdp);
   void profile_typecheck(Register mdp, Register klass);

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -1232,27 +1232,15 @@ void InterpreterMacroAssembler::profile_final_call(Register mdp) {
 
 
 void InterpreterMacroAssembler::profile_virtual_call(Register receiver,
-                                                     Register mdp,
-                                                     bool receiver_can_be_null) {
+                                                     Register mdp) {
   if (ProfileInterpreter) {
     Label profile_continue;
 
     // If no method data exists, go to profile_continue.
     test_method_data_pointer(mdp, profile_continue);
 
-    Label skip_receiver_profile;
-    if (receiver_can_be_null) {
-      Label not_null;
-      bnez(receiver, not_null);
-      // We are making a call.  Increment the count.
-      increment_mdp_data_at(mdp, in_bytes(CounterData::count_offset()));
-      b(skip_receiver_profile);
-      bind(not_null);
-    }
-
     // Record the receiver type.
     profile_receiver_type(receiver, mdp, 0);
-    bind(skip_receiver_profile);
 
     // The method data pointer needs to be updated to reflect the new target.
     update_mdp_by_constant(mdp,

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -2003,13 +2003,8 @@ const Pipeline* MachNopNode::pipeline() const {
 #ifndef PRODUCT
 void MachUEPNode::format( PhaseRegAlloc *ra_, outputStream* st ) const {
   st->print_cr("# MachUEPNode");
-  if (UseCompressedClassPointers) {
-    st->print_cr("\tld_wu  AT, T0, oopDesc::klass_offset_in_bytes()");
-    st->print_cr("\tld_wu  T4, T1, CompiledICData::speculated_klass_offset()");
-  } else {
-    st->print_cr("\tld_d  AT, T0, oopDesc::klass_offset_in_bytes()");
-    st->print_cr("\tld_d  T4, T1, CompiledICData::speculated_klass_offset()");
-  }
+  st->print_cr("\tld_wu  AT, T0, oopDesc::klass_offset_in_bytes()");
+  st->print_cr("\tld_wu  T4, T1, CompiledICData::speculated_klass_offset()");
   st->print_cr("\tbeq(AT, T4, ic_hit)");
   st->print_cr("\tjmp(SharedRuntime::get_ic_miss_stub(), relocInfo::runtime_call_type)");
   st->print_cr("    ic_hit:");

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -775,12 +775,9 @@ int MacroAssembler::ic_check(int end_alignment) {
   if (UseCompactObjectHeaders) {
     load_narrow_klass_compact(tmp1, receiver);
     ld_wu(tmp2, Address(data, CompiledICData::speculated_klass_offset()));
-  } else if (UseCompressedClassPointers) {
+  } else {
     ld_wu(tmp1, Address(receiver, oopDesc::klass_offset_in_bytes()));
     ld_wu(tmp2, Address(data, CompiledICData::speculated_klass_offset()));
-  } else {
-    ld_d(tmp1, Address(receiver, oopDesc::klass_offset_in_bytes()));
-    ld_d(tmp2, Address(data, CompiledICData::speculated_klass_offset()));
   }
 
   Label ic_hit;
@@ -1389,7 +1386,6 @@ void MacroAssembler::lipc(Register rd, Label& L) {
 }
 
 void MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
-  assert(UseCompressedClassPointers, "should only be used for compressed header");
   assert(oop_recorder() != nullptr, "this assembler needs an OopRecorder");
 
   int klass_index = oop_recorder()->find_index(k);
@@ -2163,10 +2159,8 @@ void MacroAssembler::load_method_holder_cld(Register rresult, Register rmethod) 
 void MacroAssembler::cmp_klass_compressed(Register oop, Register trial_klass, Register tmp, Label &L, bool equal) {
   if (UseCompactObjectHeaders) {
     load_narrow_klass_compact(tmp, oop);
-  } else if (UseCompressedClassPointers) {
-    ld_wu(tmp, Address(oop, oopDesc::klass_offset_in_bytes()));
   } else {
-    ld_d(tmp, Address(oop, oopDesc::klass_offset_in_bytes()));
+    ld_wu(tmp, Address(oop, oopDesc::klass_offset_in_bytes()));
   }
   if (equal) {
     beq(trial_klass, tmp, L);
@@ -2186,29 +2180,21 @@ void MacroAssembler::load_klass(Register dst, Register src) {
   if (UseCompactObjectHeaders) {
     load_narrow_klass_compact(dst, src);
     decode_klass_not_null(dst);
-  } else if (UseCompressedClassPointers) {
+  } else {
     ld_wu(dst, Address(src, oopDesc::klass_offset_in_bytes()));
     decode_klass_not_null(dst);
-  } else {
-    ld_d(dst, src, oopDesc::klass_offset_in_bytes());
   }
 }
 
 void MacroAssembler::store_klass(Register dst, Register src) {
   assert(!UseCompactObjectHeaders, "not with compact headers");
-  if(UseCompressedClassPointers){
-    encode_klass_not_null(src);
-    st_w(src, dst, oopDesc::klass_offset_in_bytes());
-  } else {
-    st_d(src, dst, oopDesc::klass_offset_in_bytes());
-  }
+  encode_klass_not_null(src);
+  st_w(src, dst, oopDesc::klass_offset_in_bytes());
 }
 
 void MacroAssembler::store_klass_gap(Register dst, Register src) {
   assert(!UseCompactObjectHeaders, "not with compact headers");
-  if (UseCompressedClassPointers) {
-    st_w(src, dst, oopDesc::klass_gap_offset_in_bytes());
-  }
+  st_w(src, dst, oopDesc::klass_gap_offset_in_bytes());
 }
 
 void MacroAssembler::access_load_at(BasicType type, DecoratorSet decorators, Register dst, Address src,
@@ -2258,7 +2244,6 @@ void MacroAssembler::store_heap_oop_null(Address dst) {
 
 #ifdef ASSERT
 void MacroAssembler::verify_heapbase(const char* msg) {
-  assert (UseCompressedOops || UseCompressedClassPointers, "should be compressed");
   assert (Universe::heap() != nullptr, "java heap should be initialized");
 }
 #endif
@@ -2519,7 +2504,6 @@ void MacroAssembler::encode_klass_not_null(Register dst, Register src) {
 }
 
 void MacroAssembler::decode_klass_not_null(Register r) {
-  assert(UseCompressedClassPointers, "should only be used for compressed headers");
   assert(r != AT, "Decoding a klass in AT");
   // Cannot assert, unverified entry point counts instructions (see .ad file)
   // vtableStubs also counts instructions in pd_code_size_limit.
@@ -2545,7 +2529,6 @@ void MacroAssembler::decode_klass_not_null(Register r) {
 }
 
 void MacroAssembler::decode_klass_not_null(Register dst, Register src) {
-  assert(UseCompressedClassPointers, "should only be used for compressed headers");
   if (dst == src) {
     decode_klass_not_null(dst);
   } else {

--- a/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/matcher_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2021, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,6 @@
   }
 
   static bool narrow_klass_use_complex_address() {
-    assert(UseCompressedClassPointers, "only for compressed klass code");
     return false;
   }
 

--- a/src/hotspot/cpu/loongarch/methodHandles_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/methodHandles_loongarch.cpp
@@ -80,14 +80,13 @@ void MethodHandles::verify_ref_kind(MacroAssembler* _masm, int ref_kind, Registe
   __ andr(temp, temp, AT);
   __ li(AT, ref_kind);
   __ beq(temp, AT, L);
-  { char* buf = NEW_C_HEAP_ARRAY(char, 100, mtInternal);
-    jio_snprintf(buf, 100, "verify_ref_kind expected %x", ref_kind);
-    if (ref_kind == JVM_REF_invokeVirtual ||
-        ref_kind == JVM_REF_invokeSpecial)
-      // could do this for all ref_kinds, but would explode assembly code size
-      trace_method_handle(_masm, buf);
-    __ STOP(buf);
+  const char* msg = ref_kind_to_verify_msg(ref_kind);
+  if (ref_kind == JVM_REF_invokeVirtual ||
+      ref_kind == JVM_REF_invokeSpecial) {
+    // could do this for all ref_kinds, but would explode assembly code size
+    trace_method_handle(_masm, msg);
   }
+  __ STOP(msg);
   BLOCK_COMMENT("} verify_ref_kind");
   __ bind(L);
 }

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -448,10 +448,8 @@ void VM_Version::get_processor_features() {
   }
 
   if (UseFPUForSpilling && !FLAG_IS_DEFAULT(UseFPUForSpilling)) {
-    if (UseCompressedOops || UseCompressedClassPointers) {
-      warning("UseFPUForSpilling not supported when UseCompressedOops or UseCompressedClassPointers is on");
-      UseFPUForSpilling = false;
-    }
+    warning("UseFPUForSpilling not supported when UseCompressedOops or UseCompressedClassPointers is on"); // UseCompressedClassPointers is always on now
+    UseFPUForSpilling = false;
   }
 
   if (FLAG_IS_DEFAULT(UsePoly1305Intrinsics)) {


### PR DESCRIPTION
37508: LA port of 8379687: Reduce C heap usage when VerifyMethodHandles flags is on
37507: LA port of 8370504: InterpreterMacroAssembler::profile_virtual_call parameter 'receiver_can_be_null' is unused
37506: LA port of 8363996: Obsolete UseCompressedClassPointers