### PR TITLE
Update (2026.06.23, 7th)

### DIFF
--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -52,6 +52,7 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/integerCast.hpp"
 #include "utilities/macros.hpp"
 
 #ifdef COMPILER2
@@ -2018,7 +2019,11 @@ void MacroAssembler::pop2(Register reg1, Register reg2) {
   addi_d(SP, SP, 16);
 }
 
-void MacroAssembler::push(unsigned int bitset) {
+int MacroAssembler::push(RegSet regset) {
+  if (regset.bits() == 0) {
+    return 0;
+  }
+  auto bitset = integer_cast<unsigned int>(regset.bits());
   unsigned char regs[31];
   int count = 0;
 
@@ -2032,9 +2037,15 @@ void MacroAssembler::push(unsigned int bitset) {
   addi_d(SP, SP, -align_up(count, 2) * wordSize);
   for (int i = 0; i < count; i ++)
     st_d(as_Register(regs[i]), SP, i * wordSize);
+
+  return count;
 }
 
-void MacroAssembler::pop(unsigned int bitset) {
+int MacroAssembler::pop(RegSet regset) {
+  if (regset.bits() == 0) {
+    return 0;
+  }
+  auto bitset = integer_cast<unsigned int>(regset.bits());
   unsigned char regs[31];
   int count = 0;
 
@@ -2048,14 +2059,17 @@ void MacroAssembler::pop(unsigned int bitset) {
   for (int i = 0; i < count; i ++)
     ld_d(as_Register(regs[i]), SP, i * wordSize);
   addi_d(SP, SP, align_up(count, 2) * wordSize);
+
+  return count;
 }
 
-void MacroAssembler::push_fpu(unsigned int bitset) {
+int MacroAssembler::push_fpu(FloatRegSet regset) {
+  if (regset.bits() == 0) {
+    return 0;
+  }
+  auto bitset = integer_cast<unsigned int>(regset.bits());
   unsigned char regs[32];
   int count = 0;
-
-  if (bitset == 0)
-    return;
 
   for (int reg = 0; reg <= 31; reg++) {
     if (1 & bitset)
@@ -2066,14 +2080,17 @@ void MacroAssembler::push_fpu(unsigned int bitset) {
   addi_d(SP, SP, -align_up(count, 2) * wordSize);
   for (int i = 0; i < count; i++)
     fst_d(as_FloatRegister(regs[i]), SP, i * wordSize);
+
+  return count;
 }
 
-void MacroAssembler::pop_fpu(unsigned int bitset) {
+int MacroAssembler::pop_fpu(FloatRegSet regset) {
+  if (regset.bits() == 0) {
+    return 0;
+  }
+  auto bitset = integer_cast<unsigned int>(regset.bits());
   unsigned char regs[32];
   int count = 0;
-
-  if (bitset == 0)
-    return;
 
   for (int reg = 0; reg <= 31; reg++) {
     if (1 & bitset)
@@ -2084,6 +2101,8 @@ void MacroAssembler::pop_fpu(unsigned int bitset) {
   for (int i = 0; i < count; i++)
     fld_d(as_FloatRegister(regs[i]), SP, i * wordSize);
   addi_d(SP, SP, align_up(count, 2) * wordSize);
+
+  return count;
 }
 
 static int vpr_offset(int off) {
@@ -2097,12 +2116,13 @@ static int vpr_offset(int off) {
   return off * slots_per_vpr * VMRegImpl::stack_slot_size;
 }
 
-void MacroAssembler::push_vp(unsigned int bitset) {
+int MacroAssembler::push_vp(FloatRegSet regset) {
+  if (regset.bits() == 0) {
+    return 0;
+  }
+  auto bitset = integer_cast<unsigned int>(regset.bits());
   unsigned char regs[32];
   int count = 0;
-
-  if (bitset == 0)
-    return;
 
   for (int reg = 0; reg <= 31; reg++) {
     if (1 & bitset)
@@ -2119,14 +2139,17 @@ void MacroAssembler::push_vp(unsigned int bitset) {
     else if (UseLSX)
       vst(as_FloatRegister(regs[i]), SP, off);
   }
+
+  return count;
 }
 
-void MacroAssembler::pop_vp(unsigned int bitset) {
+int MacroAssembler::pop_vp(FloatRegSet regset) {
+  if (regset.bits() == 0) {
+    return 0;
+  }
+  auto bitset = integer_cast<unsigned int>(regset.bits());
   unsigned char regs[32];
   int count = 0;
-
-  if (bitset == 0)
-    return;
 
   for (int reg = 0; reg <= 31; reg++) {
     if (1 & bitset)
@@ -2143,6 +2166,8 @@ void MacroAssembler::pop_vp(unsigned int bitset) {
   }
 
   addi_d(SP, SP, vpr_offset(align_up(count, 2)));
+
+  return count;
 }
 
 void MacroAssembler::load_method_holder(Register holder, Register method) {

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -654,12 +654,12 @@ class MacroAssembler: public Assembler {
   void pop_call_clobbered_registers() {
     pop_call_clobbered_registers_except(RegSet());
   }
-  void push(RegSet regs) { if (regs.bits()) push(regs.bits()); }
-  void pop(RegSet regs) { if (regs.bits()) pop(regs.bits()); }
-  void push_fpu(FloatRegSet regs) { if (regs.bits()) push_fpu(regs.bits()); }
-  void pop_fpu(FloatRegSet regs) { if (regs.bits()) pop_fpu(regs.bits()); }
-  void push_vp(FloatRegSet regs) { if (regs.bits()) push_vp(regs.bits()); }
-  void pop_vp(FloatRegSet regs) { if (regs.bits()) pop_vp(regs.bits()); }
+  int push(RegSet regset);
+  int pop(RegSet regset);
+  int push_fpu(FloatRegSet regset);
+  int pop_fpu(FloatRegSet regset);
+  int push_vp(FloatRegSet regset);
+  int pop_vp(FloatRegSet regset);
 
   void li(Register rd, jlong value);
   void li(Register rd, address addr) { li(rd, (long)addr); }
@@ -830,13 +830,6 @@ class MacroAssembler: public Assembler {
 #endif
 
 private:
-  void push(unsigned int bitset);
-  void pop(unsigned int bitset);
-  void push_fpu(unsigned int bitset);
-  void pop_fpu(unsigned int bitset);
-  void push_vp(unsigned int bitset);
-  void pop_vp(unsigned int bitset);
-
   // Check the current thread doesn't need a cross modify fence.
   void verify_cross_modify_fence_not_required() PRODUCT_RETURN;
   void generate_kernel_sin(FloatRegister x, bool iyIsOne, address dsin_coef);

--- a/src/hotspot/cpu/loongarch/stubDeclarations_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/stubDeclarations_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2025, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,28 +29,32 @@
 #define STUBGEN_PREUNIVERSE_BLOBS_ARCH_DO(do_stub,                      \
                                           do_arch_blob,                 \
                                           do_arch_entry,                \
-                                          do_arch_entry_init)           \
+                                          do_arch_entry_init,           \
+                                          do_arch_entry_array)          \
   do_arch_blob(preuniverse, 0)                                          \
 
 
 #define STUBGEN_INITIAL_BLOBS_ARCH_DO(do_stub,                          \
                                       do_arch_blob,                     \
                                       do_arch_entry,                    \
-                                      do_arch_entry_init)               \
+                                      do_arch_entry_init,               \
+                                      do_arch_entry_array)              \
   do_arch_blob(initial, 20000)                                          \
 
 
 #define STUBGEN_CONTINUATION_BLOBS_ARCH_DO(do_stub,                     \
                                            do_arch_blob,                \
                                            do_arch_entry,               \
-                                           do_arch_entry_init)          \
+                                           do_arch_entry_init,          \
+                                           do_arch_entry_array)         \
   do_arch_blob(continuation, 2000)                                      \
 
 
 #define STUBGEN_COMPILER_BLOBS_ARCH_DO(do_stub,                         \
                                        do_arch_blob,                    \
                                        do_arch_entry,                   \
-                                       do_arch_entry_init)              \
+                                       do_arch_entry_init,              \
+                                       do_arch_entry_array)             \
   do_arch_blob(compiler, 70000)                                         \
   do_stub(compiler, vector_iota_indices)                                \
   do_arch_entry(la, compiler, vector_iota_indices,                      \
@@ -69,7 +73,8 @@
 #define STUBGEN_FINAL_BLOBS_ARCH_DO(do_stub,                            \
                                     do_arch_blob,                       \
                                     do_arch_entry,                      \
-                                    do_arch_entry_init)                 \
+                                    do_arch_entry_init,                 \
+                                    do_arch_entry_array)                \
   do_arch_blob(final, 60000 ZGC_ONLY(+477000))                          \
   do_stub(final, jlong_fill)                                            \
   do_arch_entry(la, final, jlong_fill,                                  \

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,9 +61,13 @@ class la {
 #define DECLARE_ARCH_ENTRY_INIT(arch, blob_name, stub_name, field_name, getter_name, init_function) \
   DECLARE_ARCH_ENTRY(arch, blob_name, stub_name, field_name, getter_name)
 
-private:
-  STUBGEN_ARCH_ENTRIES_DO(DECLARE_ARCH_ENTRY, DECLARE_ARCH_ENTRY_INIT)
+#define DECLARE_ARCH_ENTRY_ARRAY(arch, blob_name, stub_name, field_name, getter_name, count) \
+  static address STUB_FIELD_NAME(field_name) [count] ;
 
+private:
+  STUBGEN_ARCH_ENTRIES_DO(DECLARE_ARCH_ENTRY, DECLARE_ARCH_ENTRY_INIT, DECLARE_ARCH_ENTRY_ARRAY)
+
+#undef DECLARE_ARCH_ENTRY_ARRAY
 #undef DECLARE_ARCH_ENTRY_INIT
 #undef DECLARE_ARCH_ENTRY
 
@@ -92,8 +96,12 @@ public:
 #define DEFINE_ARCH_ENTRY_GETTER_INIT(arch, blob_name, stub_name, field_name, getter_name, init_function) \
   DEFINE_ARCH_ENTRY_GETTER(arch, blob_name, stub_name, field_name, getter_name)
 
-  STUBGEN_ARCH_ENTRIES_DO(DEFINE_ARCH_ENTRY_GETTER, DEFINE_ARCH_ENTRY_GETTER_INIT)
+#define DEFINE_ARCH_ENTRY_GETTER_ARRAY(arch, blob_name, stub_name, field_name, getter_name, count) \
+  static address getter_name(int idx) { return STUB_FIELD_NAME(field_name) [idx] ; }
 
+  STUBGEN_ARCH_ENTRIES_DO(DEFINE_ARCH_ENTRY_GETTER, DEFINE_ARCH_ENTRY_GETTER_INIT, DEFINE_ARCH_ENTRY_GETTER_ARRAY)
+
+#undef DEFINE_ARCH_ENTRY_GETTER_ARRAY
 #undef DEFINE_ARCH_ENTRY_GETTER_INIT
 #undef DEFINE_ARCH_ENTRY_GETTER
 

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
@@ -38,8 +38,12 @@
 #define DEFINE_ARCH_ENTRY_INIT(arch, blob_name, stub_name, field_name, getter_name, init_function) \
   address StubRoutines:: arch :: STUB_FIELD_NAME(field_name)  = CAST_FROM_FN_PTR(address, init_function);
 
-STUBGEN_ARCH_ENTRIES_DO(DEFINE_ARCH_ENTRY, DEFINE_ARCH_ENTRY_INIT)
+#define DEFINE_ARCH_ENTRY_ARRAY(arch, blob_name, stub_name, field_name, getter_name, count) \
+  address StubRoutines:: arch :: STUB_FIELD_NAME(field_name)  [count] ;
 
+STUBGEN_ARCH_ENTRIES_DO(DEFINE_ARCH_ENTRY, DEFINE_ARCH_ENTRY_INIT, DEFINE_ARCH_ENTRY_ARRAY)
+
+#undef DEFINE_ARCH_ENTRY_ARRAY
 #undef DEFINE_ARCH_ENTRY_INIT
 #undef DEFINE_ARCH_ENTRY
 

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -361,10 +361,6 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA3Intrinsics, false);
   }
 
-  if (!(UseSHA1Intrinsics || UseSHA256Intrinsics || UseSHA3Intrinsics || UseSHA512Intrinsics)) {
-    FLAG_SET_DEFAULT(UseSHA, false);
-  }
-
   if (FLAG_IS_DEFAULT(UseMD5Intrinsics)) {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, true);
   }


### PR DESCRIPTION
37586: Fix implicit conversion in macroAssembler_loongarch.hpp
37578: LA port of 8382039: Add support do_arch_array_entry() template
37577: LA port of 8381677: Remove dependence of UseSHA on UseSHAIntrinsics