### PR TITLE
Update (2026.06.23, 8th)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_LIRGenerator_loongarch_64.cpp
@@ -1396,14 +1396,6 @@ void LIRGenerator::volatile_field_store(LIR_Opr value, LIR_Address* address,
 
 void LIRGenerator::volatile_field_load(LIR_Address* address, LIR_Opr result,
                                        CodeEmitInfo* info) {
-  // 8179954: We need to make sure that the code generated for
-  // volatile accesses forms a sequentially-consistent set of
-  // operations when combined with STLR and LDAR.  Without a leading
-  // membar it's possible for a simple Dekker test to fail if loads
-  // use LD;DMB but stores use STLR.  This can happen if C2 compiles
-  // the stores in one method and C1 compiles the loads in another.
-  if (!CompilerConfig::is_c1_only_no_jvmci()) {
-    __ membar();
-  }
   __ volatile_load_mem_reg(address, result, info);
+  __ membar_acquire();
 }

--- a/src/hotspot/cpu/loongarch/gc/shenandoah/c1/shenandoahBarrierSetC1_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/c1/shenandoahBarrierSetC1_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2021, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2022, 2025, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, 2026, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,14 +50,10 @@ void LIR_OpShenandoahCompareAndSwap::emit_code(LIR_Assembler* masm) {
 
   ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm->masm(), addr, cmpval, newval, /*acquire*/ true, /*is_cae*/ false, result);
 
-  if (CompilerConfig::is_c1_only_no_jvmci()) {
-    // The membar here is necessary to prevent reordering between the
-    // release store in the CAS above and a subsequent volatile load.
-    // However for tiered compilation C1 inserts a full barrier before
-    // volatile loads which means we don't need an additional barrier
-    // here (see LIRGenerator::volatile_field_load()).
-    __ membar(__ AnyAny);
-  }
+  // The membar here is necessary to prevent reordering between the
+  // release store in the CAS above and a subsequent volatile load.
+  // See also: LIR_Assembler::casw, LIR_Assembler::casl.
+  __ membar(__ AnyAny);
 }
 
 #undef __

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -3456,7 +3456,6 @@ void TemplateTable::invokeinterface(int byte_no) {
   __ bind(notVFinal);
 
   // Get receiver klass into T1
-  __ restore_locals();
   __ load_klass(T1, T3);
 
   Label no_such_method;


### PR DESCRIPTION
37648: LA: Clean up redundant restore_locals() in TemplateTable::invokeinterface
37644: LA port of 8365147: AArch64: Replace DMB + LD + DMB with LDAR for C1 volatile field loads