### PR TITLE
Update (2026.06.23, 6th)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.cpp
@@ -90,23 +90,27 @@ void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembl
 }
 
 // Does a store check for the oop in register obj.
-void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register obj, Register tmp) {
-  assert_different_registers(obj, tmp, SCR1);
+void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register obj, Register tmp1, Register tmp2) {
+  precond(tmp1 != noreg);
+  precond(tmp2 != noreg);
+  assert_different_registers(obj, tmp1, tmp2);
+  BarrierSet* bs = BarrierSet::barrier_set();
+  assert(bs->kind() == BarrierSet::CardTableBarrierSet, "Wrong barrier set kind");
 
   __ srli_d(obj, obj, CardTable::card_shift());
 
-  __ load_byte_map_base(tmp);
-
   assert(CardTable::dirty_card_val() == 0, "must be");
+
+  __ load_byte_map_base(tmp1);
 
   if (UseCondCardMark) {
     Label L_already_dirty;
-    __ ldx_b(SCR1, obj, tmp);
-    __ beqz(SCR1, L_already_dirty);
-    __ stx_b(R0, obj, tmp);
+    __ ldx_b(tmp2, obj, tmp1);
+    __ beqz(tmp2, L_already_dirty);
+    __ stx_b(R0, obj, tmp1);
     __ bind(L_already_dirty);
   } else {
-    __ stx_b(R0, obj, tmp);
+    __ stx_b(R0, obj, tmp1);
   }
 }
 
@@ -122,10 +126,10 @@ void CardTableBarrierSetAssembler::oop_store_at(MacroAssembler* masm, DecoratorS
   if (needs_post_barrier) {
     // flatten object address if needed
     if (!precise || (dst.index() == noreg && dst.disp() == 0)) {
-      store_check(masm, dst.base(), tmp1);
+      store_check(masm, dst.base(), tmp1, tmp2);
     } else {
-      __ lea(tmp1, dst);
-      store_check(masm, tmp1, tmp2);
+      __ lea(tmp3, dst);
+      store_check(masm, tmp3, tmp1, tmp2);
     }
   }
 }

--- a/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.hpp
@@ -31,7 +31,7 @@
 
 class CardTableBarrierSetAssembler: public BarrierSetAssembler {
 protected:
-  void store_check(MacroAssembler* masm, Register obj, Register tmp);
+  void store_check(MacroAssembler* masm, Register obj, Register tmp1, Register tmp2);
 
   virtual void gen_write_ref_array_pre_barrier(MacroAssembler* masm, DecoratorSet decorators,
                                                Register addr, Register count, RegSet saved_regs) {}

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -6222,7 +6222,7 @@ static const int64_t right_3_bits = right_n_bits(3);
   }
 
  public:
-  StubGenerator(CodeBuffer* code, BlobId blob_id) : StubCodeGenerator(code, blob_id) {
+  StubGenerator(CodeBuffer* code, BlobId blob_id, AOTStubData* stub_data) : StubCodeGenerator(code, blob_id, stub_data) {
     switch(blob_id) {
       case BlobId::stubgen_preuniverse_id:
         generate_preuniverse_stubs();
@@ -6246,6 +6246,6 @@ static const int64_t right_3_bits = right_n_bits(3);
   }
 }; // end class declaration
 
-void StubGenerator_generate(CodeBuffer* code, BlobId blob_id) {
-  StubGenerator g(code, blob_id);
+void StubGenerator_generate(CodeBuffer* code, BlobId blob_id, AOTStubData* stub_data) {
+  StubGenerator g(code, blob_id, stub_data);
 }

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -201,3 +201,9 @@ ATTRIBUTE_ALIGNED(64) jfloat StubRoutines::la::_round_float_imm[] = {
 ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::la::_round_double_imm[] = {
   -0.5d, 0.49999999999999994d // magic number for ties
 };
+
+#if INCLUDE_CDS
+// nothing to do for loongarch
+void StubRoutines::init_AOTAddressTable() {
+}
+#endif // INCLUDE_CDS


### PR DESCRIPTION
37537: LA: Pass temp registers and use them in CardTableBarrierSetAssembler::store_check()
37532: LA port of 8372617: Save and restore stubgen stubs when using an AOT code cache